### PR TITLE
Fix rotate (#25)

### DIFF
--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -429,9 +429,9 @@ export function render (x: number, y: number, drawing: Drawing, canvas: HTMLCanv
       // the origin.
       ctx.translate(centerX, centerY)
       ctx.rotate(angle)
-      ctx.translate(-centerX, -centerY)
+      ctx.translate(-drawing.drawing.width / 2, -drawing.drawing.height / 2)
       render(x, y, drawing.drawing, canvas)
-      ctx.translate(centerX, centerY)
+      ctx.translate(drawing.drawing.width / 2, drawing.drawing.height / 2)
       ctx.rotate(-angle)
       ctx.translate(-centerX, -centerY)
       break


### PR DESCRIPTION
I am not 100% clear on why this works, but I believe it is because the `width`/`height` of the `rotate` drawing is not representative of the `width`/`height` of the drawing once the orientation of the canvas and drawing align.