### PR TITLE
Give car/cdr an (or/p pair? nonempty-list?) contract (#256)

### DIFF
--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -13,14 +13,13 @@ import * as Runtime from './runtime/index.js'
 import * as Test from './test/index.js'
 
 // N.B., prelude/index.ts groups a handful of dynamically-named functions
-// (list accessors, char/string comparators) into plain records -- keyed by
-// their already-prefixed binding names -- rather than individual named
-// exports, since JS modules can't declare a dynamic number of top-level
-// bindings. The container records themselves (prelude_listAccessorFns, etc.)
-// aren't bindings anyone should look up, so they're excluded below in favor
-// of their flattened contents.
+// (char/string comparators) into plain records -- keyed by their
+// already-prefixed binding names -- rather than individual named exports,
+// since JS modules can't declare a dynamic number of top-level bindings. The
+// container records themselves (prelude_charCompareFns, etc.) aren't bindings
+// anyone should look up, so they're excluded below in favor of their
+// flattened contents.
 const {
-  prelude_listAccessorFns,
   prelude_charCompareFns,
   prelude_charPredicateFns,
   prelude_stringCompareFns,
@@ -44,7 +43,6 @@ const internals = new Map<string, L.Value>([
   ...Object.entries(Lab),
   ...Object.entries(Music),
   ...Object.entries(preludeBindings),
-  ...Object.entries(prelude_listAccessorFns),
   ...Object.entries(prelude_charCompareFns),
   ...Object.entries(prelude_charPredicateFns),
   ...Object.entries(prelude_stringCompareFns),

--- a/src/js/prelude/index.ts
+++ b/src/js/prelude/index.ts
@@ -350,56 +350,13 @@ export function prelude_cdr(x: L.Value): L.Value {
   }
 }
 
-const listAccessors = [
-  // 4-character accessors
-  'caar',
-  'cadr',
-  'cdar',
-  'cddr',
-  // 5-character accessors
-  'caaar',
-  'cadar',
-  'cdaar',
-  'cddar',
-  'caadr',
-  'caddr',
-  'cdadr',
-  'cdddr',
-  // 6-character accessors
-  'caaaar',
-  'cadaar',
-  'cdaaar',
-  'cddaar',
-  'caadar',
-  'caddar',
-  'cdadar',
-  'cdddar',
-  'caaadr',
-  'cadadr',
-  'cdaadr',
-  'cddadr',
-  'caaddr',
-  'cadddr',
-  'cdaddr',
-  'cddddr',
-]
-export const prelude_listAccessorFns: Record<string, (x: L.Value) => L.Value> = {}
-listAccessors.forEach((name) => {
-  const path = name.slice(1, name.length - 1)
-  const fn = function (x: L.Value): L.Value {
-    let ret = path.endsWith('a') ? prelude_car(x) : prelude_cdr(x)
-    for (let i = path.length - 2; i >= 0; i--) {
-      ret = path[i] === 'a' ? prelude_car(ret) : prelude_cdr(ret)
-    }
-    return ret
-  }
-  prelude_listAccessorFns[`prelude_${name}`] = fn
-})
+// N.B., the c[ad]+r accessor family (caar, cadr, ..., cddddr) is defined in
+// prelude.scm as ordinary Scheme compositions over car/cdr, so it inherits
+// their (or/p pair? nonempty-list?) contract checks rather than leaking a raw
+// JS TypeError on a bad argument.
 
 // N.B., set-car! and set-cdr! are unimplemented since we only implement the
 // pure, functional subset of Scheme.
-
-// TODO: implement caar, cadr, cdar, cddr, caaar, ..., cdddr in some elegant way
 
 export function prelude_nullQ(x: any): boolean {
   return x === null
@@ -407,6 +364,10 @@ export function prelude_nullQ(x: any): boolean {
 
 export function prelude_listQ(x: any): boolean {
   return L.isList(x)
+}
+
+export function prelude_nonemptyListQ(x: L.Value): boolean {
+  return prelude_listQ(x) && x !== null
 }
 
 export function prelude_list(...xs: L.Value[]): L.List {

--- a/src/lib/prelude.scm
+++ b/src/lib/prelude.scm
@@ -363,16 +363,40 @@
 ;;; @category list, list creation
 (define pair (js-var "prelude_pair"))
 
+;; N.B., left undocumented, like all-satisfy?: it's contract-support
+;; infrastructure (or/p's fold over its predicates), not a user-facing
+;; binding. Documenting it would make contract.ts wrap it in a checking
+;; lambda whose own checks call all-satisfy? -> car/cdr -> back into the
+;; contracted car/cdr, so it MUST stay undocumented to avoid that cycle.
+;; Uses match (not car/cdr) to walk the list for the same reason: match
+;; decomposes via the runtime's pMatch, so it never reaches contracted car/cdr.
+(define some-satisfy?
+  (lambda (pred? lst)
+    (match lst
+      [null #f]
+      [(cons x rest) (if (pred? x) #t (some-satisfy? pred? rest))])))
+
+;; N.B., or/p combines predicates disjunctively: (or/p p q) is a predicate
+;; that holds when p OR q holds. Written in plain Scamper (not a js-var) so
+;; that applying each predicate is ordinary Scamper application -- JS code can
+;; no longer call back into Scamper (Closure.call/callScamperFn are disabled).
+;; Left UNDOCUMENTED for the same reason as some-satisfy?: a docstring would
+;; make contract.ts wrap it, and that wrapper's checks would recurse through
+;; car/cdr into or/p (which car/cdr's own contract references), re-creating the
+;; cycle. Requires at least one predicate: the arglist grammar has no
+;; zero-fixed-param rest form, and or/p over no predicates is never needed.
+(define or/p
+  (lambda (first . rest)
+    (lambda (x) (some-satisfy? (lambda (p) (p x)) (cons first rest)))))
+
 ;;; (car v) -> any
-;;;  v : any
-;;;   pair? or list?
+;;;  v : (or/p pair? nonempty-list?)
 ;;; Returns the first element of `v`.
 ;;; @category list, list manipulation, association list
 (define car (js-var "prelude_car"))
 
 ;;; (cdr v) -> any
-;;;  v : any
-;;;   pair? or list?
+;;;  v : (or/p pair? nonempty-list?)
 ;;; Returns the second element of `v`.
 ;;; @category list, list manipulation, association list
 (define cdr (js-var "prelude_cdr"))
@@ -388,6 +412,12 @@
 ;;; Returns `#t` if and only `v` is a list.
 ;;; @category list, association list, typecheck, predicates
 (define list? (js-var "prelude_listQ"))
+
+;;; (nonempty-list? v) -> boolean?
+;;;  v : any
+;;; Returns `#t` if and only if `v` is a non-empty list.
+;;; @category typecheck, predicates
+(define nonempty-list? (js-var "prelude_nonemptyListQ"))
 
 ;;; (list . v1) -> list?
 ;;;  v1 : any
@@ -963,199 +993,171 @@
 
 ;;; (caar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (car v))`.
 ;;; @category list, list manipulation, association list
-(define caar (js-var "prelude_caar"))
+(define caar (lambda (v) (car (car v))))
 
 ;;; (cadr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (cdr v))`.
 ;;; @category list, list manipulation, association list
-(define cadr (js-var "prelude_cadr"))
+(define cadr (lambda (v) (car (cdr v))))
 
 ;;; (cdar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (car v))`.
 ;;; @category list, list manipulation, association list
-(define cdar (js-var "prelude_cdar"))
+(define cdar (lambda (v) (cdr (car v))))
 
 ;;; (cddr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (cdr v))`.
 ;;; @category list, list manipulation, association list
-(define cddr (js-var "prelude_cddr"))
+(define cddr (lambda (v) (cdr (cdr v))))
 
 ;;; (caaar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (car (car v)))`.
 ;;; @category list, list manipulation, association list
-(define caaar (js-var "prelude_caaar"))
+(define caaar (lambda (v) (car (car (car v)))))
 
 ;;; (cadar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (cdr (car v)))`.
 ;;; @category list, list manipulation, association list
-(define cadar (js-var "prelude_cadar"))
+(define cadar (lambda (v) (car (cdr (car v)))))
 
 ;;; (cdaar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (car (car v)))`.
 ;;; @category list, list manipulation, association list
-(define cdaar (js-var "prelude_cdaar"))
+(define cdaar (lambda (v) (cdr (car (car v)))))
 
 ;;; (cddar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (cdr (car v)))`.
 ;;; @category list, list manipulation, association list
-(define cddar (js-var "prelude_cddar"))
+(define cddar (lambda (v) (cdr (cdr (car v)))))
 
 ;;; (caadr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (car (cdr v)))`.
 ;;; @category list, list manipulation, association list
-(define caadr (js-var "prelude_caadr"))
+(define caadr (lambda (v) (car (car (cdr v)))))
 
 ;;; (caddr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (cdr (cdr v)))`.
 ;;; @category list, list manipulation, association list
-(define caddr (js-var "prelude_caddr"))
+(define caddr (lambda (v) (car (cdr (cdr v)))))
 
 ;;; (cdadr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (car (cdr v)))`.
 ;;; @category list, list manipulation, association list
-(define cdadr (js-var "prelude_cdadr"))
+(define cdadr (lambda (v) (cdr (car (cdr v)))))
 
 ;;; (cdddr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (cdr (cdr v)))`.
 ;;; @category list, list manipulation, association list
-(define cdddr (js-var "prelude_cdddr"))
+(define cdddr (lambda (v) (cdr (cdr (cdr v)))))
 
 ;;; (caaaar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (car (car (car v))))`.
 ;;; @category list, list manipulation, association list
-(define caaaar (js-var "prelude_caaaar"))
+(define caaaar (lambda (v) (car (car (car (car v))))))
 
 ;;; (cadaar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (cdr (car (car v))))`.
 ;;; @category list, list manipulation, association list
-(define cadaar (js-var "prelude_cadaar"))
+(define cadaar (lambda (v) (car (cdr (car (car v))))))
 
 ;;; (cdaaar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (car (car (car v))))`.
 ;;; @category list, list manipulation, association list
-(define cdaaar (js-var "prelude_cdaaar"))
+(define cdaaar (lambda (v) (cdr (car (car (car v))))))
 
 ;;; (cddaar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (cdr (car (car v))))`.
 ;;; @category list, list manipulation, association list
-(define cddaar (js-var "prelude_cddaar"))
+(define cddaar (lambda (v) (cdr (cdr (car (car v))))))
 
 ;;; (caadar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (car (cdr (car v))))`.
 ;;; @category list, list manipulation, association list
-(define caadar (js-var "prelude_caadar"))
+(define caadar (lambda (v) (car (car (cdr (car v))))))
 
 ;;; (caddar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (cdr (cdr (car v))))`.
 ;;; @category list, list manipulation, association list
-(define caddar (js-var "prelude_caddar"))
+(define caddar (lambda (v) (car (cdr (cdr (car v))))))
 
 ;;; (cdadar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (car (cdr (car v))))`.
 ;;; @category list, list manipulation, association list
-(define cdadar (js-var "prelude_cdadar"))
+(define cdadar (lambda (v) (cdr (car (cdr (car v))))))
 
 ;;; (cdddar v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (cdr (cdr (car v))))`.
 ;;; @category list, list manipulation, association list
-(define cdddar (js-var "prelude_cdddar"))
+(define cdddar (lambda (v) (cdr (cdr (cdr (car v))))))
 
 ;;; (caaadr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (car (car (cdr v))))`.
 ;;; @category list, list manipulation, association list
-(define caaadr (js-var "prelude_caaadr"))
+(define caaadr (lambda (v) (car (car (car (cdr v))))))
 
 ;;; (cadadr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (cdr (car (cdr v))))`.
 ;;; @category list, list manipulation, association list
-(define cadadr (js-var "prelude_cadadr"))
+(define cadadr (lambda (v) (car (cdr (car (cdr v))))))
 
 ;;; (cdaadr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (car (car (cdr v))))`.
 ;;; @category list, list manipulation, association list
-(define cdaadr (js-var "prelude_cdaadr"))
+(define cdaadr (lambda (v) (cdr (car (car (cdr v))))))
 
 ;;; (cddadr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (cdr (car (cdr v))))`.
 ;;; @category list, list manipulation, association list
-(define cddadr (js-var "prelude_cddadr"))
+(define cddadr (lambda (v) (cdr (cdr (car (cdr v))))))
 
 ;;; (caaddr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (car (cdr (cdr v))))`.
 ;;; @category list, list manipulation, association list
-(define caaddr (js-var "prelude_caaddr"))
+(define caaddr (lambda (v) (car (car (cdr (cdr v))))))
 
 ;;; (cadddr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(car (cdr (cdr (cdr v))))`.
 ;;; @category list, list manipulation, association list
-(define cadddr (js-var "prelude_cadddr"))
+(define cadddr (lambda (v) (car (cdr (cdr (cdr v))))))
 
 ;;; (cdaddr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (car (cdr (cdr v))))`.
 ;;; @category list, list manipulation, association list
-(define cdaddr (js-var "prelude_cdaddr"))
+(define cdaddr (lambda (v) (cdr (car (cdr (cdr v))))))
 
 ;;; (cddddr v) -> any
 ;;;  v : any
-;;;   pair? or list?
 ;;; Equivalent to `(cdr (cdr (cdr (cdr v))))`.
 ;;; @category list, list manipulation, association list
-(define cddddr (js-var "prelude_cddddr"))
+(define cddddr (lambda (v) (cdr (cdr (cdr (cdr v))))))
 
 ;;; (char=? . c1) -> boolean?
 ;;;  c1 : char?

--- a/src/scheme/contract.ts
+++ b/src/scheme/contract.ts
@@ -14,16 +14,39 @@ import { Param } from './docstring/param.js'
 const contractTargetName = '##contract-target##'
 
 /**
+ * The bare name of a simple `var` predicate with any trailing `?` stripped,
+ * e.g. `pair?` ~> "pair", `nonempty-list?` ~> "nonempty-list". Used to render
+ * the disjuncts of an `(or/p ...)` predicate without an article.
+ */
+function predBareName(pred: A.Var): string {
+  return pred.name.endsWith('?') ? pred.name.slice(0, -1) : pred.name
+}
+
+/**
  * A short, human-readable description of a predicate, suitable for embedding
  * in an "expected ..." contract violation message, e.g. `number?` ~> `a
- * number`, `integer?` ~> `an integer`. Complex predicates (`(list-of
- * number?)`) don't reduce to a single word, so they're rendered as-is.
+ * number`, `integer?` ~> `an integer`. An `(or/p p1 ... pk)` predicate over
+ * simple `var` disjuncts renders as `p1, ..., or pk` (Oxford join, no
+ * leading article), e.g. `(or/p pair? nonempty-list?)` ~> "pair or
+ * nonempty-list". Other complex predicates (`(list-of number?)`) don't reduce
+ * to a single word, so they're rendered as-is.
  */
 function describePred(pred: Pred): string {
   if (pred.tag !== 'var') {
+    const args = pred.args
+    if (pred.head.name === 'or/p' && args.length > 0 && args.every(A.isVar)) {
+      const names = args.map(predBareName)
+      if (names.length === 1) {
+        return names[0]
+      }
+      if (names.length === 2) {
+        return `${names[0]} or ${names[1]}`
+      }
+      return `${names.slice(0, -1).join(', ')}, or ${names[names.length - 1]}`
+    }
     return `a value matching \`${A.expToString(pred)}\``
   }
-  const name = pred.name.endsWith('?') ? pred.name.slice(0, -1) : pred.name
+  const name = predBareName(pred)
   const article = /^[aeiou]/i.test(name) ? 'an' : 'a'
   return `${article} ${name}`
 }

--- a/test/libs/prelude.test.ts
+++ b/test/libs/prelude.test.ts
@@ -2153,191 +2153,25 @@ test('=-eps', async () => {
 ////////////////////////////////////////////////////////////////////////////////
 // Pairs & List Accessors (car/cdr family)
 
-describe('list accessors (c[ad]+r family) - shallow-list failures', () => {
-  // N.B., these accessors' docstrings declare `v : any`, so there is no real
-  // contract check -- a non-pair like a number silently returns void instead
-  // of erroring, and the empty list leaks a raw JS TypeError (#256). Only
-  // running past the end of the list actually throws, and the reported range
-  // points at the accessor's own definition in prelude.scm rather than the
-  // call site (#254), same as not-boolean/cons-pair above.
+describe('list accessors (c[ad]+r family) - empty-list failures', () => {
+  // N.B., car/cdr now carry an `(or/p pair? nonempty-list?)` contract, and the
+  // whole c[ad]+r family is defined as Scheme compositions over them, so every
+  // member rejects the empty list with the same clean contract error (#256)
+  // instead of leaking a raw JS TypeError. The innermost (rightmost) accessor
+  // letter decides which primitive first sees null: `a` -> car, `d` -> cdr.
+  // The reported range points at that primitive's definition in prelude.scm.
+  const stripRange = (msgs: string[]): string[] =>
+    msgs.map((m) => m.replace(/\[\d+:\d+-\d+:\d+\]/, '[..]'))
+  const members = [
+    'car', 'cdr', 'caar', 'cadr', 'cdar', 'cddr', 'caaar', 'cadar', 'cdaar',
+    'cddar', 'caadr', 'caddr', 'cdadr', 'cdddr', 'caaaar', 'cadaar', 'cdaaar',
+    'cddaar', 'caadar', 'caddar', 'cdadar', 'cdddar', 'caaadr', 'cadadr',
+    'cdaadr', 'cddadr', 'caaddr', 'cadddr', 'cdaddr', 'cddddr',
+  ]
 
-  test('car', async () => {
-    expect(await runProgram('(car (list))')).toEqual([
-      "Runtime error [371:1-371:35]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cdr', async () => {
-    expect(await runProgram('(cdr (list))')).toEqual([
-      "Runtime error [378:1-378:35]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('caar', async () => {
-    expect(await runProgram('(caar (list))')).toEqual([
-      "Runtime error [969:1-969:37]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cadr', async () => {
-    expect(await runProgram('(cadr (list))')).toEqual([
-      "Runtime error [976:1-976:37]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cdar', async () => {
-    expect(await runProgram('(cdar (list))')).toEqual([
-      "Runtime error [983:1-983:37]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cddr', async () => {
-    expect(await runProgram('(cddr (list))')).toEqual([
-      "Runtime error [990:1-990:37]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('caaar', async () => {
-    expect(await runProgram('(caaar (list))')).toEqual([
-      "Runtime error [997:1-997:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cadar', async () => {
-    expect(await runProgram('(cadar (list))')).toEqual([
-      "Runtime error [1004:1-1004:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cdaar', async () => {
-    expect(await runProgram('(cdaar (list))')).toEqual([
-      "Runtime error [1011:1-1011:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cddar', async () => {
-    expect(await runProgram('(cddar (list))')).toEqual([
-      "Runtime error [1018:1-1018:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('caadr', async () => {
-    expect(await runProgram('(caadr (list))')).toEqual([
-      "Runtime error [1025:1-1025:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('caddr', async () => {
-    expect(await runProgram('(caddr (list))')).toEqual([
-      "Runtime error [1032:1-1032:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cdadr', async () => {
-    expect(await runProgram('(cdadr (list))')).toEqual([
-      "Runtime error [1039:1-1039:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cdddr', async () => {
-    expect(await runProgram('(cdddr (list))')).toEqual([
-      "Runtime error [1046:1-1046:39]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('caaaar', async () => {
-    expect(await runProgram('(caaaar (list))')).toEqual([
-      "Runtime error [1053:1-1053:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cadaar', async () => {
-    expect(await runProgram('(cadaar (list))')).toEqual([
-      "Runtime error [1060:1-1060:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cdaaar', async () => {
-    expect(await runProgram('(cdaaar (list))')).toEqual([
-      "Runtime error [1067:1-1067:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cddaar', async () => {
-    expect(await runProgram('(cddaar (list))')).toEqual([
-      "Runtime error [1074:1-1074:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('caadar', async () => {
-    expect(await runProgram('(caadar (list))')).toEqual([
-      "Runtime error [1081:1-1081:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('caddar', async () => {
-    expect(await runProgram('(caddar (list))')).toEqual([
-      "Runtime error [1088:1-1088:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cdadar', async () => {
-    expect(await runProgram('(cdadar (list))')).toEqual([
-      "Runtime error [1095:1-1095:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('cdddar', async () => {
-    expect(await runProgram('(cdddar (list))')).toEqual([
-      "Runtime error [1102:1-1102:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'head')",
-    ])
-  })
-
-  test('caaadr', async () => {
-    expect(await runProgram('(caaadr (list))')).toEqual([
-      "Runtime error [1109:1-1109:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cadadr', async () => {
-    expect(await runProgram('(cadadr (list))')).toEqual([
-      "Runtime error [1116:1-1116:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cdaadr', async () => {
-    expect(await runProgram('(cdaadr (list))')).toEqual([
-      "Runtime error [1123:1-1123:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cddadr', async () => {
-    expect(await runProgram('(cddadr (list))')).toEqual([
-      "Runtime error [1130:1-1130:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('caaddr', async () => {
-    expect(await runProgram('(caaddr (list))')).toEqual([
-      "Runtime error [1137:1-1137:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cadddr', async () => {
-    expect(await runProgram('(cadddr (list))')).toEqual([
-      "Runtime error [1144:1-1144:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cdaddr', async () => {
-    expect(await runProgram('(cdaddr (list))')).toEqual([
-      "Runtime error [1151:1-1151:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
-    ])
-  })
-
-  test('cddddr', async () => {
-    expect(await runProgram('(cddddr (list))')).toEqual([
-      "Runtime error [1158:1-1158:41]: Unexpected error in Javascript function call: TypeError: Cannot read properties of null (reading 'tail')",
+  test.each(members)('%s rejects the empty list', async (name) => {
+    expect(stripRange(await runProgram(`(${name} (list))`))).toEqual([
+      'Runtime error [..]: (error) expected pair or nonempty-list, received null',
     ])
   })
 })
@@ -2436,8 +2270,8 @@ test('sort-contract', async () => {
 (sort (list 1 2) 5)
 `),
   ).toEqual([
-    'Runtime error [493:1-493:37]: (error) expected a list, received number',
-    'Runtime error [493:1-493:37]: (error) expected a procedure, received number',
+    'Runtime error [523:1-523:37]: (error) expected a list, received number',
+    'Runtime error [523:1-523:37]: (error) expected a procedure, received number',
   ])
 })
 
@@ -2564,7 +2398,7 @@ test('string-constructor', async () => {
 `),
   ).toEqual([
     '"abc"',
-    'Runtime error [554:1-554:41]: (error) expected every value of c1 to be a char, but at least one was not',
+    'Runtime error [584:1-584:41]: (error) expected every value of c1 to be a char, but at least one was not',
   ])
 })
 
@@ -2579,8 +2413,8 @@ test('string-vector-conversions', async () => {
   ).toEqual([
     '(vector #\\a #\\b #\\c)',
     '"abc"',
-    'Runtime error [617:1-617:57]: (error) expected a string, received number',
-    'Runtime error [623:1-623:57]: (error) expected a vector, received string',
+    'Runtime error [647:1-647:57]: (error) expected a string, received number',
+    'Runtime error [653:1-653:57]: (error) expected a vector, received string',
   ])
 })
 
@@ -2596,7 +2430,7 @@ test('string-contains', async () => {
     '#t',
     '#f',
     '#t',
-    'Runtime error [630:1-630:58]: (error) expected a string, received number',
+    'Runtime error [660:1-660:58]: (error) expected a string, received number',
   ])
 })
 
@@ -2608,7 +2442,7 @@ test('string-split-vector', async () => {
 `),
   ).toEqual([
     '(vector "a" "b" "c")',
-    'Runtime error [644:1-644:65]: (error) expected a string, received number',
+    'Runtime error [674:1-674:65]: (error) expected a string, received number',
   ])
 })
 
@@ -2668,7 +2502,7 @@ test('make-vector', async () => {
     '(vector "a" "a" "a")',
     '(vector)',
     '(vector #t #t #t #t #t)',
-    'Runtime error [663:1-663:50]: (error) expected an integer, received string',
+    'Runtime error [693:1-693:50]: (error) expected an integer, received string',
   ])
 })
 
@@ -2683,7 +2517,7 @@ test('vector-length', async () => {
   ).toEqual([
     '3',
     '0',
-    'Runtime error [669:1-669:54]: (error) expected a vector, received number',
+    'Runtime error [699:1-699:54]: (error) expected a vector, received number',
   ])
 })
 
@@ -2701,7 +2535,7 @@ test('vector-ref', async () => {
   ).toEqual([
     '1',
     '3',
-    'Runtime error [677:1-677:48]: (error) expected a vector, received number',
+    'Runtime error [707:1-707:48]: (error) expected a vector, received number',
     'void',
     'void',
   ])
@@ -2717,7 +2551,7 @@ test('vector-append', async () => {
 `),
   ).toEqual([
     '(vector 1 2 3 4 5)',
-    'Runtime error [722:1-722:54]: (error) expected every value of v1 to be a vector, but at least one was not',
+    'Runtime error [752:1-752:54]: (error) expected every value of v1 to be a vector, but at least one was not',
     '(vector)',
   ])
 })
@@ -2733,7 +2567,7 @@ test('vector-to-list', async () => {
   ).toEqual([
     '(list 1 2 3)',
     'null',
-    'Runtime error [699:1-699:53]: (error) expected a vector, received list',
+    'Runtime error [729:1-729:53]: (error) expected a vector, received list',
   ])
 })
 
@@ -2748,7 +2582,7 @@ test('list-to-vector', async () => {
   ).toEqual([
     '(vector 1 2 3)',
     '(vector)',
-    'Runtime error [705:1-705:53]: (error) expected a list, received vector',
+    'Runtime error [735:1-735:53]: (error) expected a list, received vector',
   ])
 })
 
@@ -2837,7 +2671,7 @@ test('string-to-words', async () => {
     '(list "Hello" "world" "How" "are" "you")',
     'null',
     '(list "...")',
-    'Runtime error [899:1-899:55]: (error) expected a string, received number',
+    'Runtime error [929:1-929:55]: (error) expected a string, received number',
   ])
 })
 
@@ -2865,8 +2699,8 @@ r
     '10',
     'Runtime error [8:1-8:5]: Arity mismatch in function call: expected 1 arguments, got 0',
     'Runtime error [9:1-9:6]: Arity mismatch in function call: expected 1 arguments, got 0',
-    'Runtime error [917:1-917:39]: (error) expected a ref, received number',
-    'Runtime error [924:1-924:43]: (error) expected a ref, received number',
+    'Runtime error [947:1-947:39]: (error) expected a ref, received number',
+    'Runtime error [954:1-954:43]: (error) expected a ref, received number',
   ])
 })
 
@@ -2906,7 +2740,7 @@ test('with-file', async () => {
 `),
   ).toEqual([
     '(reactive-file "foo.txt" [Function: ##anonymous##])',
-    'Runtime error [956:1-956:46]: (error) expected a string, received number',
+    'Runtime error [986:1-986:46]: (error) expected a string, received number',
   ])
 })
 
@@ -2918,7 +2752,7 @@ test('with-file-chooser', async () => {
 `),
   ).toEqual([
     '(reactive-file-chooser [Function: ##anonymous##])',
-    'Runtime error [962:1-962:61]: (error) expected a procedure, received number',
+    'Runtime error [992:1-992:61]: (error) expected a procedure, received number',
   ])
 })
 
@@ -2928,7 +2762,7 @@ test('random-wrong-type', async () => {
 (random "a")
 `),
   ).toEqual([
-    'Runtime error [870:1-870:41]: (error) expected an integer, received string',
+    'Runtime error [900:1-900:41]: (error) expected an integer, received string',
   ])
 })
 

--- a/test/regressions/car-cdr-contract.test.ts
+++ b/test/regressions/car-cdr-contract.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/256
+//
+// `car`/`cdr` (and the whole `c[ad]+r` family, `caar`..`cddddr`) had a `v :
+// any` contract, so calling them on the empty list leaked a raw JS
+// `TypeError` and calling them on a non-pair (e.g. a number) silently
+// returned void. The fix gives `car`/`cdr` an `(or/p pair? nonempty-list?)`
+// contract and rebuilds the family as Scheme compositions over them, so every
+// bad argument now surfaces a clean, uniform contract error.
+//
+// Ranges are stripped from error messages here: they point at car/cdr's
+// definition in prelude.scm and would shift with any edit to that file.
+
+const stripRange = (msgs: string[]): string[] =>
+  msgs.map((m) => m.replace(/\[\d+:\d+-\d+:\d+\]/, '[..]'))
+
+describe('car/cdr reject non-pairs cleanly (#256)', () => {
+  test('empty list', async () => {
+    expect(stripRange(await runProgram(`
+    (car (list))
+    (cdr (list))
+    `))).toEqual([
+      'Runtime error [..]: (error) expected pair or nonempty-list, received null',
+      'Runtime error [..]: (error) expected pair or nonempty-list, received null',
+    ])
+  })
+
+  test('non-list value', async () => {
+    expect(stripRange(await runProgram(`
+    (car 5)
+    (cdr "hi")
+    (car #t)
+    `))).toEqual([
+      'Runtime error [..]: (error) expected pair or nonempty-list, received number',
+      'Runtime error [..]: (error) expected pair or nonempty-list, received string',
+      'Runtime error [..]: (error) expected pair or nonempty-list, received boolean',
+    ])
+  })
+})
+
+describe('c[ad]+r family reject bad arguments cleanly (#256)', () => {
+  test('empty list', async () => {
+    expect(stripRange(await runProgram(`
+    (cadr (list))
+    (caddr (list))
+    (cddr (list))
+    `))).toEqual([
+      'Runtime error [..]: (error) expected pair or nonempty-list, received null',
+      'Runtime error [..]: (error) expected pair or nonempty-list, received null',
+      'Runtime error [..]: (error) expected pair or nonempty-list, received null',
+    ])
+  })
+
+  test('list too short', async () => {
+    expect(stripRange(await runProgram(`
+    (cadr (list 1))
+    (caddr (list 1 2))
+    `))).toEqual([
+      'Runtime error [..]: (error) expected pair or nonempty-list, received null',
+      'Runtime error [..]: (error) expected pair or nonempty-list, received null',
+    ])
+  })
+
+  test('non-list value', async () => {
+    expect(stripRange(await runProgram('(cadr 5)'))).toEqual([
+      'Runtime error [..]: (error) expected pair or nonempty-list, received number',
+    ])
+  })
+})
+
+describe('car/cdr/family still return correct results (#256)', () => {
+  test('valid car/cdr on lists and pairs', async () => {
+    expect(await runProgram(`
+    (car (list 1 2 3))
+    (cdr (list 1 2 3))
+    (car (pair 1 2))
+    (cdr (pair 1 2))
+    `)).toEqual([
+      '1',
+      '(list 2 3)',
+      '1',
+      '2',
+    ])
+  })
+
+  test('valid family accessors', async () => {
+    expect(await runProgram(`
+    (cadr (list 1 2 3))
+    (caddr (list 1 2 3))
+    (cddr (list 1 2 3))
+    (caar (list (list 1 2) 3))
+    `)).toEqual([
+      '2',
+      '3',
+      '(list 3)',
+      '1',
+    ])
+  })
+})
+
+describe('nonempty-list? and or/p (#256)', () => {
+  test('nonempty-list?', async () => {
+    expect(await runProgram(`
+    (nonempty-list? (list 1 2))
+    (nonempty-list? (list))
+    (nonempty-list? 5)
+    (nonempty-list? (pair 1 2))
+    `)).toEqual([
+      '#t',
+      '#f',
+      '#f',
+      '#f',
+    ])
+  })
+
+  test('or/p combines predicates disjunctively', async () => {
+    expect(await runProgram(`
+    ((or/p pair? nonempty-list?) (list 1 2))
+    ((or/p pair? nonempty-list?) (pair 1 2))
+    ((or/p pair? nonempty-list?) (list))
+    ((or/p pair? nonempty-list?) 5)
+    `)).toEqual([
+      '#t',
+      '#t',
+      '#f',
+      '#f',
+    ])
+  })
+
+  test('or/p renders in contract messages without an article', async () => {
+    // Only library exports are contracted, so car/cdr's own `(or/p pair?
+    // nonempty-list?)` contract is what exercises describePred's or/p case:
+    // the message reads "pair or nonempty-list", not "a value matching ...".
+    expect(stripRange(await runProgram('(car 5)'))).toEqual([
+      'Runtime error [..]: (error) expected pair or nonempty-list, received number',
+    ])
+  })
+})

--- a/test/scheme/codegen.test.ts
+++ b/test/scheme/codegen.test.ts
@@ -186,7 +186,7 @@ describe('End-to-end cases', () => {
 
 (+ 1 2 3 "bye")
 `, [
-      'Runtime error [560:1-560:54]: (error) expected a string, received list',
+      'Runtime error [590:1-590:54]: (error) expected a string, received list',
       // N.B., "+" is documented as a rest param (`. v1`), so its contract
       // check is a single all-satisfy? over the whole argument list rather
       // than a per-argument check -- it can report that *some* argument


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

## The bug (#256)

`(car '())` / `(cdr '())` leaked a raw JS `TypeError` ("Cannot read properties of null"), and `car`/`cdr` plus the whole `c[ad]+r` family (`caar`..`cddddr`) silently returned void on non-pairs (e.g. numbers). Their docstrings declared `v : any`, so no contract check ran.

## The design (declarative)

- **`nonempty-list?`** (`prelude_nonemptyListQ`): a new documented predicate. Since `pair?` matches only the pair struct and `(list? '())` is `#t`, car/cdr's valid domain is "pair OR non-empty list", and `'()` must be rejected. `nonempty-list?` makes that domain expressible.
- **`or/p` in pure Scheme** (undocumented, match-based): a variadic predicate combinator, `(or/p p q)` holds when `p` or `q` holds, built on a small `some-satisfy?` helper. It is written in plain Scamper (not a `js-var`) because JS can no longer call back into Scamper (`callScamperFn` is disabled), so applying each predicate must be ordinary Scamper application. `some-satisfy?` walks its list with `match` (which decomposes via the runtime's `pMatch`), **not** car/cdr.
- **Why `or/p` and `some-satisfy?` are undocumented:** they are contract-support infrastructure, exactly like the existing `all-satisfy?`. Documenting either would make `contractStmt` wrap it in a checking lambda whose own checks call `all-satisfy?` -> car/cdr -> back into `or/p` (which car/cdr's contract references), recreating a compile/runtime cycle. Keeping them undocumented guarantees no wrapping. A follow-up could add a `contractStmt` skip-list to make `or/p` user-facing.
- **`describePred` rendering** (`contract.ts`): an `(or/p ...)` predicate over simple `var` disjuncts renders with no leading article and an Oxford join -- `A or B` for two, `A, B, or C` for three-plus -- so the message reads `expected pair or nonempty-list, received null`.
- **car/cdr contract**: `v : any` -> `v : (or/p pair? nonempty-list?)`. The raw `prelude_car`/`prelude_cdr` are left guard-free.
- **Family recompose**: each `c[ad]+r` is now an ordinary Scheme composition over the *contracted* car/cdr (e.g. `(define cadr (lambda (v) (car (cdr v))))`), so it inherits their contract instead of leaking a TypeError. The dead JS generator (`listAccessors`, `prelude_listAccessorFns`, and its wiring in `src/js/index.ts`) is removed.

## Verification

- `(car (list 1 2))` -> `1` (no recursion cycle -- walking the list with `match` avoids re-entering contracted car/cdr).
- `(car '())` -> `Runtime error: (error) expected pair or nonempty-list, received null`.
- `(cadr (list 1))` (too short), `(cadr 5)` (non-list), `(car 5)` -> clean contract errors; `(cadr (list 1 2))` -> `2`, `(caddr (list 1 2 3))` -> `3`.

## Tests

- New `test/regressions/car-cdr-contract.test.ts`: empty-list / too-short / non-list failures for car/cdr and the family, valid results, and `nonempty-list?` / `or/p` behavior (failing-before, passing-after).
- Flipped the `test/libs/prelude.test.ts` family block that asserted the old raw-`TypeError` behavior to the new clean contract error.
- Bumped line-number ranges in contract-error assertions (`prelude.test.ts`, `codegen.test.ts`) that shifted because the new definitions moved later lines down; messages are unchanged.

`npm run validate` -> typecheck: PASS, test: PASS, lint: PASS (0 errors; pre-existing warnings only).

Fixes #256
