### PR TITLE
Fix hsv? binding to a predicate (Fixes #250)

### DIFF
--- a/src/lib/image.scm
+++ b/src/lib/image.scm
@@ -104,11 +104,11 @@
 ;;; @category color, image, rgb
 (define rgb->string (js-var "image_rgbToString"))
 
-;;; (hsv? . v) -> boolean?
+;;; (hsv? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a hsv value.
 ;;; @category color, image, hsv, predicates, typecheck
-(define hsv? (js-var "image_hsv"))
+(define hsv? (js-var "image_isHsv"))
 
 ;;; (hsv h s v . a) -> hsv?
 ;;;  h : number?

--- a/test/regressions/hsv-predicate.test.ts
+++ b/test/regressions/hsv-predicate.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/250
+//
+// `hsv?` was bound to the `hsv` constructor rather than an actual predicate.
+// The auto-generated contract layer invokes `hsv?` to validate every
+// parameter declared `hsv?`, so it called the constructor with a single
+// struct argument and every hsv accessor/derived function errored with
+// `(hsv?) hsv: expects 3 or 4 arguments, but got 1`.
+
+test('hsv? is a predicate and hsv-typed contracts pass', async () => {
+  expect(await runProgram(`
+  (import image)
+  (hsv? (hsv 180 50 50))
+  (hsv? 5)
+  (hsv-hue (hsv 180 50 50))
+  (hsv-saturation (hsv 180 50 50))
+  (hsv-value (hsv 180 50 50))
+  (hsv-alpha (hsv 180 50 50))
+  `)).toEqual([
+    '#t',
+    '#f',
+    '180',
+    '50',
+    '50',
+    '255',
+  ])
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

**Bug:** Every `image` function with an `hsv?`-typed parameter errored with `(hsv?) hsv: expects 3 or 4 arguments, but got 1` — including `hsv-hue`, `hsv-saturation`, `hsv-value`, `hsv-alpha`, `hsv-complement`, `hsv->string`, and `hsv?` itself.

**Root cause:** In `src/lib/image.scm`, `hsv?` was bound to `image_hsv` (the `hsv` *constructor*) rather than the `image_isHsv` predicate. The auto-generated contract layer calls `hsv?` to validate each `hsv?`-typed argument, so it invoked the constructor with the single struct argument and failed.

**Fix:** Bind `hsv? -> image_isHsv` (mirroring `rgb? -> image_isRgb`) and correct the docstring signature from the variadic `(hsv? . v)` to `(hsv? v)`.

**Regression test:** `test/regressions/hsv-predicate.test.ts` asserts `(hsv? (hsv 180 50 50))` is `#t`, `(hsv? 5)` is `#f`, and the hsv accessors return their components. Confirmed failing before the fix and passing after.

**Note (out of scope):** With the contract fixed, control now reaches the JS bodies of `hsv->rgb` and `rgb->hsv`, which fail with a separate, pre-existing bug (`colorsys.hsvToRgb is not a function` — a `colorsys` module-interop issue). This is independent of the `hsv?` binding and is not addressed here.

`npm run validate` passes (typecheck / test / lint all PASS).

Fixes #250