### PR TITLE
Fix more sizing/scrolling issues

### DIFF
--- a/ide/file-chooser.html
+++ b/ide/file-chooser.html
@@ -11,7 +11,6 @@
   <link href="css/solid.css" rel="stylesheet">
   <style>
     html, body {
-      position: fixed;
       width: 100%;
       height: 100%;
       margin: 0px;
@@ -20,8 +19,10 @@
       font-size: 1em;
     }
 
-    body {
-      display: block;
+    #ide {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
     }
 
     #loading {
@@ -50,7 +51,7 @@
       background: #eee;
       color: #333;
       padding: 0.5em;
-      width: 99%;
+      flex: 0 0 auto;
 
       display: flex;
       flex-direction: row;
@@ -101,7 +102,8 @@
       flex-flow: row wrap;
       align-content: start;
       width: 100%;
-      height: 95vh;
+      flex: 1;
+      min-height: 0;
     }
   </style>
 </head>

--- a/ide/ide.html
+++ b/ide/ide.html
@@ -12,7 +12,6 @@
   <link href="css/scamper-hljs.css" rel="stylesheet">
   <style>
     html, body {
-      position: fixed;
       width: 100%;
       height: 100%;
       margin: 0px;
@@ -21,8 +20,10 @@
       font-size: 1em;
     }
 
-    body {
-      display: block;
+    #ide {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
     }
 
     #loading {
@@ -51,7 +52,7 @@
       background: #eee;
       color: #333;
       padding: 0.5em;
-      width: 99%;
+      flex: 0 0 auto;
 
       display: flex;
       flex-direction: row;
@@ -65,7 +66,8 @@
       display: flex;
       flex-direction: row;
       width: 100%;
-      height: 95vh;
+      flex: 1;
+      min-height: 0;
     }
 
     #editor {
@@ -75,7 +77,15 @@
       height: 100%;
     }
 
+    #results {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-height: 0;
+    }
+
     #results-toolbar {
+      flex: 0 0 auto;
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
@@ -87,7 +97,8 @@
     #output {
       background: #fff;
       color: #333;
-      height: 100%;
+      flex: 1;
+      min-height: 0;
       overflow: scroll;
       white-space: pre-wrap;
     }

--- a/ide/runner.html
+++ b/ide/runner.html
@@ -11,7 +11,6 @@
   <link href="css/solid.css" rel="stylesheet">
   <style>
     html, body {
-      position: fixed;
       width: 100%;
       height: 100%;
       margin: 0px;
@@ -20,15 +19,17 @@
       font-size: 1em;
     }
 
-    body {
-      display: block;
+    #ide {
+      height: 100%;
+      display: flex;
+      flex-direction: column;
     }
 
     #header {
       background: #eee;
       color: #333;
       padding: 0.5em;
-      width: 99%;
+      flex: 0 0 auto;
     }
 
     #loading {
@@ -56,7 +57,8 @@
     #output {
       background: #fff;
       color: #333;
-      height: 100%;
+      flex: 1;
+      min-height: 0;
       overflow: scroll;
       white-space: pre-wrap;
     }


### PR DESCRIPTION
looks like the scrolling got fixed in the previous commit, but there were still some issues:
- still a little blank space at the bottom
- the “runner” (output) window and file chooser scrolling broke
- “report an issue” link on the headers was still slightly cut off

I switched some sizing to flexbox to fix them