### PR TITLE
Enforce no-semicolon style with ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,6 +81,7 @@ export default defineConfig(
         },
       ],
       quotes: ['warn', 'single', { avoidEscape: true }],
+      semi: ['warn', 'never'],
       'lines-between-class-members': [
         'warn',
         'always',

--- a/src/app/search/ApiEntries.vue
+++ b/src/app/search/ApiEntries.vue
@@ -151,7 +151,7 @@ const tagList = ref([
   { id: 24, val: 'reactive' },
 
   { id: 21, val: 'other' },
-]);
+])
 
 const indentList = ref([
 'association list', 
@@ -175,7 +175,7 @@ const indentList = ref([
 'create' ,
 'plot' ,
 'parse' ,
-]);
+])
 
 const AisOpen = ref(false)
 const RisOpen = ref(false)

--- a/src/app/search/DocsApp.vue
+++ b/src/app/search/DocsApp.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import ApiEntries from './ApiEntries.vue';
+import ApiEntries from './ApiEntries.vue'
 const appVersion = APP_VERSION
 
 const search = ref('')
@@ -9,8 +9,8 @@ function searchForFunction(searchTerm: string) {
   window.open('search.html?search=' + encodeURIComponent(searchTerm), '_self')
 }
 
-const urlParams = new URLSearchParams(window.location.search);
-const searched: string | null = urlParams.get('search');
+const urlParams = new URLSearchParams(window.location.search)
+const searched: string | null = urlParams.get('search')
 </script>
 
 <template>

--- a/src/js/audio/index.ts
+++ b/src/js/audio/index.ts
@@ -1,13 +1,13 @@
-import * as L from '../../lpm';
+import * as L from '../../lpm'
 
 // N.B., lazily instantiate AudioContext to avoid issues with non-web contexts
 // TODO: need to factor appropriately so that we aren't initializing any
 // web things unless we are definitely in the browser.
-let ctx: AudioContext | undefined;
+let ctx: AudioContext | undefined
 export const audio_getCtx = (): AudioContext => {
-  ctx ??= new AudioContext({ sampleRate: 16000 });
-  return ctx;
-};
+  ctx ??= new AudioContext({ sampleRate: 16000 })
+  return ctx
+}
 
 export interface SampleNode extends L.Struct {
   [L.structKind]: 'sample';
@@ -20,27 +20,27 @@ export function audio_sampleNode(data: number[]): SampleNode {
       throw new L.ScamperError(
         'Runtime',
         `expected a list of numbers between -1.0 and 1.0, received ${sample.toString()}`,
-      );
+      )
     }
   }
   return {
     [L.scamperTag]: 'struct',
     [L.structKind]: 'sample',
     data: new Float32Array(data),
-  };
+  }
 }
 
 export function audio_sampleQ(v: any): boolean {
-  return L.isStructKind(v, 'sample');
+  return L.isStructKind(v, 'sample')
 }
 
 export function audio_audioContext(sampleRate: number): AudioContext {
-  const AudioContext = window.AudioContext;
-  return new AudioContext({ sampleRate });
+  const AudioContext = window.AudioContext
+  return new AudioContext({ sampleRate })
 }
 
 export function audio_contextQ(v: any): boolean {
-  return v instanceof AudioContext;
+  return v instanceof AudioContext
 }
 
 export interface AudioPipeline extends L.Struct {
@@ -57,33 +57,33 @@ export function audio_audioPipeline(
 ) {
   // TODO: need to check types on the anys... but they're JS types!
   for (let i = 0; i < nodes.length - 1; i++) {
-    nodes[i].connect(nodes[i + 1]);
+    nodes[i].connect(nodes[i + 1])
   }
   if (nodes.length > 0) {
-    pipeline.connect(nodes[0]);
+    pipeline.connect(nodes[0])
   }
-  const onOffNode = new GainNode(ctx);
+  const onOffNode = new GainNode(ctx)
   if (nodes.length > 0) {
-    nodes[nodes.length - 1].connect(onOffNode);
+    nodes[nodes.length - 1].connect(onOffNode)
   } else {
-    pipeline.connect(onOffNode);
+    pipeline.connect(onOffNode)
   }
-  onOffNode.connect(ctx.destination);
+  onOffNode.connect(ctx.destination)
   return {
     [L.scamperTag]: 'struct',
     [L.structKind]: 'audio-pipeline',
     ctx,
     pipeline,
     onOffNode,
-  };
+  }
 }
 
 export function audio_pipelineQ(v: any): boolean {
-  return L.isStructKind(v, 'audio-pipeline');
+  return L.isStructKind(v, 'audio-pipeline')
 }
 
 export function audio_audioNodeQ(v: any): boolean {
-  return v instanceof AudioNode;
+  return v instanceof AudioNode
 }
 
 export function audio_oscillatorNode(
@@ -91,10 +91,10 @@ export function audio_oscillatorNode(
   type: OscillatorType,
   freq: number,
 ): OscillatorNode {
-  const oscillator = ctx.createOscillator();
-  oscillator.type = type;
-  oscillator.frequency.value = freq;
-  return oscillator;
+  const oscillator = ctx.createOscillator()
+  oscillator.type = type
+  oscillator.frequency.value = freq
+  return oscillator
 }
 
 // NOTE: microphone usage requires an async call! Oof! How are we suppose to
@@ -111,14 +111,14 @@ export function audio_audioFileNode(
   ctx: AudioContext,
   filename: string,
 ): MediaElementAudioSourceNode {
-  const mediaElement = document.createElement('audio');
-  mediaElement.src = filename;
-  const source = new MediaElementAudioSourceNode(ctx, { mediaElement });
-  return source;
+  const mediaElement = document.createElement('audio')
+  mediaElement.src = filename
+  const source = new MediaElementAudioSourceNode(ctx, { mediaElement })
+  return source
 }
 
 export function audio_delayNode(ctx: AudioContext, delayTime: number): DelayNode {
-  return new DelayNode(ctx, { delayTime });
+  return new DelayNode(ctx, { delayTime })
 }
 
 export function audio_playSample(pipeline: SampleNode): void {
@@ -129,16 +129,16 @@ export function audio_playSample(pipeline: SampleNode): void {
   //     `expected a sample node, received ${pipeline}`,
   //   );
   // }
-  const ctx = audio_getCtx();
+  const ctx = audio_getCtx()
   // TODO: error message function should be in some util file instead of inlined
-  const data = pipeline.data;
+  const data = pipeline.data
   // N.B., for now, make the audio sample stereo (2 channels)
-  const buffer = ctx.createBuffer(2, data.length, ctx.sampleRate);
-  buffer.copyToChannel(data, 0);
-  buffer.copyToChannel(data, 1);
-  const source = ctx.createBufferSource();
-  source.buffer = buffer;
-  source.connect(ctx.destination);
-  source.start();
+  const buffer = ctx.createBuffer(2, data.length, ctx.sampleRate)
+  buffer.copyToChannel(data, 0)
+  buffer.copyToChannel(data, 1)
+  const source = ctx.createBufferSource()
+  source.buffer = buffer
+  source.connect(ctx.destination)
+  source.start()
 }
 

--- a/src/js/audio/renderers/html.ts
+++ b/src/js/audio/renderers/html.ts
@@ -1,9 +1,9 @@
-import * as L from '../../../lpm';
-import HtmlRenderer from '../../../lpm/renderers/html.js';
-import { SampleNode, AudioPipeline, audio_getCtx } from '../index.js';
+import * as L from '../../../lpm'
+import HtmlRenderer from '../../../lpm/renderers/html.js'
+import { SampleNode, AudioPipeline, audio_getCtx } from '../index.js'
 
 function throwError(msg: string): never {
-  throw new L.ScamperError('Runtime', msg);
+  throw new L.ScamperError('Runtime', msg)
 }
 
 export function drawOscilloscope(
@@ -12,77 +12,77 @@ export function drawOscilloscope(
   analyser: AnalyserNode,
 ) {
   requestAnimationFrame(() => {
-    drawOscilloscope(data, canvas, analyser);
-  });
+    drawOscilloscope(data, canvas, analyser)
+  })
 
-  const bufferLength = analyser.frequencyBinCount;
-  analyser.getByteTimeDomainData(data);
-  const ctx = canvas.getContext('2d') ?? throwError('no canvas context');
-  ctx.fillStyle = 'rgb(200, 200, 200)';
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const bufferLength = analyser.frequencyBinCount
+  analyser.getByteTimeDomainData(data)
+  const ctx = canvas.getContext('2d') ?? throwError('no canvas context')
+  ctx.fillStyle = 'rgb(200, 200, 200)'
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
 
-  ctx.lineWidth = 2;
-  ctx.strokeStyle = 'rgb(0, 0, 0)';
-  ctx.beginPath();
-  const sliceWidth = (canvas.width * 1.0) / bufferLength;
-  let x = 0;
+  ctx.lineWidth = 2
+  ctx.strokeStyle = 'rgb(0, 0, 0)'
+  ctx.beginPath()
+  const sliceWidth = (canvas.width * 1.0) / bufferLength
+  let x = 0
 
   for (let i = 0; i < bufferLength; i++) {
-    const v = data[i] / 128.0;
-    const y = (v * canvas.height) / 2;
+    const v = data[i] / 128.0
+    const y = (v * canvas.height) / 2
 
     if (i === 0) {
-      ctx.moveTo(x, y);
+      ctx.moveTo(x, y)
     } else {
-      ctx.lineTo(x, y);
+      ctx.lineTo(x, y)
     }
 
-    x += sliceWidth;
+    x += sliceWidth
   }
 
-  ctx.lineTo(canvas.width, canvas.height / 2);
-  ctx.stroke();
+  ctx.lineTo(canvas.width, canvas.height / 2)
+  ctx.stroke()
 }
 
 export function sampleRenderer(sample: SampleNode): HTMLElement {
-  const ctx = audio_getCtx();
-  const ret = document.createElement('span');
-  const playButton = document.createElement('button');
-  playButton.textContent = '▶';
-  const stopButton = document.createElement('button');
-  stopButton.textContent = '■';
-  const visualizer = document.createElement('canvas');
+  const ctx = audio_getCtx()
+  const ret = document.createElement('span')
+  const playButton = document.createElement('button')
+  playButton.textContent = '▶'
+  const stopButton = document.createElement('button')
+  stopButton.textContent = '■'
+  const visualizer = document.createElement('canvas')
 
-  const analyser = ctx.createAnalyser();
-  analyser.fftSize = 2048;
-  const bufferLength = analyser.frequencyBinCount;
-  const dataArray = new Uint8Array(bufferLength);
-  analyser.getByteTimeDomainData(dataArray);
+  const analyser = ctx.createAnalyser()
+  analyser.fftSize = 2048
+  const bufferLength = analyser.frequencyBinCount
+  const dataArray = new Uint8Array(bufferLength)
+  analyser.getByteTimeDomainData(dataArray)
 
-  const data = sample.data;
+  const data = sample.data
   // N.B., for now, make the audio sample stereo (2 channels)
-  const buffer = ctx.createBuffer(2, data.length, ctx.sampleRate);
-  buffer.copyToChannel(data, 0);
-  buffer.copyToChannel(data, 1);
-  let source: AudioBufferSourceNode | undefined;
+  const buffer = ctx.createBuffer(2, data.length, ctx.sampleRate)
+  buffer.copyToChannel(data, 0)
+  buffer.copyToChannel(data, 1)
+  let source: AudioBufferSourceNode | undefined
   playButton.onclick = () => {
-    source = ctx.createBufferSource();
-    source.buffer = buffer;
-    source.connect(ctx.destination);
-    source.connect(analyser);
-    source.start();
-    drawOscilloscope(dataArray, visualizer, analyser);
-  };
+    source = ctx.createBufferSource()
+    source.buffer = buffer
+    source.connect(ctx.destination)
+    source.connect(analyser)
+    source.start()
+    drawOscilloscope(dataArray, visualizer, analyser)
+  }
   stopButton.onclick = () => {
     if (source !== undefined) {
-      source.stop();
+      source.stop()
     }
-  };
+  }
 
-  ret.appendChild(playButton);
-  ret.appendChild(stopButton);
-  ret.appendChild(visualizer);
-  return ret;
+  ret.appendChild(playButton)
+  ret.appendChild(stopButton)
+  ret.appendChild(visualizer)
+  return ret
 }
 
 export interface MediaElementSource extends AudioNode {
@@ -92,61 +92,61 @@ export interface MediaElementSource extends AudioNode {
 export function isMediaElementSource(
   node: AudioNode,
 ): node is MediaElementSource {
-  const maybeSource = node as unknown as Record<string, unknown>;
+  const maybeSource = node as unknown as Record<string, unknown>
   return (
     'mediaElement' in node &&
     typeof maybeSource.mediaElement === 'object' &&
     maybeSource.mediaElement !== null &&
     typeof (maybeSource.mediaElement as Record<string, unknown>).play ===
       'function'
-  );
+  )
 }
 
 export function audioPipelineRenderer(blob: AudioPipeline): HTMLElement {
-  const pipeline: AudioNode = blob.pipeline;
-  const onOffNode: GainNode = blob.onOffNode;
+  const pipeline: AudioNode = blob.pipeline
+  const onOffNode: GainNode = blob.onOffNode
 
-  const ret = document.createElement('span');
-  const playButton = document.createElement('button');
-  playButton.textContent = '▶';
-  const stopButton = document.createElement('button');
-  stopButton.textContent = '■';
+  const ret = document.createElement('span')
+  const playButton = document.createElement('button')
+  playButton.textContent = '▶'
+  const stopButton = document.createElement('button')
+  stopButton.textContent = '■'
   const startable =
     'start' in pipeline &&
     typeof (pipeline as unknown as Record<string, unknown>).start ===
-      'function';
-  const isMediaElement = isMediaElementSource(pipeline);
-  let started = false;
-  onOffNode.gain.value = 0;
+      'function'
+  const isMediaElement = isMediaElementSource(pipeline)
+  let started = false
+  onOffNode.gain.value = 0
   playButton.onclick = () => {
-    onOffNode.gain.value = 1;
+    onOffNode.gain.value = 1
     if (startable && !started) {
-      (pipeline as AudioScheduledSourceNode).start();
-      started = true;
+      (pipeline as AudioScheduledSourceNode).start()
+      started = true
     } else if (isMediaElement) {
       pipeline.mediaElement.play().catch((e: unknown) => {
-        throw e as L.ScamperError;
-      });
-      started = true;
+        throw e as L.ScamperError
+      })
+      started = true
     }
-  };
+  }
   stopButton.onclick = () => {
-    onOffNode.gain.value = 0;
+    onOffNode.gain.value = 0
     if (isMediaElement) {
-      pipeline.mediaElement.load();
-      started = false;
+      pipeline.mediaElement.load()
+      started = false
     }
-  };
-  ret.appendChild(playButton);
-  ret.appendChild(stopButton);
-  return ret;
+  }
+  ret.appendChild(playButton)
+  ret.appendChild(stopButton)
+  return ret
 }
 
 HtmlRenderer.registerCustomRenderer(
   (v) => L.isStructKind(v, 'sample'),
   (v) => sampleRenderer(v as SampleNode),
-);
+)
 HtmlRenderer.registerCustomRenderer(
   (v) => L.isStructKind(v, 'audio-pipeline'),
   (v) => audioPipelineRenderer(v as AudioPipeline),
-);
+)

--- a/src/js/audio/renderers/vue.ts
+++ b/src/js/audio/renderers/vue.ts
@@ -1,13 +1,13 @@
-import * as L from '../../../lpm';
-import VueRenderer from '../../../lpm/renderers/vue.js';
-import SampleRenderer from './SampleRenderer.vue';
-import AudioPipelineRenderer from './AudioPipelineRenderer.vue';
+import * as L from '../../../lpm'
+import VueRenderer from '../../../lpm/renderers/vue.js'
+import SampleRenderer from './SampleRenderer.vue'
+import AudioPipelineRenderer from './AudioPipelineRenderer.vue'
 
 VueRenderer.registerCustomRenderer(
   (v) => L.isStructKind(v, 'sample'),
   () => SampleRenderer,
-);
+)
 VueRenderer.registerCustomRenderer(
   (v) => L.isStructKind(v, 'audio-pipeline'),
   () => AudioPipelineRenderer,
-);
+)

--- a/src/js/image/color.ts
+++ b/src/js/image/color.ts
@@ -235,7 +235,7 @@ const namedCssColors = new Map<string, Rgb>([
   ['whitesmoke', image_rgb(245, 245, 245)],
   ['yellow', image_rgb(255, 255, 0)],
   ['yellowgreen', image_rgb(154, 205, 50)]
-]);
+])
 
 export function image_isColorName(name: string): boolean {
   return namedCssColors.has(name.toLowerCase())

--- a/src/js/image/drawing.ts
+++ b/src/js/image/drawing.ts
@@ -241,9 +241,9 @@ function getDrawingPoints (drawing: Drawing): [number, number][] {
   const points: [number, number][] = []
   switch(drawing[L.structKind]) {
     case 'ellipse':
-      const n = 100;
+      const n = 100
       for (let i = 1; i < n; i++) {
-        const t = 2 * Math.PI * i / n;
+        const t = 2 * Math.PI * i / n
         points.push([
           0.5 * drawing.width * Math.cos(t),
           0.5 * drawing.height * Math.sin(t)
@@ -756,10 +756,10 @@ export function image_clearDrawing (canvas: HTMLCanvasElement) {
 }
 
 // TODO: aria labels should be in a central location
-export const image_canvasAriaLabel = 'scamper-canvas';
+export const image_canvasAriaLabel = 'scamper-canvas'
 export function image_renderer (drawing: Drawing): HTMLElement {
   const canvas = document.createElement('canvas')
-  canvas.setAttribute('aria-label', image_canvasAriaLabel);
+  canvas.setAttribute('aria-label', image_canvasAriaLabel)
   canvas.width = Math.ceil(drawing.width)
   canvas.height = Math.ceil(drawing.height)
   image_clearDrawing(canvas)

--- a/src/js/image/renderers/html.ts
+++ b/src/js/image/renderers/html.ts
@@ -69,7 +69,7 @@ function render (rif: ReactiveImageFile): HTMLElement {
             outp.appendChild(HtmlRenderer.render(e as L.ScamperError))
           }
         }
-        img.src = e.target.result as string;
+        img.src = e.target.result as string
       }
     }
     if (inp.files !== null && inp.files.length > 0) {

--- a/src/js/rex/index.ts
+++ b/src/js/rex/index.ts
@@ -22,7 +22,7 @@ class RexEmpty implements L.Struct, Re {
   [key: number]: never;
   [key: string]: L.Value;
   [L.scamperTag] = 'struct' as const;
-  [L.structKind] = 'rex-empty';
+  [L.structKind] = 'rex-empty'
   toRegexString(): string {
     return ''
   }
@@ -32,7 +32,7 @@ class RexString implements L.Struct, Re {
   [key: number]: never;
   [key: string]: L.Value;
   [L.scamperTag] = 'struct' as const;
-  [L.structKind] = 'rex-string';
+  [L.structKind] = 'rex-string'
   value: string
   constructor (value: string) {
     this.value = value
@@ -47,7 +47,7 @@ class RexRepeat implements L.Struct, Re {
   [key: number]: never;
   [key: string]: L.Value;
   [L.scamperTag] = 'struct' as const;
-  [L.structKind] = 'rex-repeat';
+  [L.structKind] = 'rex-repeat'
   value: Re
   constructor (value: Re) {
     this.value = value
@@ -62,7 +62,7 @@ class RexRepeat0 implements L.Struct, Re {
   [key: number]: never;
   [key: string]: L.Value;
   [L.scamperTag] = 'struct' as const;
-  [L.structKind] = 'rex-repeat-0';
+  [L.structKind] = 'rex-repeat-0'
   value: Re
   constructor (value: Re) {
     this.value = value
@@ -92,7 +92,7 @@ class RexAnyChar implements L.Struct, Re {
   [key: number]: never;
   [key: string]: L.Value;
   [L.scamperTag] = 'struct' as const;
-  [L.structKind] = 'rex-any-char';
+  [L.structKind] = 'rex-any-char'
   toRegexString(): string {
     return '.'
   }

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 import * as Scheme from '../src/scheme'
 import * as LPM from '../src/lpm'
 import { Fiber } from '../src/lpm/fiber'
-import HTMLDisplay from '../src/lpm/output/html';
+import HTMLDisplay from '../src/lpm/output/html'
 
 // Runs a fiber to completion, sending displayed values/reported errors to
 // `out` and recovering from runtime errors the way the scheduler does for
@@ -54,9 +54,9 @@ export async function runProgramWithHTML (src: string, out: HTMLDisplay): Promis
 }
 
 export function scamperTest (label: string, src: string, expected: string[]) {
-  test(label, async () => { expect(await runProgram(src.trim())).toEqual(expected); })
+  test(label, async () => { expect(await runProgram(src.trim())).toEqual(expected) })
 }
 
 export function failingScamperTest (label: string, src: string, expected: string[]) {
-  test.fails(label, async () => { expect(await runProgram(src.trim())).toEqual(expected); })
+  test.fails(label, async () => { expect(await runProgram(src.trim())).toEqual(expected) })
 }

--- a/test/lpm/machine.test.ts
+++ b/test/lpm/machine.test.ts
@@ -314,14 +314,14 @@ describe('rest parameters', () => {
     const out = new LoggingChannel(false, false)
     const cls = U.mkCls(['x', 'y'], [U.mkVar('z')], 'f', undefined, 'z')
     const fiber = makeTestFiber([U.mkDisp([cls, U.mkLit(1), U.mkAp(1)])])
-    expect(() => { testExecute(fiber, out); }).toThrow(/Arity mismatch/)
+    expect(() => { testExecute(fiber, out) }).toThrow(/Arity mismatch/)
   })
 
   test('ap - arity mismatch when fewer than required args, no rest param', () => {
     const out = new LoggingChannel(false, false)
     const cls = U.mkCls(['x', 'y'], [U.mkVar('x')], 'f')
     const fiber = makeTestFiber([U.mkDisp([cls, U.mkLit(1), U.mkAp(1)])])
-    expect(() => { testExecute(fiber, out); }).toThrow(/Arity mismatch/)
+    expect(() => { testExecute(fiber, out) }).toThrow(/Arity mismatch/)
   })
 
   test('ap - arity mismatch when more args than fixed params, no rest param', () => {
@@ -330,6 +330,6 @@ describe('rest parameters', () => {
     const fiber = makeTestFiber([
       U.mkDisp([cls, U.mkLit(1), U.mkLit(2), U.mkAp(2)]),
     ])
-    expect(() => { testExecute(fiber, out); }).toThrow(/Arity mismatch/)
+    expect(() => { testExecute(fiber, out) }).toThrow(/Arity mismatch/)
   })
 })

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,9 +1,9 @@
-import * as matchers from '@testing-library/jest-dom/matchers';
-import { expect } from 'vitest';
-import 'vitest-canvas-mock';
-import { initializeLibs } from '../src/lib';
+import * as matchers from '@testing-library/jest-dom/matchers'
+import { expect } from 'vitest'
+import 'vitest-canvas-mock'
+import { initializeLibs } from '../src/lib'
 
-expect.extend(matchers);
+expect.extend(matchers)
 // N.B., only initializeLibs() here, not scamper.ts's initialize(): importing
 // scamper.ts triggers its module-load-time renderer registration (a
 // fire-and-forget `import("./app/web/renderers.js")`), and doing that from this
@@ -12,4 +12,4 @@ expect.extend(matchers);
 // dependencies (e.g. src/fs/opfs.ts) out from under tests that mock them.
 // Test files that actually need Scamper.getInstance() (or anything else
 // from scamper.ts) call its initialize() themselves, after their own mocks.
-await initializeLibs();
+await initializeLibs()


### PR DESCRIPTION
## Summary
- Add a `semi: ['warn', 'never']` ESLint rule matching the semicolon-free style already set in `.prettierrc` (`semi: false`), so lint catches drift going forward.
- Run `lint:fix` to strip unnecessary semicolons from files that had fallen out of sync (audio/rex/image JS libs, a couple of Vue/test files).

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (411 passed, 2 expected fail, 19 skipped)
- [x] `npm run lint` shows 0 errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)