### PR TITLE
Add bounds checking to vector-ref and vector-set! (#257)

### DIFF
--- a/src/js/prelude/index.ts
+++ b/src/js/prelude/index.ts
@@ -842,10 +842,22 @@ export function prelude_vectorLength(v: L.Value[]): number {
 }
 
 export function prelude_vectorRef(v: L.Value[], i: number): L.Value {
+  if (i < 0 || i >= v.length) {
+    throw new L.ScamperError(
+      'Runtime',
+      `vector-ref: index ${i} out of bounds of vector`,
+    )
+  }
   return v[i]
 }
 
 export function prelude_vectorSet(v: L.Value[], i: number, x: L.Value): void {
+  if (i < 0 || i >= v.length) {
+    throw new L.ScamperError(
+      'Runtime',
+      `vector-set!: index ${i} out of bounds of vector`,
+    )
+  }
   v[i] = x
 }
 

--- a/test/libs/prelude.test.ts
+++ b/test/libs/prelude.test.ts
@@ -2522,8 +2522,10 @@ test('vector-length', async () => {
 })
 
 test('vector-ref', async () => {
-  // N.B., contract error location points at the definition site, not the call site (#254)
-  // BUG (#257): vector-ref performs no bounds checking, so an out-of-range index silently returns void
+  // N.B., the contract (type) error points at the definition site, not the
+  // call site (#254); the #257 bounds errors, thrown from the function body,
+  // point at the call site.
+  // #257: an out-of-range index (>= length or negative) now raises a clean bounds error
   expect(
     await runProgram(`
 (vector-ref (vector 1 2 3) 0)
@@ -2536,8 +2538,8 @@ test('vector-ref', async () => {
     '1',
     '3',
     'Runtime error [707:1-707:48]: (error) expected a vector, received number',
-    'void',
-    'void',
+    'Runtime error [4:1-4:29]: (vector-ref) vector-ref: index 5 out of bounds of vector',
+    'Runtime error [5:1-5:30]: (vector-ref) vector-ref: index -1 out of bounds of vector',
   ])
 })
 
@@ -2587,8 +2589,9 @@ test('list-to-vector', async () => {
 })
 
 test('vector-set-out-of-range', async () => {
-  // BUG (#257): vector-set! performs no bounds checking: a too-large index
-  // grows the vector with holes, a negative index is silently a no-op
+  // #257: an out-of-range index (>= length or negative) now raises a clean
+  // bounds error and leaves the vector unchanged, rather than growing it with
+  // holes (too-large index) or silently no-op'ing (negative index).
   expect(
     await runProgram(`
 (define v (vector 1 2 3))
@@ -2600,10 +2603,10 @@ v
 v2
 `),
   ).toEqual([
-    'void',
-    '(vector 1 2 3   10)',
-    '6',
-    'void',
+    'Runtime error [2:1-2:20]: (vector-set!) vector-set!: index 5 out of bounds of vector',
+    '(vector 1 2 3)',
+    '3',
+    'Runtime error [6:1-6:22]: (vector-set!) vector-set!: index -1 out of bounds of vector',
     '(vector 1 2 3)',
   ])
 })

--- a/test/regressions/vector-bounds.test.ts
+++ b/test/regressions/vector-bounds.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/257
+//
+// `vector-ref` did `return v[i]` and `vector-set!` did `v[i] = x` with no
+// bounds check. An out-of-range `vector-ref` silently returned void; an
+// out-of-range `vector-set!` either grew the vector with holes (index >=
+// length) or silently no-op'd (negative index). Both now raise a clean
+// bounds error mirroring `list-ref`'s "index N out of bounds of list".
+// Non-integer indices were, and remain, caught by the `integer?` docstring
+// contract.
+//
+// Ranges are stripped from error messages here: they point at vector-ref /
+// vector-set!'s definitions in prelude.scm and would shift with any edit to
+// that file.
+
+const stripRange = (msgs: string[]): string[] =>
+  msgs.map((m) => m.replace(/\[\d+:\d+-\d+:\d+\]/, '[..]'))
+
+describe('vector-ref rejects out-of-bounds indices cleanly (#257)', () => {
+  test('index == length', async () => {
+    expect(stripRange(await runProgram('(vector-ref (vector 1 2 3) 3)'))).toEqual([
+      'Runtime error [..]: (vector-ref) vector-ref: index 3 out of bounds of vector',
+    ])
+  })
+
+  test('index > length', async () => {
+    expect(stripRange(await runProgram('(vector-ref (vector 1 2 3) 5)'))).toEqual([
+      'Runtime error [..]: (vector-ref) vector-ref: index 5 out of bounds of vector',
+    ])
+  })
+
+  test('negative index', async () => {
+    expect(stripRange(await runProgram('(vector-ref (vector 1 2 3) -1)'))).toEqual([
+      'Runtime error [..]: (vector-ref) vector-ref: index -1 out of bounds of vector',
+    ])
+  })
+
+  test('empty vector', async () => {
+    expect(stripRange(await runProgram('(vector-ref (vector) 0)'))).toEqual([
+      'Runtime error [..]: (vector-ref) vector-ref: index 0 out of bounds of vector',
+    ])
+  })
+
+  test('non-integer index still caught by the integer? contract', async () => {
+    expect(stripRange(await runProgram('(vector-ref (vector 1 2 3) 1.5)'))).toEqual([
+      'Runtime error [..]: (error) expected an integer, received number',
+    ])
+  })
+
+  test('valid in-range access still works', async () => {
+    expect(await runProgram(`
+    (vector-ref (vector 1 2 3) 0)
+    (vector-ref (vector 1 2 3) 2)
+    `)).toEqual([
+      '1',
+      '3',
+    ])
+  })
+})
+
+describe('vector-set! rejects out-of-bounds indices cleanly (#257)', () => {
+  test('index == length does not grow the vector', async () => {
+    expect(stripRange(await runProgram(`
+    (define v (vector 1 2 3))
+    (vector-set! v 3 99)
+    v
+    (vector-length v)
+    `))).toEqual([
+      'Runtime error [..]: (vector-set!) vector-set!: index 3 out of bounds of vector',
+      '(vector 1 2 3)',
+      '3',
+    ])
+  })
+
+  test('index > length does not create holes', async () => {
+    expect(stripRange(await runProgram(`
+    (define v (vector 1 2 3))
+    (vector-set! v 5 99)
+    v
+    (vector-length v)
+    `))).toEqual([
+      'Runtime error [..]: (vector-set!) vector-set!: index 5 out of bounds of vector',
+      '(vector 1 2 3)',
+      '3',
+    ])
+  })
+
+  test('negative index is no longer a silent no-op', async () => {
+    expect(stripRange(await runProgram(`
+    (define v (vector 1 2 3))
+    (vector-set! v -1 99)
+    v
+    `))).toEqual([
+      'Runtime error [..]: (vector-set!) vector-set!: index -1 out of bounds of vector',
+      '(vector 1 2 3)',
+    ])
+  })
+
+  test('valid in-range mutation is reflected by a subsequent ref', async () => {
+    expect(await runProgram(`
+    (define v (vector 1 2 3))
+    (vector-set! v 1 99)
+    v
+    (vector-ref v 1)
+    `)).toEqual([
+      'void',
+      '(vector 1 99 3)',
+      '99',
+    ])
+  })
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

## The bug

`prelude_vectorRef` was `return v[i]` and `prelude_vectorSet` was `v[i] = x` (src/js/prelude/index.ts) with no bounds check, despite both docstrings declaring the index as "a valid index into v":

- `(vector-ref (vector 1 2 3) 5)` and `(vector-ref (vector 1 2 3) -1)` silently returned `void`.
- `(vector-set! v 5 10)` on a 3-element vector grew it into the holey `(vector 1 2 3   10)` with `(vector-length v)` now 6; `(vector-set! v -1 10)` was a silent no-op.

For a teaching language, off-by-one mistakes producing sparse vectors or `void` instead of a clear diagnostic are especially harmful.

## The fix

Both functions now validate `0 <= i < v.length` and otherwise raise a clean `ScamperError('Runtime', ...)`:

- `vector-ref: index <i> out of bounds of vector`
- `vector-set!: index <i> out of bounds of vector`

This mirrors the existing `list-ref` range error (`list-ref: index <n> out of bounds of list`) in the same file — same "index N out of bounds of X" shape — for consistency. The valid-index fast path is untouched.

## Edge cases covered

- **index >= length** (both `== length` and `> length`): clean error, vector unchanged for `vector-set!` (no more holes / length growth).
- **negative index**: clean error, no longer a silent no-op for `vector-set!`.
- **non-integer index** (e.g. `1.5`): already rejected by the existing `n : integer?` docstring contract (`expected an integer, received number`) — no new code needed, confirmed by a regression case.
- **empty vector**: `(vector-ref (vector) 0)` errors cleanly.
- **valid in-range access/mutation** still works: `(vector-ref (vector 1 2 3) 0)` -> `1`; a valid `vector-set!` followed by `vector-ref` reflects the change.

## Tests

- New regression suite `test/regressions/vector-bounds.test.ts` (mirrors the `#256` car/cdr regression style, strips definition-site ranges).
- **Flipped two existing tests** in `test/libs/prelude.test.ts` that documented the old silent/holey behavior: `vector-ref` (two `void` results -> bounds errors) and `vector-set-out-of-range` (holey `(vector 1 2 3   10)` / length 6 / silent no-op -> bounds errors with the vector unchanged).

`npm run validate` passes: typecheck PASS, test PASS, lint PASS (0 errors; ~1076 pre-existing warnings).

Fixes #257
