### PR TITLE
Auto-indent feature with ctrl+i

### DIFF
--- a/src/web/ide.ts
+++ b/src/web/ide.ts
@@ -8,6 +8,7 @@ import { Scamper, mkOptions } from '../scamper.js'
 import { renderToOutput } from '../display.js'
 import { ScamperSupport } from '../codemirror/language.js'
 import makeScamperLinter from '../codemirror/linter.js'
+import { indentSelection } from "@codemirror/commands"
 
 const editorPane      = document.getElementById('editor')!
 const outputPane      = document.getElementById('output')!
@@ -54,7 +55,20 @@ class IDE {
       doc: '',
       extensions: [
         basicSetup,
-        keymap.of([indentWithTab]),
+        keymap.of([indentWithTab,
+          {
+            key: "Ctrl-i",
+            run: (view) => {
+              const allPage = view.state.doc
+              view.dispatch({
+                selection: {
+                  anchor: 0,
+                  head: allPage.length
+                }
+              })
+              return indentSelection(view)
+            }
+          }]),
         ScamperSupport(),
 
         makeScamperLinter(outputPane),


### PR DESCRIPTION
This indents code appropriately, adjusting for nesting and parenthesis alignment. The command to use this feature is Ctlr+i. Ported from jakerss2:indent-feature.

**Implementation details**
- Imported indentSelection from @codemirror/commands
- Made a new keymap of Ctlr+i command key to select the whole document and map indentSelection().