### PR TITLE
Fix string->lines docstring contract to match implementation (#249)

### DIFF
--- a/src/lib/data.scm
+++ b/src/lib/data.scm
@@ -10,9 +10,9 @@
 ;;; @category data
 (define string->chars (js-var "data_stringToChars"))
 
-;;; (string->lines chars) -> list?
-;;;  chars : list?
-;;; Splits the string `s` into a list of strings, where each string is a line of text..
+;;; (string->lines s) -> list?
+;;;  s : string?
+;;; Splits the string `s` into a list of strings, where each string is a line of text.
 ;;; @category data
 (define string->lines (js-var "data_stringToLines"))
 

--- a/test/libs/data.test.ts
+++ b/test/libs/data.test.ts
@@ -71,24 +71,25 @@ describe('string->chars', () => {
 })
 
 describe('string->lines', () => {
-  // The docstring declares this parameter as `list?`, but data_stringToLines
-  // (src/js/data/utils.ts) implements it as a plain string split -- so no
-  // call currently succeeds. These tests document that mismatch.
-  test('a string argument violates the documented list? contract', async () => {
+  // Regression for #249: the docstring declared the parameter as `list?`, but
+  // data_stringToLines (src/js/data/utils.ts) splits a plain string -- so no
+  // call could satisfy both the contract and the implementation. The docstring
+  // now correctly declares `s : string?`.
+  test('splits a string into a list of lines', async () => {
     expect(await runProgram(`
     (import data)
     (string->lines "a\nb\nc")
     `)).toEqual([
-      'Runtime error [17:1-17:52]: (error) expected a list, received string'
+      '(list "a" "b" "c")'
     ])
   })
 
-  test('a list argument satisfies the contract but not the implementation', async () => {
+  test('a list argument violates the string? contract', async () => {
     expect(await runProgram(`
     (import data)
     (string->lines (list "a" "b"))
     `)).toEqual([
-      'Runtime error [17:1-17:52]: Unexpected error in Javascript function call: TypeError: s.split is not a function'
+      'Runtime error [17:1-17:52]: (error) expected a string, received list'
     ])
   })
 })


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

**Mismatch:** `string->lines` in `src/lib/data.scm` declared its parameter as `chars : list?`, but the implementation `data_stringToLines` (`src/js/data/utils.ts`) splits a plain string on newlines. Runtime contract checks are generated from the docstring, so no call could succeed: a string argument failed the `list?` contract, while a list argument passed the contract but crashed the JS (`s.split is not a function`). The function was effectively uncallable.

**Fix (docstring side):** aligned the docstring to the implementation — parameter is now `s : string?`, matching the function name, its description ("Splits the string `s`..."), the sibling `string->chars` (`s : string?`), and the JS signature `data_stringToLines(s: string)`. Also removed a stray double-period.

**Regression test:** updated the `string->lines` block in `test/libs/data.test.ts` (which previously documented the bug) to assert correct behavior — `(string->lines "a\nb\nc")` returns `(list "a" "b" "c")`; a list argument now reports `expected a string, received list`. Both cases fail before the fix and pass after.

Validation (`npm run validate`): typecheck PASS, test PASS, lint PASS (0 errors).

Fixes #249
