### PR TITLE
Fix docs page overflow

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -66,7 +66,8 @@
         display: flex;
         flex-direction: row;
         width: 100%;
-        height: 95vh;
+        flex: 1;
+        min-height: 0;
       } 
 
       #index {


### PR DESCRIPTION
fixes the extra padding on the bottom of the docs page that made it scrollable (same as #93)