### PR TITLE
Implement tally-all in the data library

### DIFF
--- a/src/docs/api/data.ts
+++ b/src/docs/api/data.ts
@@ -27,3 +27,10 @@ export const charsToLines: Doc = new Doc(
   [ new ArgDoc('chars', 'list?') ],
   'Converts a list of char values into a list of strings, where each string is a line of text.'
 )
+
+export const tallyAll: Doc = new Doc (
+  'tally-all',
+  'list?',
+  [ new ArgDoc('lst', 'list?') ],
+  'Takes a list `lst` and returns a list of pairs where each pair consists of an element from `lst` and the number of times that element appears in `lst`.'
+)

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -41,4 +41,39 @@ function stringToLines (s: string): L.List {
 }
 Data.registerValue('string->lines', stringToLines)
 
+/**
+ * A simple association list over LPM values for the purposes of tallying. We
+ * reimplement the basic functionality of a dictionary because the JS Map
+ * datatype does not allow for arbitrary equality over keys.
+ */
+class TallyList {
+  public data: { key: L.Value, value: number }[]
+
+  constructor () {
+    this.data = []
+  }
+
+  update (key: L.Value, updater: (value: number) => number, def: number): void {
+    for (let i = 0; i < this.data.length; i++) {
+      if (L.equals(this.data[i].key, key)) {
+        this.data[i].value = updater(this.data[i].value)
+        return
+      }
+    }
+    this.data.push({ key, value: def })
+  }
+}
+
+function tallyAll (lst: L.List): L.List {
+  const tally = new TallyList()
+  let cur: L.List = lst
+  while (cur !== null) {
+    const value = cur.head
+    tally.update(value, v => v + 1, 1)
+    cur = cur.tail
+  }
+  return L.vectorToList(tally.data.map(p => L.mkPair(p.key, p.value)))
+}
+Data.registerValue('tally-all', tallyAll)
+
 export default Data

--- a/test/libs/data.test.ts
+++ b/test/libs/data.test.ts
@@ -1,0 +1,9 @@
+import { scamperTest } from '../harness.js'
+
+scamperTest('tally-all', `
+  (import data)
+  (tally-all (list "a" "b" "a" "c" "c" "d" "b" "a" "q" "r" "r" "a" "d"))
+`,[
+  '(list (pair "a" 4) (pair "b" 2) (pair "c" 2) (pair "d" 2) (pair "q" 1) (pair "r" 2))'
+])
+

--- a/test/libs/libs.test.ts
+++ b/test/libs/libs.test.ts
@@ -1,8 +1,8 @@
 import {expect, test} from '@jest/globals'
 
-import builtinLibs from '../src/lib'
-import * as Scheme from '../src/scheme'
-import * as LPM from '../src/lpm'
+import builtinLibs from '../../src/lib'
+import * as Scheme from '../../src/scheme'
+import * as LPM from '../../src/lpm'
 
 function runProgram (src: string): string[] {
     const out = new LPM.LoggingChannel()


### PR DESCRIPTION
Adds the `tally-all` function to the data library.

Fixes #125