### PR TITLE
Fix string? contract on color-name?/find-colors/color-name->rgb

### DIFF
--- a/src/lib/image.scm
+++ b/src/lib/image.scm
@@ -81,7 +81,7 @@
 (define rgb-distance (js-var "image_rgbDistance"))
 
 ;;; (color-name? v) -> boolean?
-;;;  v : string
+;;;  v : string?
 ;;; Returns `#t` if and only if `v` is a valid color name.
 ;;; @category color, image, predicates, typecheck
 (define color-name? (js-var "image_isColorName"))
@@ -93,7 +93,7 @@
 (define all-color-names (js-var "image_allColorNames"))
 
 ;;; (find-colors color-name) -> list?
-;;;  color-name : string
+;;;  color-name : string?
 ;;; Returns a list of all color names that contain `color`, case-insensitive.
 ;;; @category image
 (define find-colors (js-var "image_findColors"))
@@ -184,7 +184,7 @@
 (define hsv->string (js-var "image_hsvToString"))
 
 ;;; (color-name->rgb color-name) -> rgb?
-;;;  color-name : string
+;;;  color-name : string?
 ;;; Returns the rgb value of the color name.
 ;;; @category color, image, rgb
 (define color-name->rgb (js-var "image_colorNameToRgb"))

--- a/test/libs/image.test.ts
+++ b/test/libs/image.test.ts
@@ -176,17 +176,55 @@ describe('color', () => {
     ])
   })
 
-  // color-name?, find-colors, and color-name->rgb all write their string
-  // parameter's contract as `string` instead of `string?` in image.scm's
-  // docstring. The generated contract check calls the real `string`
-  // (char ... -> string) constructor as a predicate; since a genuine string
-  // argument is never a char, that check's own rest-parameter contract
-  // fails for every call, regardless of input, so none of these three can
-  // succeed right now.
-  describe('blocked by a docstring contract typo (string instead of string?)', () => {
-    test.skip('color-name?')
-    test.skip('find-colors')
-    test.skip('color-name->rgb')
+  // https://github.com/slag-plt/scamper/issues/251
+  // color-name?, find-colors, and color-name->rgb declared their string
+  // parameter's contract as `string` instead of `string?`. Fixed in image.scm
+  // so the contract layer treats it as the `string?` predicate.
+  test('color-name?', async () => {
+    expect(
+      await runProgram(`
+(import image)
+(color-name? "red")
+(color-name? "RED")
+(color-name? "not-a-real-color")
+(color-name? 5)
+`),
+    ).toEqual([
+      '#t',
+      '#t',
+      '#f',
+      'Runtime error [87:1-87:49]: (error) expected a string, received number',
+    ])
+  })
+
+  test('find-colors', async () => {
+    expect(
+      await runProgram(`
+(import image)
+(find-colors "red")
+(find-colors "zzz-no-match")
+(find-colors 5)
+`),
+    ).toEqual([
+      '(list "darkred" "indianred" "mediumvioletred" "orangered" "palevioletred" "red")',
+      'null',
+      'Runtime error [99:1-99:48]: (error) expected a string, received number',
+    ])
+  })
+
+  test('color-name->rgb', async () => {
+    expect(
+      await runProgram(`
+(import image)
+(color-name->rgb "red")
+(color-name->rgb "not-a-color")
+(color-name->rgb 5)
+`),
+    ).toEqual([
+      '(rgba 255 0 0 255)',
+      'Runtime error [3:1-3:31]: (color-name->rgb) color-name->rgb: unknown color name not-a-color',
+      'Runtime error [190:1-190:56]: (error) expected a string, received number',
+    ])
   })
 
   test('all-color-names', async () => {

--- a/test/regressions/color-name-string-contract.test.ts
+++ b/test/regressions/color-name-string-contract.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/251
+//
+// `color-name?`, `find-colors`, and `color-name->rgb` declared their string
+// parameter's contract as bare `string` instead of the predicate `string?`.
+// The auto-generated contract layer invokes the annotation as a predicate, so
+// it called the real `string` (char ... -> string) constructor; a genuine
+// string argument is never a char, so that constructor's own contract failed
+// on every call and all three functions errored unconditionally.
+
+test('color-name?/find-colors/color-name->rgb accept string arguments', async () => {
+  expect(await runProgram(`
+  (import image)
+  (color-name? "red")
+  (color-name? "not-a-real-color")
+  (rgb-red (color-name->rgb "red"))
+  (rgb-green (color-name->rgb "red"))
+  (rgb-blue (color-name->rgb "red"))
+  (list? (find-colors "red"))
+  (>= (index-of (find-colors "red") "red") 0)
+  `)).toEqual([
+    '#t',
+    '#f',
+    '255',
+    '0',
+    '0',
+    '#t',
+    '#t',
+  ])
+})
+
+// With the contract now correctly `string?`, passing a non-string is a
+// contract violation (an error), not a `#f` result -- confirming the
+// annotation is enforced as a predicate rather than ignored.
+test('color-name? rejects a non-string argument via its contract', async () => {
+  const out = await runProgram(`
+  (import image)
+  (color-name? 5)
+  `)
+  expect(out).toHaveLength(1)
+  expect(out[0]).toContain('expected a string, received number')
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

**Bug:** `color-name?`, `find-colors`, and `color-name->rgb` in `src/lib/image.scm` errored on every call, regardless of input — e.g. `(color-name? "red")` raised `Runtime error: expected every value of c1 to be a char, but at least one was not` instead of returning `#t`.

**Root cause:** All three declared their string parameter's contract as bare `string` instead of the predicate `string?`. The auto-generated contract layer invokes the annotation as a predicate, so it called the real `string` (`char ... -> string`) constructor; a genuine string argument is never a char, so that constructor's own rest-parameter contract failed unconditionally. (The other 31 string params in the file correctly use `string?`; only these 3 were wrong.)

**Fix:** Changed the three annotations from `string` to `string?`.

**Tests:**
- Added `test/regressions/color-name-string-contract.test.ts` asserting the three functions accept strings (`(color-name? "red")` → `#t`, `(color-name->rgb "red")` → rgb 255/0/0, `find-colors` returns a list containing `"red"`) and that the now-enforced contract rejects a non-string argument.
- Un-skipped and implemented the three previously `test.skip`ped cases in `test/libs/image.test.ts`.

Regression test confirmed failing before the fix and passing after. `npm run validate` passes (typecheck / test / lint, 0 errors).

Fixes #251