### PR TITLE
Fix string->number leaking internal JS error on non-numerals (#255)

### DIFF
--- a/src/js/prelude/index.ts
+++ b/src/js/prelude/index.ts
@@ -196,13 +196,14 @@ export function prelude_numberToString(x: number): string {
 //   (string->number s)
 //   (string->number s radix)
 
-export function prelude_stringToNumber(s: string): number {
+export function prelude_stringToNumber(s: string): number | boolean {
+  // N.B., per R7RS, return #f when the string does not denote a number.
   if (/^[+-]?\d+$/.test(s)) {
     return parseInt(s)
   } else if (/^[+-]?(\d+|(\d*\.\d+)|(\d+\.\d*))([eE][+-]?\d+)?$/.test(s)) {
     return parseFloat(s)
   } else {
-    throw new Error(`Runtime error: string->number: invalid string: ${s}`)
+    return false
   }
 }
 

--- a/src/lib/prelude.scm
+++ b/src/lib/prelude.scm
@@ -214,8 +214,8 @@
 
 ;;; (string->number s) -> number?
 ;;;  s : string?
-;;;   presumed to be a number
-;;; Returns the number denoted by `s` as a `number`.
+;;; Returns the number denoted by `s`, or `#f` if `s`
+;;; does not denote a number.
 ;;; @category string
 (define string->number (js-var "prelude_stringToNumber"))
 

--- a/test/libs/prelude.test.ts
+++ b/test/libs/prelude.test.ts
@@ -2936,13 +2936,9 @@ test('random-wrong-type', async () => {
 // Non-callback logic & error branches
 
 test('string->number-invalid', async () => {
-  // BUG (#255): a non-numeral string makes string->number throw a bare JS
-  // Error, so the op-handler double-wraps it into this confusing internal
-  // message (R7RS says it should just return #f). Range points at the
-  // definition site (#254). Both pinned as current behavior.
-  expect(await runProgram('(string->number "abc")')).toEqual([
-    'Runtime error [220:1-220:57]: Unexpected error in Javascript function call: Error: Runtime error: string->number: invalid string: abc',
-  ])
+  // Fixed (#255): a non-numeral string returns #f (per R7RS) rather than
+  // leaking a double-wrapped internal JS exception.
+  expect(await runProgram('(string->number "abc")')).toEqual(['#f'])
 })
 
 test('char-compare-single-arg', async () => {

--- a/test/regressions/string-to-number-invalid.test.ts
+++ b/test/regressions/string-to-number-invalid.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/255
+//
+// `string->number` threw a bare JS `Error` for non-numeral input instead of a
+// `ScamperError`, so the LPM op-handler treated it as an unexpected JS
+// exception and double-wrapped it into a confusing internal message
+// ("Unexpected error in Javascript function call: ..."). Per R7RS,
+// `string->number` returns `#f` when the string does not denote a number.
+
+test('string->number returns #f on non-numeral input', async () => {
+  expect(await runProgram(`
+  (string->number "abc")
+  (string->number "")
+  (string->number "12x")
+  (string->number "  5  ")
+  (string->number "1.2.3")
+  `)).toEqual([
+    '#f',
+    '#f',
+    '#f',
+    '#f',
+    '#f',
+  ])
+})
+
+test('string->number still parses valid numerals', async () => {
+  expect(await runProgram(`
+  (string->number "9")
+  (string->number "-3.14")
+  (string->number "+42")
+  (string->number "100")
+  (string->number "0.4472135954999579")
+  (string->number "1e3")
+  `)).toEqual([
+    '9',
+    '-3.14',
+    '42',
+    '100',
+    '0.4472135954999579',
+    '1000',
+  ])
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

**Bug:** `(string->number "abc")` surfaced a confusing internal message: `Runtime error [...]: Unexpected error in Javascript function call: Error: Runtime error: string->number: invalid string: abc`.

**Root cause:** `prelude_stringToNumber` (`src/js/prelude/index.ts`) threw a bare JS `Error` for non-numeral input. Because it was a plain `Error` and not a `ScamperError`, the LPM op-handler treated it as an unexpected JS exception and double-wrapped it.

**Fix:** Per R7RS, `string->number` returns `#f` when the string does not denote a number. The function now returns `false` (rendered as `#f`) instead of throwing. Also updated the docstring to document the `#f`-on-failure behavior.

**Edge cases covered:** non-numeral (`"abc"`), empty string (`""`), partial numeral (`"12x"`), surrounding whitespace (`"  5  "`, not trimmed per R7RS), malformed (`"1.2.3"`). Valid numerals (integers, floats, signed, scientific notation) still parse correctly.

**Regression test:** `test/regressions/string-to-number-invalid.test.ts` (`string->number returns #f on non-numeral input` and `string->number still parses valid numerals`). Also updated the pinned assertion in `test/libs/prelude.test.ts` (`string->number-invalid`) to the corrected behavior. `npm run validate` passes (typecheck, test, lint; 0 errors).

Fixes #255