### PR TITLE
AST Fixes

### DIFF
--- a/ide.html
+++ b/ide.html
@@ -173,10 +173,10 @@
     <div id="header">
       <div class="text-align: left;">
         <a href="index.html" aria-label="Return to Index">Scamper</a> <span id="version">{{ver}}</span> ⋅ <span id="current-file"></span> ⋅
-        <button id="run" class="fa-solid fa-play" aria-label="Run" accesskey="w" aria-keyshortcuts="w"></button>
-        <button id="step" class="fa-solid fa-route" aria-label="Trace"></button>
-        <button id="run-window" class="fa-solid fa-window-maximize" aria-label="Maximize Output Window "></button>
-        <button id="ast-window" class="fa-solid fa-tree" aria-label="Display Syntax Tree"></button> ⋅
+        <button id="run" class="fa-solid fa-play" aria-label="Run" accesskey="m" aria-keyshortcuts="m"></button>
+        <button id="step" class="fa-solid fa-route" aria-label="Trace" accesskey="w"></button>
+        <button id="run-window" class="fa-solid fa-window-maximize" aria-label="Maximize Output Window " accesskey="y"></button>
+        <button id="ast-window" class="fa-solid fa-tree" aria-label="Display Syntax Trece" accesskey="z"></button> ⋅
         <a href="docs.html">Docs</a> ⋅
         <a href="reference.html">Reference</a>
       </div>

--- a/runner.html
+++ b/runner.html
@@ -61,7 +61,6 @@
       min-height: 0;
       overflow-x: auto;
       overflow-y: auto;    
-      white-space: nowrap; 
       padding: 1rem;       
       box-sizing: border-box;
     }
@@ -99,14 +98,15 @@
     }
 
     .tree {
-      display: inline-block;
-      vertical-align: top;
+      display: block;
       justify-content: center;
       align-items: flex-start;
       padding-top: 40px;
       margin-bottom: 60px;
       border-top: 1px dashed #ccc;
       padding-top: 20px;
+      width: max-content;
+      min-width: 100%;
     }
 
     .tree ul {
@@ -150,6 +150,19 @@
       left: 50%;
       border-left: 1px solid #ccc;
       height: 20px;
+    }
+
+    .tree li:only-child::before,
+    .tree li:only-child::after {
+      display: none;
+    }
+
+    .tree li:first-child::before {
+      display: none;
+    }
+
+    .tree li:last-child::after {
+      display: none;
     }
 
     .box {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -16,43 +16,43 @@ import {EditorSelection} from "@codemirror/state";
 class SyntaxNode {
     syntax: Value.Syntax
     value: string = ''
-    name: string = ''
-    parentname: string | null = null;
+    //name: string = ''
+    //parentname: string | null = null;
     simplename: string = '';
     index: number | null = null;
     children: SyntaxNode[] = [];
     parent: SyntaxNode | null = null;
 
-    constructor(syntax: Value.Syntax, parent: string | null = null, index: number | null = null) {
+    constructor(syntax: Value.Syntax, index: number | null = null) {
         this.syntax = syntax; 
-        this.parentname = parent;
+        //this.parentname = parent;
         this.index = index;
         let v: T = this.syntax.value;
 
         switch (typeof v) {
             case 'boolean':
                 this.value = "Boolean "+v;
-                this.name = "a boolean "+v;
+                //this.name = "a boolean "+v;
                 this.simplename = ''+v;
                 break;
             case 'number':
                 this.value = "Numerical "+v;
-                this.name = "the number "+v;
+                //this.name = "the number "+v;
                 this.simplename = ''+v;
                 break;
             case 'string':
                 this.value = '"'+v+'"';
-                this.name = 'the string "'+v+'"';
+                //this.name = 'the string "'+v+'"';
                 this.simplename = '"'+v+'"';
                 break;
             case 'undefined':
                 this.value = "Undefined";
-                this.name = 'an undefined value';
+                //this.name = 'an undefined value';
                 this.simplename = 'undefined';
                 break;
             case 'function':
                 this.value = 'Function';
-                this.name = 'a function';
+                //this.name = 'a function';
                 this.simplename = 'a function';
                 break;
             case 'object':
@@ -67,7 +67,6 @@ class SyntaxNode {
                     while (isPair(tail)) {
                         const child = new SyntaxNode(
                             mkSyntax(((tail as Pair).fst as Syntax).range, ((tail as Pair).fst as Syntax).value),
-                            this.children[0].simplename,
                             i
                         );
                         child.parent = this;
@@ -76,58 +75,159 @@ class SyntaxNode {
                         tail = (tail as Pair).snd;
                       }
 
-                    this.value = "Parenthesis List";
-                    if (this.parentname != null) {
-                        this.name = "the parenthesis list in argument "+this.index+" of "+this.parentname;
-                    } else {
-                        this.name = "the parenthesis starting with " + this.children[0].name;
-                    }
-                    this.simplename = 'a parenthesis list';
-                } else if (isArray(v)) {
-                    this.simplename = 'a square bracket array';
-                    this.value = "Square bracket array";
-                    this.name = "the square bracket array at "+this.syntax.range;
+                    let typeofstatement = "Function application"
 
-                    if (this.parentname != null) {
-                        this.name = "the square bracket array in argument "+this.index+" of "+this.parentname;
+                    // There are several special types of statement this could be
+                    // and
+                    if (this.children[0].simplename === 'and') {
+                        typeofstatement = 'And statement';
                     }
+                    // begin
+                    if (this.children[0].simplename === 'begin') {
+                        typeofstatement = 'Begin statement';
+                    }
+                    // cond
+                    if (this.children[0].simplename === 'cond') {
+                        typeofstatement = 'Cond statement';
+                        for (let c of this.children) {
+                            if (c.simplename === "vector") {
+                                c.value = "Cond branch"
+                            }
+                        }
+                    }
+                    // define
+                    if (this.children[0].simplename === 'define') {
+                        typeofstatement = 'Define statement';
+                    }
+                    // if
+                    if (this.children[0].simplename === 'if') {
+                        typeofstatement = 'If statement';
+                    }
+                    // import
+                    if (this.children[0].simplename === 'import') {
+                        typeofstatement = 'Import statement';
+                    }
+                    // lambda
+                    if (this.children[0].simplename === 'lambda') {
+                        typeofstatement = 'Lambda statement';
+                        this.children[1].value = "Parameter list"
+                    }
+                    // let
+                    if (this.children[0].simplename === 'let') {
+                        typeofstatement = 'Let statement';
+                        this.children[1].value = "List of let bindings"
+                        for (let c of this.children[1].children) {
+                            c.value = "Let binding"
+                        }
+                    }
+                    // let*
+                    if (this.children[0].simplename === 'let*') {
+                        typeofstatement = 'Let* statement';
+                        this.children[1].value = "List of let* bindings"
+                        for (let c of this.children[1].children) {
+                            c.value = "Let* binding"
+                        }
+                    }
+                    // letrec
+                    if (this.children[0].simplename === 'letrec') {
+                        typeofstatement = 'Letrec statement';
+                        this.children[1].value = "List of letrec bindings"
+                        for (let c of this.children[1].children) {
+                            c.value = "Letrec binding"
+                        }
+                    }
+                    // match
+                    if (this.children[0].simplename === 'match') {
+                        typeofstatement = 'Match statement';
+                        for (let c of this.children) {
+                            if (c.simplename === 'vector') {
+                                c.value = "Match branch";
+                            }
+                        }
+                    }
+                    // or
+                    if (this.children[0].simplename === 'or') {
+                        typeofstatement = 'Or statement';
+                    }
+                    // quote
+                    if (this.children[0].simplename === 'quote' || this.children[0].simplename === '"quote"') {
+                        typeofstatement = 'Quoted value';
+                        this.children = this.children.slice(1);
+                        if (this.children[0].simplename === 's-expression') {
+                            this.children[0].listify();
+                        }
+                    }
+                    // section
+                    if (this.children[0].simplename === 'section') {
+                        typeofstatement = 'Section statement';
+                    }
+                    // struct
+                    if (this.children[0].simplename === 'struct') {
+                        typeofstatement = 'Struct statement';
+                        this.children[2].value = "Field list";
+                    }
+
+                    this.value = typeofstatement;
+                    /*if (this.parentname != null) {
+                        this.name = "the "+typeofstatement+" in argument "+this.index+" of "+this.parentname;
+                    } else {
+                        this.name = "the "+typeofstatement+" starting with " + this.children[0].name;
+                    }*/
+                    this.simplename = 's-expression';
+                } else if (isArray(v)) {
+                    this.simplename = 'vector';
+                    this.value = "Vector";
+                    //this.name = "the square bracket array at "+this.syntax.range;
+
+                    /*if (this.parentname != null) {
+                        this.name = "the square bracket array in argument "+this.index+" of "+this.parentname;
+                    }*/
 
                     let i: number = 0;
                     for (let c of (v as Vector)) {
-                        const child = new SyntaxNode(mkSyntax((c as Syntax).range, (c as Syntax).value), this.name, i);
+                        const child = new SyntaxNode(mkSyntax((c as Syntax).range, (c as Syntax).value), i);
                         child.parent = this;
                         this.children.push(child);
                         i += 1;
                     }
 
-                    if (this.parentname == null) {
+                    /*if (this.parentname == null) {
                         this.name = "the square bracket array starting with " + this.children[0].name;
-                    }
+                    }*/
                 } else if (isSym(v)) {
                     this.value = "Symbol " + (v as Sym).value;
-                    this.name = "the symbol "+(v as Sym).value;
+                    //this.name = "the symbol "+(v as Sym).value;
                     this.simplename = ''+(v as Sym).value;
                 } else if (isChar(v)) {
                     this.value = "Character " + (v as Char).value;
-                    this.name = "the character " + (v as Char).value;
+                    //this.name = "the character " + (v as Char).value;
                     this.simplename = ''+(v as Char).value;
                 } else if (v === null) {
                     this.value = "null";
-                    this.name = "null";
+                    //this.name = "null";
                     this.simplename = "null";
                 } else {
                     this.value = "Unknown Object";
-                    this.name = "an unknown object";
+                    //this.name = "an unknown object";
                     this.simplename = "unknown object";
                 }
                 break;
             default:
                 this.value = "Unknown Value";
-                this.name = "an unknown value";
+                //this.name = "an unknown value";
                 this.simplename = "unknown value";
         }
         //TODO: double check this is all of the possible syntax values (probably not)
         //this.value += " " + this.syntax.range;
+    }
+
+    listify() {
+        this.value = 'List';
+        for (let c of this.children) {
+            if (c.simplename === 's-expression') {
+                c.listify();
+            }
+        }
     }
 
     toString(indent: string = ""): string {
@@ -298,7 +398,7 @@ export class AST {
         }
     }
 
-    describe() : string {
+    /*describe() : string {
         if (this.nodes.length === 0) {return "The source file is empty!";}
 
         let queue: SyntaxNode[] = [];
@@ -327,5 +427,5 @@ export class AST {
         }
 
         return ret;
-    }
+    }*/
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -14,389 +14,428 @@ import {EditorView} from "@codemirror/view";
 import {EditorSelection} from "@codemirror/state";
 
 class SyntaxNode {
-    syntax: Value.Syntax
-    value: string = ''
-    //name: string = ''
-    //parentname: string | null = null;
-    simplename: string = '';
-    index: number | null = null;
-    children: SyntaxNode[] = [];
-    parent: SyntaxNode | null = null;
+  syntax: Value.Syntax
+  value: string = ''
+  //name: string = ''
+  //parentname: string | null = null;
+  simplename: string = '';
+  index: number | null = null;
+  children: SyntaxNode[] = [];
+  parent: SyntaxNode | null = null;
 
-    constructor(syntax: Value.Syntax, index: number | null = null) {
-        this.syntax = syntax; 
-        //this.parentname = parent;
-        this.index = index;
-        let v: T = this.syntax.value;
+  constructor(syntax: Value.Syntax, index: number | null = null) {
+    this.syntax = syntax; 
+    //this.parentname = parent;
+    this.index = index;
+    let v: T = this.syntax.value;
 
-        switch (typeof v) {
-            case 'boolean':
-                this.value = "Boolean "+v;
-                //this.name = "a boolean "+v;
-                this.simplename = ''+v;
-                break;
-            case 'number':
-                this.value = "Numerical "+v;
-                //this.name = "the number "+v;
-                this.simplename = ''+v;
-                break;
-            case 'string':
-                this.value = '"'+v+'"';
-                //this.name = 'the string "'+v+'"';
-                this.simplename = '"'+v+'"';
-                break;
-            case 'undefined':
-                this.value = "Undefined";
-                //this.name = 'an undefined value';
-                this.simplename = 'undefined';
-                break;
-            case 'function':
-                this.value = 'Function';
-                //this.name = 'a function';
-                this.simplename = 'a function';
-                break;
-            case 'object':
-                if (isPair(v)) {
-                    let tail: T = (v as Pair).snd;
-                    const first = new SyntaxNode(
-                        mkSyntax(((v as Pair).fst as Syntax).range, ((v as Pair).fst as Syntax).value)
-                    );
-                      first.parent = this;
-                      this.children.push(first);
-                      let i: number = 1;
-                    while (isPair(tail)) {
-                        const child = new SyntaxNode(
-                            mkSyntax(((tail as Pair).fst as Syntax).range, ((tail as Pair).fst as Syntax).value),
-                            i
-                        );
-                        child.parent = this;
-                        this.children.push(child);
-                        i += 1;
-                        tail = (tail as Pair).snd;
-                      }
+    switch (typeof v) {
+      case 'boolean':
+        this.value = "Boolean "+v;
+        //this.name = "a boolean "+v;
+        this.simplename = ''+v;
+        break;
+      case 'number':
+        this.value = "Numerical "+v;
+        //this.name = "the number "+v;
+        this.simplename = ''+v;
+        break;
+      case 'string':
+        this.value = '"'+v+'"';
+        //this.name = 'the string "'+v+'"';
+        this.simplename = '"'+v+'"';
+        break;
+      case 'undefined':
+        this.value = "Undefined";
+        //this.name = 'an undefined value';
+        this.simplename = 'undefined';
+        break;
+      case 'function':
+        this.value = 'Function';
+        //this.name = 'a function';
+        this.simplename = 'a function';
+        break;
+      case 'object':
+        if (isPair(v)) {
+          let tail: T = (v as Pair).snd;
+          const first = new SyntaxNode(
+              mkSyntax(((v as Pair).fst as Syntax).range, ((v as Pair).fst as Syntax).value)
+          );
+          first.parent = this;
+          this.children.push(first);
+          let i: number = 1;
+          while (isPair(tail)) {
+            const child = new SyntaxNode(
+              mkSyntax(((tail as Pair).fst as Syntax).range, ((tail as Pair).fst as Syntax).value),
+              i
+            );
+            child.parent = this;
+            this.children.push(child);
+            i += 1;
+            tail = (tail as Pair).snd;
+          }
 
-                    let typeofstatement = "Function application"
+          let typeofstatement = "Function application"
 
-                    // There are several special types of statement this could be
-                    // and
-                    if (this.children[0].simplename === 'and') {
-                        typeofstatement = 'And statement';
-                    }
-                    // begin
-                    if (this.children[0].simplename === 'begin') {
-                        typeofstatement = 'Begin statement';
-                    }
-                    // cond
-                    if (this.children[0].simplename === 'cond') {
-                        typeofstatement = 'Cond statement';
-                        for (let c of this.children) {
-                            if (c.simplename === "vector") {
-                                c.value = "Cond branch"
-                            }
-                        }
-                    }
-                    // define
-                    if (this.children[0].simplename === 'define') {
-                        typeofstatement = 'Define statement';
-                    }
-                    // if
-                    if (this.children[0].simplename === 'if') {
-                        typeofstatement = 'If statement';
-                    }
-                    // import
-                    if (this.children[0].simplename === 'import') {
-                        typeofstatement = 'Import statement';
-                    }
-                    // lambda
-                    if (this.children[0].simplename === 'lambda') {
-                        typeofstatement = 'Lambda statement';
-                        this.children[1].value = "Parameter list"
-                    }
-                    // let
-                    if (this.children[0].simplename === 'let') {
-                        typeofstatement = 'Let statement';
-                        this.children[1].value = "List of let bindings"
-                        for (let c of this.children[1].children) {
-                            c.value = "Let binding"
-                        }
-                    }
-                    // let*
-                    if (this.children[0].simplename === 'let*') {
-                        typeofstatement = 'Let* statement';
-                        this.children[1].value = "List of let* bindings"
-                        for (let c of this.children[1].children) {
-                            c.value = "Let* binding"
-                        }
-                    }
-                    // letrec
-                    if (this.children[0].simplename === 'letrec') {
-                        typeofstatement = 'Letrec statement';
-                        this.children[1].value = "List of letrec bindings"
-                        for (let c of this.children[1].children) {
-                            c.value = "Letrec binding"
-                        }
-                    }
-                    // match
-                    if (this.children[0].simplename === 'match') {
-                        typeofstatement = 'Match statement';
-                        for (let c of this.children) {
-                            if (c.simplename === 'vector') {
-                                c.value = "Match branch";
-                            }
-                        }
-                    }
-                    // or
-                    if (this.children[0].simplename === 'or') {
-                        typeofstatement = 'Or statement';
-                    }
-                    // quote
-                    if (this.children[0].simplename === 'quote' || this.children[0].simplename === '"quote"') {
-                        typeofstatement = 'Quoted value';
-                        this.children = this.children.slice(1);
-                        if (this.children[0].simplename === 's-expression') {
-                            this.children[0].listify();
-                        }
-                    }
-                    // section
-                    if (this.children[0].simplename === 'section') {
-                        typeofstatement = 'Section statement';
-                    }
-                    // struct
-                    if (this.children[0].simplename === 'struct') {
-                        typeofstatement = 'Struct statement';
-                        this.children[2].value = "Field list";
-                    }
-
-                    this.value = typeofstatement;
-                    /*if (this.parentname != null) {
-                        this.name = "the "+typeofstatement+" in argument "+this.index+" of "+this.parentname;
-                    } else {
-                        this.name = "the "+typeofstatement+" starting with " + this.children[0].name;
-                    }*/
-                    this.simplename = 's-expression';
-                } else if (isArray(v)) {
-                    this.simplename = 'vector';
-                    this.value = "Vector";
-                    //this.name = "the square bracket array at "+this.syntax.range;
-
-                    /*if (this.parentname != null) {
-                        this.name = "the square bracket array in argument "+this.index+" of "+this.parentname;
-                    }*/
-
-                    let i: number = 0;
-                    for (let c of (v as Vector)) {
-                        const child = new SyntaxNode(mkSyntax((c as Syntax).range, (c as Syntax).value), i);
-                        child.parent = this;
-                        this.children.push(child);
-                        i += 1;
-                    }
-
-                    /*if (this.parentname == null) {
-                        this.name = "the square bracket array starting with " + this.children[0].name;
-                    }*/
-                } else if (isSym(v)) {
-                    this.value = "Symbol " + (v as Sym).value;
-                    //this.name = "the symbol "+(v as Sym).value;
-                    this.simplename = ''+(v as Sym).value;
-                } else if (isChar(v)) {
-                    this.value = "Character " + (v as Char).value;
-                    //this.name = "the character " + (v as Char).value;
-                    this.simplename = ''+(v as Char).value;
-                } else if (v === null) {
-                    this.value = "null";
-                    //this.name = "null";
-                    this.simplename = "null";
-                } else {
-                    this.value = "Unknown Object";
-                    //this.name = "an unknown object";
-                    this.simplename = "unknown object";
-                }
-                break;
-            default:
-                this.value = "Unknown Value";
-                //this.name = "an unknown value";
-                this.simplename = "unknown value";
-        }
-        //TODO: double check this is all of the possible syntax values (probably not)
-        //this.value += " " + this.syntax.range;
-    }
-
-    listify() {
-        this.value = 'List';
-        for (let c of this.children) {
-            if (c.simplename === 's-expression') {
-                c.listify();
+          // There are several special types of statement this could be
+          // and
+          if (this.children[0].simplename === 'and') {
+            typeofstatement = 'And statement';
+          }
+          // begin
+          if (this.children[0].simplename === 'begin') {
+            typeofstatement = 'Begin statement';
+          }
+          // cond
+          if (this.children[0].simplename === 'cond') {
+            typeofstatement = 'Cond statement';
+            for (let c of this.children) {
+              if (c.simplename === "vector") {
+                c.value = "Cond branch"
+              }
             }
+          }
+          // define
+          if (this.children[0].simplename === 'define') {
+            typeofstatement = 'Define statement';
+          }
+          // if
+          if (this.children[0].simplename === 'if') {
+            typeofstatement = 'If statement';
+          }
+          // import
+          if (this.children[0].simplename === 'import') {
+            typeofstatement = 'Import statement';
+          }
+          // lambda
+          if (this.children[0].simplename === 'lambda') {
+            typeofstatement = 'Lambda statement';
+            this.children[1].value = "Parameter list"
+          }
+          // let
+          if (this.children[0].simplename === 'let') {
+            typeofstatement = 'Let statement';
+            this.children[1].value = "List of let bindings"
+            for (let c of this.children[1].children) {
+              c.value = "Let binding"
+            }
+          }
+          // let*
+          if (this.children[0].simplename === 'let*') {
+            typeofstatement = 'Let* statement';
+            this.children[1].value = "List of let* bindings"
+            for (let c of this.children[1].children) {
+              c.value = "Let* binding"
+            }
+          }
+          // letrec
+          if (this.children[0].simplename === 'letrec') {
+            typeofstatement = 'Letrec statement';
+            this.children[1].value = "List of letrec bindings"
+            for (let c of this.children[1].children) {
+              c.value = "Letrec binding"
+            }
+          }
+          // match
+          if (this.children[0].simplename === 'match') {
+            typeofstatement = 'Match statement';
+            for (let c of this.children) {
+              if (c.simplename === 'vector') {
+                c.value = "Match branch";
+              }
+            }
+          }
+          // or
+          if (this.children[0].simplename === 'or') {
+            typeofstatement = 'Or statement';
+          }
+          // quote
+          if (this.children[0].simplename === 'quote' || this.children[0].simplename === '"quote"') {
+            typeofstatement = 'Quoted value';
+            this.children = this.children.slice(1);
+            if (this.children[0].simplename === 's-expression') {
+              this.children[0].listify();
+            }
+          }
+          // section
+          if (this.children[0].simplename === 'section') {
+            typeofstatement = 'Section statement';
+          }
+          // struct
+          if (this.children[0].simplename === 'struct') {
+            typeofstatement = 'Struct statement';
+            this.children[2].value = "Field list";
+          }
+
+          this.value = typeofstatement;
+          /*if (this.parentname != null) {
+              this.name = "the "+typeofstatement+" in argument "+this.index+" of "+this.parentname;
+          } else {
+              this.name = "the "+typeofstatement+" starting with " + this.children[0].name;
+          }*/
+          this.simplename = 's-expression';
+        } else if (isArray(v)) {
+            this.simplename = 'vector';
+            this.value = "Vector";
+            //this.name = "the square bracket array at "+this.syntax.range;
+
+            /*if (this.parentname != null) {
+                this.name = "the square bracket array in argument "+this.index+" of "+this.parentname;
+            }*/
+
+            let i: number = 0;
+            for (let c of (v as Vector)) {
+                const child = new SyntaxNode(mkSyntax((c as Syntax).range, (c as Syntax).value), i);
+                child.parent = this;
+                this.children.push(child);
+                i += 1;
+            }
+
+            /*if (this.parentname == null) {
+                this.name = "the square bracket array starting with " + this.children[0].name;
+            }*/
+        } else if (isSym(v)) {
+            this.value = "Symbol " + (v as Sym).value;
+            //this.name = "the symbol "+(v as Sym).value;
+            this.simplename = ''+(v as Sym).value;
+        } else if (isChar(v)) {
+            this.value = "Character " + (v as Char).value;
+            //this.name = "the character " + (v as Char).value;
+            this.simplename = ''+(v as Char).value;
+        } else if (v === null) {
+            this.value = "null";
+            //this.name = "null";
+            this.simplename = "null";
+        } else {
+            this.value = "Unknown Object";
+            //this.name = "an unknown object";
+            this.simplename = "unknown object";
         }
+        break;
+      default:
+        this.value = "Unknown Value";
+        //this.name = "an unknown value";
+        this.simplename = "unknown value";
+    }
+    //TODO: double check this is all of the possible syntax values (probably not)
+    //this.value += " " + this.syntax.range;
+  }
+
+  listify() {
+    this.value = 'List';
+    for (let c of this.children) {
+      if (c.simplename === 's-expression') {
+        c.listify();
+      }
+    }
+  }
+
+  toString(indent: string = ""): string {
+    let ret: string = indent+this.value;
+
+    for (let c of this.children) {
+      ret += "\n" + c.toString(indent+"  ");
     }
 
-    toString(indent: string = ""): string {
-        let ret: string = indent+this.value;
-
-        for (let c of this.children) {
-            ret += "\n" + c.toString(indent+"  ");
-        }
-
-        return ret;
-    }
+    return ret;
+  }
 }
 
 export class AST {
-    syntax: Value.Syntax[]
-    nodes: SyntaxNode[] = [];
-    labelMap: Map<SyntaxNode, HTMLButtonElement> = new Map()
+  syntax: Value.Syntax[]
+  nodes: SyntaxNode[] = [];
+  labelMap: Map<SyntaxNode, HTMLButtonElement> = new Map()
 
-    constructor(syntax: Value.Syntax[]) {
-        this.syntax = syntax;
+  constructor(syntax: Value.Syntax[]) {
+    this.syntax = syntax;
 
-        for (let s of this.syntax) {
-            this.nodes.push(new SyntaxNode(s));
-        }
+    for (let s of this.syntax) {
+      this.nodes.push(new SyntaxNode(s));
     }
+  }
     
-    renderNode(
-        node: SyntaxNode,
-        level: number,
-        isLast: boolean,
-        editor: EditorView,
-        indexInParent: number = 0,
-        totalSiblings: number = 1,
-      ): HTMLElement {
-        node.index = indexInParent;
-        const div = document.createElement('div');
-        // console.log(`Rendering "${node.value}" at level ${level} (item ${indexInParent + 1} of ${totalSiblings})`);
+  renderNode(
+    node: SyntaxNode,
+    level: number,
+    isLast: boolean,
+    editor: EditorView,
+    indexInParent: number = 0,
+    totalSiblings: number = 1,
+    ): HTMLElement {
+    node.index = indexInParent;
+    const div = document.createElement('div');
+    // console.log(`Rendering "${node.value}" at level ${level} (item ${indexInParent + 1} of ${totalSiblings})`);
 
-        const connector = isLast ? "└── " : "├── ";
-        const prefix = document.createElement('span');
-        prefix.textContent = `${'│   '.repeat(level - 1)}${connector}`;
-        prefix.setAttribute('aria-hidden', 'true');
-        prefix.setAttribute('tabindex', '-1'); // avoid accidental focus
-      
-        const label = document.createElement('button');
-        this.labelMap.set(node, label);
+    const connector = isLast ? "└── " : "├── ";
+    const prefix = document.createElement('span');
+    prefix.textContent = `${'│   '.repeat(level - 1)}${connector}`;
+    prefix.setAttribute('aria-hidden', 'true');
+    prefix.setAttribute('tabindex', '-1'); // avoid accidental focus
+  
+    const label = document.createElement('button');
+    this.labelMap.set(node, label);
 
-        label.setAttribute(
-            'aria-label',
-            `${node.value}, Level ${level}, item ${indexInParent + 1} of ${totalSiblings}`
-        );
+    label.setAttribute(
+      'aria-label',
+      `${node.value}, Level ${level}, item ${indexInParent + 1} of ${totalSiblings}`
+    );
 
-        label.textContent = node.value;
+    label.textContent = node.value;
 
-        label.onclick = () => {
-            console.log("Clicked " + node.syntax.range);
+    label.onclick = () => {
+      console.log("Clicked " + node.syntax.range);
 
-            editor.focus();
+      editor.focus();
 
-            editor.dispatch({
-                selection: EditorSelection.create([
-                    EditorSelection.range(node.syntax.range.begin.idx, node.syntax.range.end.idx+1),
-                ])
-            });
-        }
+      editor.dispatch({
+        selection: EditorSelection.create([
+          EditorSelection.range(node.syntax.range.begin.idx, node.syntax.range.end.idx+1),
+        ])
+      });
+    }
 
-        label.addEventListener("keydown", (e: KeyboardEvent) => {
-            if (e.key === "ArrowDown") {
-              if (node.children.length > 0) {
-                this.labelMap.get(node.children[0])?.focus();
-              }
-              e.preventDefault();
-            } else if (e.key === "ArrowUp") {
-              if (node.parent) {
-                this.labelMap.get(node.parent)?.focus();
-              }
-              e.preventDefault();
-            } else if (e.key === "ArrowRight") {
-              if (node.parent && node.index !== null && node.index + 1 < node.parent.children.length) {
-                this.labelMap.get(node.parent.children[node.index + 1])?.focus();
-              }
-              e.preventDefault();
-            } else if (e.key === "ArrowLeft") {
-              if (node.parent && node.index !== null && node.index - 1 >= 0) {
-                this.labelMap.get(node.parent.children[node.index - 1])?.focus();
-              }
-              e.preventDefault();
-            }
-        });
-      
-        div.appendChild(prefix);
-        div.appendChild(label);
-      
+    label.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
         if (node.children.length > 0) {
-          const group = document.createElement('div');
-          group.setAttribute('role', 'group');
-          for (let i = 0; i < node.children.length; i++) {
-            const child = node.children[i];
-            group.appendChild(
-              this.renderNode(child, level + 1, i === node.children.length - 1, editor, i, node.children.length)
-            );
-          }
-          div.appendChild(group);
+          this.labelMap.get(node.children[0])?.focus();
         }
-        return div;
+        e.preventDefault();
+      } else if (e.key === "ArrowUp") {
+        if (node.parent) {
+          this.labelMap.get(node.parent)?.focus();
+        }
+        e.preventDefault();
+      } else if (e.key === "ArrowRight") {
+        if (node.parent && node.index !== null && node.index + 1 < node.parent.children.length) {
+          this.labelMap.get(node.parent.children[node.index + 1])?.focus();
+        }
+        e.preventDefault();
+      } else if (e.key === "ArrowLeft") {
+        if (node.parent && node.index !== null && node.index - 1 >= 0) {
+          this.labelMap.get(node.parent.children[node.index - 1])?.focus();
+        }
+        e.preventDefault();
       }
+    });
+  
+    div.appendChild(prefix);
+    div.appendChild(label);
+  
+    if (node.children.length > 0) {
+      const group = document.createElement('div');
+      group.setAttribute('role', 'group');
+      for (let i = 0; i < node.children.length; i++) {
+        const child = node.children[i];
+        group.appendChild(
+          this.renderNode(child, level + 1, i === node.children.length - 1, editor, i, node.children.length)
+        );
+      }
+      div.appendChild(group);
+    }
+    return div;
+  }
 
-    render(output: HTMLElement, editor: EditorView) {
-        const container = document.createElement('div');
-        container.setAttribute('id', 'ast-output');
-        container.setAttribute('role', 'tree');
-        const heading = document.createElement('h2');
-        heading.setAttribute('aria-hidden', 'true');
-        container.appendChild(heading);
-        container.style.fontFamily = 'monospace';
-        container.style.whiteSpace = 'pre';
+  render(output: HTMLElement, editor: EditorView) {
+    const container = document.createElement('div');
+    container.setAttribute('id', 'ast-output');
+    container.setAttribute('role', 'tree');
+    const heading = document.createElement('h2');
+    heading.setAttribute('aria-hidden', 'true');
+    container.appendChild(heading);
+    container.style.fontFamily = 'monospace';
+    container.style.whiteSpace = 'pre';
+  
+    const dummySyntax = {
+      range: { begin: { idx: 0 }, end: { idx: 0 } },
+      value: null
+    } as Value.Syntax;
       
-        const dummySyntax = {
-            range: { begin: { idx: 0 }, end: { idx: 0 } },
-            value: null
-          } as Value.Syntax;
-          
-        const topParent = new SyntaxNode(dummySyntax);
-        topParent.children = this.nodes;
-        for (let i = 0; i < this.nodes.length; i++) {
-            const isLast = (i === this.nodes.length - 1);
-            const node = this.nodes[i];
-            node.index = i;
-            node.parent = topParent;
-            container.appendChild(this.renderNode(node, 1, isLast, editor, i, this.nodes.length));
-        }
-        output.appendChild(container);
+    const topParent = new SyntaxNode(dummySyntax);
+    topParent.children = this.nodes;
+    for (let i = 0; i < this.nodes.length; i++) {
+      const isLast = (i === this.nodes.length - 1);
+      const node = this.nodes[i];
+      node.index = i;
+      node.parent = topParent;
+      container.appendChild(this.renderNode(node, 1, isLast, editor, i, this.nodes.length));
+    }
+    output.appendChild(container);
+  }
+
+
+  buildTreeHTML(node: SyntaxNode): HTMLElement {
+    const li = document.createElement("li");
+    const div = document.createElement("div");
+
+    div.className = "box";
+    div.tabIndex = 1
+    div.textContent = node.value;
+    div.setAttribute("text-index", node.syntax.range.begin.idx.toString())
+    li.appendChild(div);
+
+    if (node.children && node.children.length > 0) {
+      const ul = document.createElement("ul");
+      for (const child of node.children) {
+        ul.appendChild(this.buildTreeHTML(child));
+      }
+      li.appendChild(ul);
     }
 
+    return li;
+  }
 
-    buildTreeHTML(node: SyntaxNode): HTMLElement {
-        const li = document.createElement("li");
-        const div = document.createElement("div");
+  renderTree(output: HTMLElement, nodes: SyntaxNode[]) {
+    output.innerHTML = "";
+    output.classList.remove("tree");
 
-        div.className = "box";
-        div.textContent = node.value;
-        li.appendChild(div);
+    for (const n of nodes) {
+      const treeContainer = document.createElement("div");
+      treeContainer.classList.add("tree");
 
-        if (node.children && node.children.length > 0) {
-            const ul = document.createElement("ul");
-            for (const child of node.children) {
-                ul.appendChild(this.buildTreeHTML(child));
-            }
-            li.appendChild(ul);
-        }
+      const rootUl = document.createElement("ul");
+      rootUl.appendChild(this.buildTreeHTML(n));
+      treeContainer.appendChild(rootUl);
 
-        return li;
+      output.appendChild(treeContainer);
     }
 
-    renderTree(output: HTMLElement, nodes: SyntaxNode[]) {
-        output.innerHTML = "";
-        output.classList.remove("tree");
+    const boxes = output.querySelectorAll(".box")
 
-        for (const n of nodes) {
-            const treeContainer = document.createElement("div");
-            treeContainer.classList.add("tree");
-
-            const rootUl = document.createElement("ul");
-            rootUl.appendChild(this.buildTreeHTML(n));
-            treeContainer.appendChild(rootUl);
-
-            output.appendChild(treeContainer);
+    boxes.forEach(box => {
+      box.addEventListener("click", () => {
+        const index = box.getAttribute("text-index")
+        if (index !== null) {
+          this.sendIndexToIdeTab(index)
         }
+      });
+    });
+
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === "click") {
+        const active = document.activeElement
+        if (active && active.classList.contains("box")) {
+          const index = active.getAttribute("text-index")
+          if (index !== null) {
+            this.sendIndexToIdeTab(index)
+          }
+        }
+      }
+    });
+  }
+
+  sendIndexToIdeTab(index: string) {
+    if (window.opener && !window.opener.closed) {
+      window.opener.postMessage(
+        {
+          type: "AST_CURSOR",
+          index: index,
+        },
+        "*"
+      );
+    } else {
+      alert("Could not return to source file");
     }
+  }
 
     /*describe() : string {
         if (this.nodes.length === 0) {return "The source file is empty!";}

--- a/src/web/ide.ts
+++ b/src/web/ide.ts
@@ -179,6 +179,13 @@ class IDE {
       const params = new URLSearchParams({filename: this.currentFile, isTree: "true"})
       window.open(`runner.html?${params.toString()}`)
     })
+
+    window.addEventListener("message", (event) => {
+      const { type, index } = event.data || {};
+      if (type === "AST_CURSOR" && typeof index === "string") {
+          this.moveCursorToIndex(parseInt(index));
+      }
+    });
     
     stepOnceButton.disabled = true
     stepStmtButton.disabled = true
@@ -271,6 +278,14 @@ class IDE {
   displayError (error: string) {
     document.getElementById("loading-content")!.innerText = error
     document.getElementById("loading")!.style.display = "block"
+  }
+
+  moveCursorToIndex(index: number) {
+    this.editor.dispatch({
+        selection: { anchor: index },
+        scrollIntoView: true
+    });
+    this.editor.focus();
   }
 }
 

--- a/src/web/ide.ts
+++ b/src/web/ide.ts
@@ -75,12 +75,12 @@ class IDE {
       labelEl.setAttribute('aria-label', 'Abstract Syntax Tree... Navigation instructions: use tab to traverse the tree in the order of node position on the code, or use "left/right" arrows for visiting neighbors, "down arrow" to visit children, and "up arrow" to go to parent')
       outputPane!.appendChild(labelEl)
       parsed.ast.render(outputPane, this.editor)
-      const descriptionEl = document.createElement('div')
+      /*const descriptionEl = document.createElement('div')
       descriptionEl.setAttribute('id', 'ast-desc')
       descriptionEl.innerText = parsed.ast.describe()
       descriptionEl.setAttribute('tabindex', '0')
       descriptionEl.setAttribute('role', 'region')
-      outputPane!.appendChild(descriptionEl)
+      outputPane!.appendChild(descriptionEl)*/
       this.makeClean()
     } catch (e) {
       renderToOutput(outputPane, e)

--- a/src/web/ide.ts
+++ b/src/web/ide.ts
@@ -104,15 +104,16 @@ class IDE {
               view.dispatch({
                 selection: { anchor: 0, head: doc.length }
               })     
-              const success = indentSelection(view)
+              const selec = indentSelection(view)
               const updatedLine = view.state.doc.line(line.number)
+              // Calculating the number of leading whitespace characters (spaces or tabs) at the start of updatedLine
               const nonWhitespacePrefix = updatedLine.text.match(/^\s*/)?.[0].length || 0         
               const newHead = Math.min(updatedLine.from + nonWhitespacePrefix + visualColumn, updatedLine.to)
               view.dispatch({
                 selection: { anchor: newHead },
                 scrollIntoView: true
               })
-              return success
+              return selec
             }
           },
           {


### PR DESCRIPTION
### Runner AST (visualization)
Previously, the AST using the runner was not keyboard accessible/did not have many of the features the interactive pane AST had. Additions to **ast.ts** were made to enable keyboard navigation. It also now supports a feature which when a node is clicked, moves the cursor in the code editor to the beginning of that node(**ast.ts** and **ide.ts**). The runner tree was also updated to have more simple graphics instead of extraneous lines(**runner.html**). 

### General AST
**ast.ts** was updated to provide more accurate descriptions of scamper code. The tree is now output with more syntactically meaningful labels.

### Other fix
Key binds were reorganized to provide more universally usable keys. **ide.html** was changed to support these new key binds. Also, the indentation on **ast.ts** was set to 4, and nearly everything else is 2, so everything was reindented.