### PR TITLE
Fix text-area crash: new HTMLTextAreaElement() is an illegal constructor

### DIFF
--- a/src/js/html/index.ts
+++ b/src/js/html/index.ts
@@ -13,7 +13,7 @@ export function html_buttonQ(v: any): boolean {
 }
 
 export function html_textArea(id: string): HTMLTextAreaElement {
-  const ret = new HTMLTextAreaElement()
+  const ret = document.createElement('textarea')
   ret.id = id
   return ret
 }

--- a/test/libs/html.test.ts
+++ b/test/libs/html.test.ts
@@ -40,10 +40,8 @@ describe('element?', () => {
 })
 
 describe('text-area?', () => {
-  // N.B., positive case can't go through the Scamper-level `text-area`
-  // here -- see the `text-area` describe block below.
-  test('is true for an HTMLTextAreaElement', () => {
-    expect(html_textAreaQ(document.createElement('textarea'))).toBe(true)
+  test('is true for a value made by text-area', () => {
+    expect(html_textAreaQ(html_textArea('my-id'))).toBe(true)
   })
 
   test('is false for non-text-area values', () => {
@@ -55,13 +53,12 @@ describe('text-area?', () => {
 })
 
 describe('text-area', () => {
-  // html_textArea builds its result via `new HTMLTextAreaElement()`, unlike
-  // html_tag/html_button which correctly use document.createElement. The
-  // HTMLConstructor behavior throws "Illegal constructor" in every environment
-  // (real browsers and jsdom alike), so text-area is broken everywhere, not
-  // just here -- github.com/slag-plt/scamper#260.
-  test('always throws -- new HTMLTextAreaElement() is illegal (see #260)', () => {
-    expect(() => html_textArea('my-id')).toThrow()
+  test('creates a text-area element with the given id', () => {
+    const ta = html_textArea('my-id')
+    expect(html_isElement(ta)).toBe(true)
+    expect(html_textAreaQ(ta)).toBe(true)
+    expect(ta.tagName).toBe('TEXTAREA')
+    expect(ta.id).toBe('my-id')
   })
 })
 

--- a/test/regressions/html-text-area-constructor.test.ts
+++ b/test/regressions/html-text-area-constructor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+import {
+  html_isElement,
+  html_textArea,
+  html_textAreaQ,
+} from '../../src/js/html/index.js'
+
+// https://github.com/slag-plt/scamper/issues/260
+// html_textArea built its result via `new HTMLTextAreaElement()`, an illegal
+// constructor (HTML element interfaces carry [HTMLConstructor] and throw
+// outside custom-element upgrade) in every environment, jsdom included. The
+// fix uses document.createElement('textarea'), matching sibling html_tag /
+// html_button.
+describe('#260: text-area constructor', () => {
+  test('html_textArea builds a text-area element without throwing', () => {
+    const ta = html_textArea('my-id')
+    expect(html_isElement(ta)).toBe(true)
+    expect(html_textAreaQ(ta)).toBe(true)
+    expect(ta.tagName).toBe('TEXTAREA')
+    expect(ta.id).toBe('my-id')
+  })
+
+  test('(text-area id) runs without a runtime error', async () => {
+    const out = await runProgram(`
+    (import html)
+    (text-area? (text-area "my-id"))
+    `)
+    expect(out).toEqual(['#t'])
+  })
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

## Bug
Calling `(text-area "id")` (stdlib `text-area`, bound to `html_textArea`) crashed with `TypeError: Illegal constructor` in every environment, so the function was non-functional everywhere.

## Root cause
`src/js/html/index.ts` built its result via `new HTMLTextAreaElement()`. HTML element interfaces carry `[HTMLConstructor]` behavior and throw unless invoked during custom-element upgrade — this holds in real browsers (Chrome/Firefox/Safari) and in jsdom. The sibling `html_tag` / `html_button` correctly use `document.createElement(...)`.

## Fix
- Replace `new HTMLTextAreaElement()` with `document.createElement('textarea')`, matching the siblings. One-line change.
- Correct the stale `text-area` tests in `test/libs/html.test.ts`, which previously asserted the crash as expected behavior and mislabeled it as a jsdom-only limitation.

## Regression test
Added `test/regressions/html-text-area-constructor.test.ts` (standard Vitest/jsdom tier — this path does not need the browser tier). It confirms `html_textArea` builds a real `TEXTAREA` element and that `(text-area? (text-area "my-id"))` runs to `#t` with no runtime error. Verified failing before the fix, passing after.

## Validation
`npm run validate` passes: typecheck PASS, test PASS, lint PASS (0 errors; pre-existing warnings only).

## Scope
Grepped for the same illegal `new HTML*Element()` pattern across `src/`; the text-area site was the only occurrence. No out-of-scope siblings found.

Fixes #260
