### PR TITLE
Add pair? contract to car/cdr and the c[ad]+r family (#256)

### DIFF
--- a/src/js/prelude/index.ts
+++ b/src/js/prelude/index.ts
@@ -334,20 +334,32 @@ export function prelude_pair(x: any, y: any): L.Value {
   return L.mkPair(x, y)
 }
 
+// N.B., car/cdr accept a pair or a non-empty list (cons). The empty list
+// (null) and every other non-pair are rejected with a contract error rather
+// than leaking a raw JS TypeError or silently returning void (#256). The
+// c[ad]+r family below composes from these, so it inherits the check.
+function isConsOrPair(x: L.Value): boolean {
+  return L.isPair(x) || (L.isList(x) && x !== null)
+}
+
 export function prelude_car(x: L.Value): L.Value {
-  if (L.isPair(x)) {
-    return (x as any).fst
-  } else {
-    return (x as any).head
+  if (!isConsOrPair(x)) {
+    throw new L.ScamperError(
+      'Runtime',
+      `expected a pair or nonempty list, received ${L.typeOf(x)}`,
+    )
   }
+  return L.isPair(x) ? (x as any).fst : (x as any).head
 }
 
 export function prelude_cdr(x: L.Value): L.Value {
-  if (L.isPair(x)) {
-    return (x as any).snd
-  } else {
-    return (x as any).tail
+  if (!isConsOrPair(x)) {
+    throw new L.ScamperError(
+      'Runtime',
+      `expected a pair or nonempty list, received ${L.typeOf(x)}`,
+    )
   }
+  return L.isPair(x) ? (x as any).snd : (x as any).tail
 }
 
 const listAccessors = [

--- a/test/libs/prelude.test.ts
+++ b/test/libs/prelude.test.ts
@@ -2153,191 +2153,42 @@ test('=-eps', async () => {
 ////////////////////////////////////////////////////////////////////////////////
 // Pairs & List Accessors (car/cdr family)
 
-describe('list accessors (c[ad]+r family) - shallow-list failures', () => {
-  // N.B., these accessors' docstrings declare `v : any`, so there is no real
-  // contract check -- a non-pair like a number silently returns void instead
-  // of erroring, and the empty list leaks a raw JS TypeError (#256). Only
-  // running past the end of the list actually throws, and the reported range
-  // points at the accessor's own definition in prelude.scm rather than the
-  // call site (#254), same as not-boolean/cons-pair above.
+describe('list accessors (c[ad]+r family) - non-pair contract failures', () => {
+  // car/cdr (and so the whole composed c[ad]+r family) now reject anything
+  // that is neither a pair nor a non-empty list with a proper contract error
+  // (#256), instead of leaking a raw JS TypeError on the empty list or
+  // silently returning void on other non-pairs. Each accessor is composed from
+  // car/cdr, so it inherits the check and reports its own name at the actual
+  // call site.
 
-  test('car', async () => {
-    expect(await runProgram('(car (list))')).toEqual([
-      "Runtime error [371:1-371:35]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
+  const accessors = [
+    'car', 'cdr',
+    'caar', 'cadr', 'cdar', 'cddr',
+    'caaar', 'cadar', 'cdaar', 'cddar', 'caadr', 'caddr', 'cdadr', 'cdddr',
+    'caaaar', 'cadaar', 'cdaaar', 'cddaar', 'caadar', 'caddar', 'cdadar',
+    'cdddar', 'caaadr', 'cadadr', 'cdaadr', 'cddadr', 'caaddr', 'cadddr',
+    'cdaddr', 'cddddr',
+  ]
 
-  test('cdr', async () => {
-    expect(await runProgram('(cdr (list))')).toEqual([
-      "Runtime error [378:1-378:35]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
+  // `(<name> (list))` spans from column 1 to column name.length + 9
+  // ("(" + name + " " + "(list)" + ")").
+  const endCol = (name: string): string => (name.length + 9).toString()
 
-  test('caar', async () => {
-    expect(await runProgram('(caar (list))')).toEqual([
-      "Runtime error [969:1-969:37]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
+  for (const name of accessors) {
+    test(`${name} on the empty list`, async () => {
+      expect(await runProgram(`(${name} (list))`)).toEqual([
+        `Runtime error [1:1-1:${endCol(name)}]: (${name}) expected a pair or nonempty list, received null`,
+      ])
+    })
+  }
 
-  test('cadr', async () => {
-    expect(await runProgram('(cadr (list))')).toEqual([
-      "Runtime error [976:1-976:37]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cdar', async () => {
-    expect(await runProgram('(cdar (list))')).toEqual([
-      "Runtime error [983:1-983:37]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cddr', async () => {
-    expect(await runProgram('(cddr (list))')).toEqual([
-      "Runtime error [990:1-990:37]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('caaar', async () => {
-    expect(await runProgram('(caaar (list))')).toEqual([
-      "Runtime error [997:1-997:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cadar', async () => {
-    expect(await runProgram('(cadar (list))')).toEqual([
-      "Runtime error [1004:1-1004:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cdaar', async () => {
-    expect(await runProgram('(cdaar (list))')).toEqual([
-      "Runtime error [1011:1-1011:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cddar', async () => {
-    expect(await runProgram('(cddar (list))')).toEqual([
-      "Runtime error [1018:1-1018:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('caadr', async () => {
-    expect(await runProgram('(caadr (list))')).toEqual([
-      "Runtime error [1025:1-1025:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('caddr', async () => {
-    expect(await runProgram('(caddr (list))')).toEqual([
-      "Runtime error [1032:1-1032:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cdadr', async () => {
-    expect(await runProgram('(cdadr (list))')).toEqual([
-      "Runtime error [1039:1-1039:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cdddr', async () => {
-    expect(await runProgram('(cdddr (list))')).toEqual([
-      "Runtime error [1046:1-1046:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('caaaar', async () => {
-    expect(await runProgram('(caaaar (list))')).toEqual([
-      "Runtime error [1053:1-1053:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cadaar', async () => {
-    expect(await runProgram('(cadaar (list))')).toEqual([
-      "Runtime error [1060:1-1060:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cdaaar', async () => {
-    expect(await runProgram('(cdaaar (list))')).toEqual([
-      "Runtime error [1067:1-1067:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cddaar', async () => {
-    expect(await runProgram('(cddaar (list))')).toEqual([
-      "Runtime error [1074:1-1074:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('caadar', async () => {
-    expect(await runProgram('(caadar (list))')).toEqual([
-      "Runtime error [1081:1-1081:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('caddar', async () => {
-    expect(await runProgram('(caddar (list))')).toEqual([
-      "Runtime error [1088:1-1088:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cdadar', async () => {
-    expect(await runProgram('(cdadar (list))')).toEqual([
-      "Runtime error [1095:1-1095:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cdddar', async () => {
-    expect(await runProgram('(cdddar (list))')).toEqual([
-      "Runtime error [1102:1-1102:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('caaadr', async () => {
-    expect(await runProgram('(caaadr (list))')).toEqual([
-      "Runtime error [1109:1-1109:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cadadr', async () => {
-    expect(await runProgram('(cadadr (list))')).toEqual([
-      "Runtime error [1116:1-1116:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cdaadr', async () => {
-    expect(await runProgram('(cdaadr (list))')).toEqual([
-      "Runtime error [1123:1-1123:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cddadr', async () => {
-    expect(await runProgram('(cddadr (list))')).toEqual([
-      "Runtime error [1130:1-1130:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('caaddr', async () => {
-    expect(await runProgram('(caaddr (list))')).toEqual([
-      "Runtime error [1137:1-1137:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cadddr', async () => {
-    expect(await runProgram('(cadddr (list))')).toEqual([
-      "Runtime error [1144:1-1144:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cdaddr', async () => {
-    expect(await runProgram('(cdaddr (list))')).toEqual([
-      "Runtime error [1151:1-1151:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cddddr', async () => {
-    expect(await runProgram('(cddddr (list))')).toEqual([
-      "Runtime error [1158:1-1158:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
+  test('car/cdr on a non-pair report the value type, not void', async () => {
+    expect(await runProgram(`
+(car 5)
+(cdr "x")
+`)).toEqual([
+      'Runtime error [1:1-1:7]: (car) expected a pair or nonempty list, received number',
+      'Runtime error [2:1-2:9]: (cdr) expected a pair or nonempty list, received string',
     ])
   })
 })

--- a/test/regressions/car-cdr-pair-contract.test.ts
+++ b/test/regressions/car-cdr-pair-contract.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/256
+//
+// `car`/`cdr` (and so the whole composed c[ad]+r family) performed no contract
+// check: on the empty list they read `.head`/`.tail` of `null` and leaked a
+// raw JS TypeError, and on any other non-pair they read `undefined` and
+// silently returned void. They now reject anything that is neither a pair nor a
+// non-empty list with a proper Scamper contract error; the family inherits the
+// check since each accessor is composed from car/cdr, so each reports its own
+// name at the actual call site.
+
+test('car/cdr error on the empty list instead of leaking a JS TypeError', async () => {
+  expect(await runProgram(`
+  (car (list))
+  (cdr (list))
+  `)).toEqual([
+    'Runtime error [1:1-1:12]: (car) expected a pair or nonempty list, received null',
+    'Runtime error [2:3-2:14]: (cdr) expected a pair or nonempty list, received null',
+  ])
+})
+
+test('car/cdr error on a non-pair instead of returning void', async () => {
+  expect(await runProgram(`
+  (car 5)
+  (cdr 5)
+  `)).toEqual([
+    'Runtime error [1:1-1:7]: (car) expected a pair or nonempty list, received number',
+    'Runtime error [2:3-2:9]: (cdr) expected a pair or nonempty list, received number',
+  ])
+})
+
+test('the c[ad]+r family inherits the contract on the empty list', async () => {
+  const out = await runProgram(`
+  (cadr (list))
+  (cddr (list))
+  (caddr (list))
+  `)
+  expect(out).toHaveLength(3)
+  expect(out[0]).toContain('(cadr) expected a pair or nonempty list, received null')
+  expect(out[1]).toContain('(cddr) expected a pair or nonempty list, received null')
+  expect(out[2]).toContain('(caddr) expected a pair or nonempty list, received null')
+})
+
+test('the c[ad]+r family inherits the contract on a non-pair', async () => {
+  const out = await runProgram(`
+  (cadr 5)
+  (cddr 5)
+  (caddr 5)
+  `)
+  expect(out).toHaveLength(3)
+  expect(out[0]).toContain('(cadr) expected a pair or nonempty list, received number')
+  expect(out[1]).toContain('(cddr) expected a pair or nonempty list, received number')
+  expect(out[2]).toContain('(caddr) expected a pair or nonempty list, received number')
+})
+
+test('valid car/cdr and family uses still work on pairs and non-empty lists', async () => {
+  expect(await runProgram(`
+  (car (list 1 2))
+  (cdr (list 1 2))
+  (cadr (list 1 2))
+  (caddr (list 1 2 3))
+  (car (pair 1 2))
+  (cdr (pair 1 2))
+  `)).toEqual([
+    '1',
+    '(list 2)',
+    '2',
+    '3',
+    '1',
+    '2',
+  ])
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

`car`/`cdr` performed no contract check. On the empty list they read `.head`/`.tail` of `null` and leaked a raw JS `TypeError` (`Unexpected error in Javascript function call: ...`); on any other non-pair they read `undefined` and silently returned `void`. The whole composed `c[ad]+r` family inherited both bugs.

**Root cause:** `prelude_car`/`prelude_cdr` (src/js/prelude/index.ts) destructured their argument with no guard, and the docstrings declared `v : any`, so nothing enforced the intended contract.

**Fix:** Guard `prelude_car`/`prelude_cdr` with `isConsOrPair` (a pair, or a non-empty list/cons) and raise a proper `ScamperError` otherwise: `expected a pair or nonempty list, received <type>`. Valid inputs (pairs and non-empty lists) are unchanged. Every `c[ad]+r` accessor composes from `car`/`cdr`, so the whole family inherits the check automatically -- and because each accessor is its own named JS function, the error reports that accessor's own name at the actual call site (e.g. `(cadr) expected a pair or nonempty list, received null`).

**Note on the predicate:** this codebase (Clojure-style) lets `car`/`cdr` operate on both pairs and non-empty lists (`cons`), and `(list 1 2)` is a `cons`, not a `pair?` -- so a literal `pair?` contract would have wrongly rejected valid list usage. The guard accepts pair-or-nonempty-list and rejects only the empty list and true non-pairs.

**Tests:**
- Added regression suite `test/regressions/car-cdr-pair-contract.test.ts` covering `car`/`cdr` on `'()` and on non-pairs, family members (`cadr`, `cddr`, `caddr`), and valid uses (`(car (list 1 2))` -> `1`, etc.). Confirmed the error cases fail before the fix and pass after.
- Flipped the existing bug-documenting block in `test/libs/prelude.test.ts` (formerly `- shallow-list failures`, which asserted the raw JS TypeError) to `- non-pair contract failures`, now asserting the clean contract error for the whole family plus non-pair type reporting.

`npm run validate` passes (typecheck / test / lint, 0 errors, no new warnings).

Fixes #256