### PR TITLE
Fixes to file drawer: lost focus and formatting

### DIFF
--- a/ide/index.html
+++ b/ide/index.html
@@ -44,7 +44,15 @@
       font-size: 1.2em;
     }
 
-    #file-toolbar 
+    #files ul {
+      display: block;
+      list-style-type: disc;
+      margin-block-start: 0em;
+      margin-block-end: 0em;
+      margin-inline-start: 0px;
+      margin-inline-end: 0px;
+      padding-inline-start: 0px;
+    }
     
     #files li {
       list-style-type: none;

--- a/src/web/fs.ts
+++ b/src/web/fs.ts
@@ -102,9 +102,7 @@ class FS {
 
   deleteFile (filename: string): void {
     const fileList = this.getFileList()
-    console.log(`before: ${JSON.stringify(fileList)}`)
     fileList.splice(fileList.indexOf(filename), 1)
-    console.log(`after: ${JSON.stringify(fileList)}`)
     localStorage.setItem(this.fileListTag, JSON.stringify(fileList))
     localStorage.removeItem(this.fileTag(filename))
   }


### PR DESCRIPTION
Added a handler to exit filename editing when the editable loses focus. Also fixed formatting of the file drawer due to a CSS typo.