### PR TITLE
Add recursion limit

### DIFF
--- a/src/sem.ts
+++ b/src/sem.ts
@@ -3,6 +3,8 @@ import { Env, Prog, Op, reservedWords, Value, } from './lang.js'
 import { renderToHTML, mkCodeElement, mkSourceBlock, renderToOutput } from './display.js'
 import * as C from './contract.js'
 
+const maxCallStackDepth = 1000;
+
 ///// Machine state structures /////////////////////////////////////////////////
 
 class Control {
@@ -44,24 +46,25 @@ class ExecutionState {
     // step of computation
     if (ops.length === 1 && ops[0].tag === 'val') {
       this.stack = [ops[0].value]
-      this.env = env
       this.control = new Control([])
-      this.dump = []
     } else {
       this.stack = []
-      this.env = env
       this.control = new Control(ops)
-      this.dump = []
     }
+    this.env = env
+    this.dump = []
   }
 
   isFinished(): boolean { return this.control.isEmpty() && this.dump.length === 0 }
 
-  dumpAndSwitch (stack: Value.T[], env: Env, ops: Op.T[]): void {
+  dumpAndSwitch (stack: Value.T[], env: Env, ops: Op.T[], range?: Range): void {
     this.dump.push([this.stack, this.env, this.control])
     this.stack = stack
     this.env = env
     this.control = new Control(ops)
+    if (this.dump.length > maxCallStackDepth) {
+      throw new ScamperError('Runtime', "Maximum call stack size exceeded", undefined, range)
+    }
   }
 
   isDumpEmpty() { return this.dump.length === 0 }
@@ -420,7 +423,7 @@ function stepPrim (state: ExecutionState): boolean {
           // TODO: here, we can check if this control is done.
           // If so, then this is a tail call! No need to dump,
           // just overwrite the current state and go forward.
-          state.dumpAndSwitch([], closure.env.extend(closure.params.map((p, i) => [p, args[i]])), closure.ops)
+          state.dumpAndSwitch([], closure.env.extend(closure.params.map((p, i) => [p, args[i]])), closure.ops, op.range)
         }
         return false
       } else if (Value.isJsFunction(head)) {
@@ -449,9 +452,9 @@ function stepPrim (state: ExecutionState): boolean {
       if (stack.length >= 1) {
         const guard = stack.pop()!
         if (guard === true) {
-          state.dumpAndSwitch([], state.env, op.ifb)
+          state.dumpAndSwitch([], state.env, op.ifb, op.range)
         } else if (guard === false) {
-          state.dumpAndSwitch([], state.env, op.elseb)
+          state.dumpAndSwitch([], state.env, op.elseb, op.range)
         } else {
           throw new ScamperError('Runtime', `Boolean expected in conditional, received ${Value.toString(guard)} instead`, undefined, op.range)
         }
@@ -496,7 +499,7 @@ function stepPrim (state: ExecutionState): boolean {
         for (let i = 0; !foundMatch && i < op.branches.length; i++) {
           const bindings = tryMatch(op.branches[i].pattern, scrutinee)
           if (bindings) {
-            state.dumpAndSwitch([], state.env.extend(bindings), op.branches[i].body)
+            state.dumpAndSwitch([], state.env.extend(bindings), op.branches[i].body, op.range)
             foundMatch = true
           }
         }
@@ -550,7 +553,7 @@ function stepPrim (state: ExecutionState): boolean {
         // N.B., make sure to switch this frame's instr pointer before jumping
         // otherwise we'll forget where to return to!
         state.jumpPast(op.end)
-        state.dumpAndSwitch([], state.env, op.body)
+        state.dumpAndSwitch([], state.env, op.body, op.range)
       }
       return false
     }


### PR DESCRIPTION
a few people were frustrated with scamper crashing last night while using recursion incorrectly since it would freeze and not save code

i set a max call stack depth of 1000 which is probably reasonable (same as python's default), but if you think it introduces some kind of limit that might get hit, it could be adjusted

example to test:
```scm
"above crash" ; so we can see if output happens

(define crash-example
  (lambda ()
    (crash-example)))

(crash-example)

"below crash"
```

prior behavior:
scamper would freeze without outputting anything and eventually the page would error

new behavior:
```scm
"above crash"
Runtime error [5:5-5:19]: Maximum call stack size exceeded
"below crash"
```

ported from https://github.com/cbratland/scamper-rs/commit/d9de92a0ba160f62ff00ae9e6fdc71fef5142ab3