### PR TITLE
Fix #252: escape backslashes and quotes in string output

### DIFF
--- a/src/lpm/renderers/html.ts
+++ b/src/lpm/renderers/html.ts
@@ -18,7 +18,7 @@ export class Renderer extends R.Renderer<HTMLElement> {
       case 'number':
         return mkCodeElement(v.toString())
       case 'string':
-        return mkCodeElement(`"${v}"`)
+        return mkCodeElement(`"${U.escapeStringLiteral(v)}"`)
       case 'undefined':
         return mkCodeElement('void')
       default:

--- a/src/lpm/renderers/text.ts
+++ b/src/lpm/renderers/text.ts
@@ -12,7 +12,7 @@ class Renderer extends R.Renderer<string> {
       switch (typeof v) {
         case 'boolean': return v ? '#t' : '#f'
         case 'number': return v.toString()
-        case 'string': return `"${v}"`
+        case 'string': return `"${U.escapeStringLiteral(v)}"`
         case 'undefined': return 'void'
         default:
           if (v === null) {

--- a/src/lpm/renderers/vue/simple-renderers.ts
+++ b/src/lpm/renderers/vue/simple-renderers.ts
@@ -1,5 +1,12 @@
 import { Char, Closure, Sym } from '../../lang'
-import { charToName, isChar, isClosure, isJsFunction, isSym } from '../../util'
+import {
+  charToName,
+  escapeStringLiteral,
+  isChar,
+  isClosure,
+  isJsFunction,
+  isSym,
+} from '../../util'
 import { createTextRenderer, Strategy, VueStrategyProps } from '../vue'
 
 export function createSimpleVueRenderer<T>(
@@ -23,7 +30,7 @@ const numberStrategy: Strategy = {
 }
 const stringStrategy: Strategy = {
   predicate: (v) => typeof v === 'string',
-  ...createSimpleVueRenderer<string>((v) => `"${v}"`),
+  ...createSimpleVueRenderer<string>((v) => `"${escapeStringLiteral(v)}"`),
 }
 const undefinedStrategy: Strategy = {
   predicate: (v) => v === undefined,

--- a/src/lpm/util.ts
+++ b/src/lpm/util.ts
@@ -282,6 +282,15 @@ export function charToName(c: string): string {
     return c
   }
 }
+
+/** @return `s` with the characters special to string-literal syntax (the
+ *  backslash and the double-quote) escaped, so that wrapping the result in
+ *  quotes yields a valid, re-readable literal. Inverse of the reader's
+ *  `parseStringLiteral`. Backslashes must be escaped first to avoid
+ *  double-escaping the backslash introduced for each quote. */
+export function escapeStringLiteral(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
 /** @return a vector (array) representation of the input list. */
 export function listToVector(l: L.List): L.Value[] {
   const ret: L.Value[] = []
@@ -404,7 +413,7 @@ export function toString(v: L.Value): string {
     case 'number':
       return v.toString()
     case 'string':
-      return `"${v}"`
+      return `"${escapeStringLiteral(v)}"`
     case 'undefined':
       return 'void'
     default:

--- a/test/regressions/literal-escape.test.ts
+++ b/test/regressions/literal-escape.test.ts
@@ -11,6 +11,6 @@ test('literal-escape', async () => {
   `)).toEqual([
     '"["',
     '"]"',
-    '"\\"'
+    '"\\\\"' // string containing a single backslash -> escaped as "\\" (see #252)
   ])
 })

--- a/test/regressions/string-output-escaping.test.ts
+++ b/test/regressions/string-output-escaping.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/252
+//
+// When a string value is displayed, characters that are special to string
+// literal syntax (the backslash and the double-quote) must be escaped so the
+// printed form is a valid, re-readable string literal.
+
+test('string-output-escaping', async () => {
+  expect(await runProgram(`
+    "a\\"b"
+    "a\\\\b"
+    "hello\\""
+  `)).toEqual([
+    '"a\\"b"',   // string  a"b  ->  "a\"b"
+    '"a\\\\b"',  // string  a\b  ->  "a\\b"
+    '"hello\\""' // string  hello"  ->  "hello\""
+  ])
+})


### PR DESCRIPTION
Fixes #252.

## Problem
String values were rendered by wrapping their raw contents in quotes, so special characters were not escaped:

- `"hello\""` (the string `hello"`) printed as `"hello""`
- a string containing a single backslash printed as `"\"`

Neither is a valid, re-readable string literal.

## Fix
Added `escapeStringLiteral` in `src/lpm/util.ts` — the inverse of the reader's `parseStringLiteral`. It escapes `\` first, then `"`, guaranteeing the printed form round-trips back through the parser.

Applied it in all four value renderers that print strings:
- `src/lpm/renderers/text.ts` (console / CLI)
- `src/lpm/renderers/html.ts` (web output)
- `src/lpm/renderers/vue/simple-renderers.ts` (Vue output)
- `src/lpm/util.ts` `toString`

Nested strings (inside lists, vectors, pairs, structs) are covered automatically since each renderer recurses back through its `string` case.

## Scope note
Only `\` and `"` are escaped — the two characters that are special to string-literal *syntax*. Whitespace characters (newline, tab) are left literal; they still round-trip correctly and render readably in a teaching context. Happy to extend to full `\n`/`\t` escaping if you'd prefer stricter `write` semantics.

## Tests
- New regression test `test/regressions/string-output-escaping.test.ts` (fails before the fix).
- Updated one assertion in the existing `test/regressions/literal-escape.test.ts`: its backslash case had frozen the old *unescaped* output (`"\"`); it now expects the correct escaped form (`"\\"`). That test came from #151, which was purely a parser bug, so the assertion was incidental.
- `npm run validate` passes (typecheck, full test suite, lint — 0 errors).