### PR TITLE
Fix #258: raise a clean error on division by zero

### DIFF
--- a/src/js/prelude/index.ts
+++ b/src/js/prelude/index.ts
@@ -106,7 +106,15 @@ export function prelude_times(...xs: number[]): number {
 }
 
 export function prelude_div(...xs: number[]): number {
-  return xs.length === 1 ? 1 / xs[0] : xs.reduce((a, b) => a / b)
+  // `/` folds left-to-right; unary `(/ x)` means `1/x`. Any zero divisor
+  // anywhere in the chain errors rather than producing Infinity/NaN.
+  const divide = (a: number, b: number): number => {
+    if (b === 0) {
+      throw new L.ScamperError('Runtime', '/: division by zero')
+    }
+    return a / b
+  }
+  return xs.length === 1 ? divide(1, xs[0]) : xs.reduce(divide)
 }
 
 export function prelude_abs(x: number): number {
@@ -123,14 +131,23 @@ export function prelude_abs(x: number): number {
 // To avoid clutter in the documentation.
 
 export function prelude_quotient(x: number, y: number): number {
+  if (y === 0) {
+    throw new L.ScamperError('Runtime', 'quotient: division by zero')
+  }
   return Math.trunc(x / y)
 }
 
 export function prelude_remainder(x: number, y: number): number {
+  if (y === 0) {
+    throw new L.ScamperError('Runtime', 'remainder: division by zero')
+  }
   return x % y
 }
 
 export function prelude_modulo(x: number, y: number): number {
+  if (y === 0) {
+    throw new L.ScamperError('Runtime', 'modulo: division by zero')
+  }
   return ((x % y) + y) % y
 }
 

--- a/test/libs/prelude.test.ts
+++ b/test/libs/prelude.test.ts
@@ -1993,9 +1993,11 @@ test('zero', async () => {
 // Numeric & Comparison Operations
 
 test('nanQ-actual-nan', async () => {
+  // `(/ 0.0 0.0)` used to produce NaN, but division by zero now errors (#258).
+  // `(sqrt -1)` is a NaN source that does not go through a zero divisor.
   expect(
     await runProgram(`
-(nan? (/ 0.0 0.0))
+(nan? (sqrt -1))
 `),
   ).toEqual(['#t'])
 })
@@ -2010,25 +2012,31 @@ test('gt-equal', async () => {
 })
 
 test('div-zero', async () => {
-  // BUG (#258): division by zero silently yields Infinity/NaN instead of a
-  // domain error, and is inconsistent (/ and quotient give Infinity, modulo
-  // gives NaN). Pinned as current behavior.
+  // Fixed (#258): division by zero now raises a clean runtime error instead of
+  // silently yielding Infinity/NaN. See test/regressions/division-by-zero for
+  // the full matrix (variadic mid-chain, unary, 0/0, quotient/modulo/remainder).
   expect(
     await runProgram(`
 (/ 5 0)
 `),
-  ).toEqual(['Infinity'])
+  ).toEqual([
+    expect.stringContaining('/: division by zero'),
+  ])
 })
 
 test('quotient-negative-zero', async () => {
+  // The zero-divisor case used to yield Infinity; it now errors (#258). Valid
+  // negative-argument quotients are unaffected.
   expect(
     await runProgram(`
 (quotient -7 2)
 (quotient 7 -2)
 (quotient -7 -2)
-(quotient 5 0)
 `),
-  ).toEqual(['-3', '-3', '3', 'Infinity'])
+  ).toEqual(['-3', '-3', '3'])
+  expect(await runProgram('(quotient 5 0)')).toEqual([
+    expect.stringContaining('quotient: division by zero'),
+  ])
 })
 
 test('remainder-negative', async () => {

--- a/test/regressions/division-by-zero.test.ts
+++ b/test/regressions/division-by-zero.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/258
+//
+// Division by a zero divisor used to silently produce IEEE Infinity/NaN and
+// was inconsistent across operators: `/` and `quotient` gave Infinity, while
+// `modulo`/`remainder` gave NaN. All four now raise a clean Scamper runtime
+// error ("<op>: division by zero"). Scamper numbers are all IEEE doubles, so
+// `0` and `0.0` are the same value: a zero divisor errors regardless of how it
+// is written, including 0/0.
+//
+// `/` is variadic and folds left-to-right (unary `(/ x)` means `1/x`), so any
+// zero divisor anywhere in the chain must error, not just the two-argument
+// case.
+//
+// Ranges are stripped from error messages: they point at the operators'
+// definitions in prelude.scm and would shift with any edit to that file.
+
+const stripRange = (msgs: string[]): string[] =>
+  msgs.map((m) => m.replace(/\[\d+:\d+-\d+:\d+\]/, '[..]'))
+
+describe('/ rejects a zero divisor cleanly (#258)', () => {
+  test('two-argument division by zero', async () => {
+    expect(stripRange(await runProgram('(/ 1 0)'))).toEqual([
+      'Runtime error [..]: (/) /: division by zero',
+    ])
+  })
+
+  test('0 / 0 errors instead of returning NaN', async () => {
+    expect(stripRange(await runProgram('(/ 0 0)'))).toEqual([
+      'Runtime error [..]: (/) /: division by zero',
+    ])
+  })
+
+  test('negative dividend by zero errors instead of returning -Infinity', async () => {
+    expect(stripRange(await runProgram('(/ -1 0)'))).toEqual([
+      'Runtime error [..]: (/) /: division by zero',
+    ])
+  })
+
+  test('a zero divisor mid-chain errors', async () => {
+    expect(stripRange(await runProgram('(/ 5 0 2)'))).toEqual([
+      'Runtime error [..]: (/) /: division by zero',
+    ])
+  })
+
+  test('unary (/ 0) is 1/0 and errors', async () => {
+    expect(stripRange(await runProgram('(/ 0)'))).toEqual([
+      'Runtime error [..]: (/) /: division by zero',
+    ])
+  })
+
+  test('a zero divisor written as 0.0 also errors', async () => {
+    expect(stripRange(await runProgram('(/ 1 0.0)'))).toEqual([
+      'Runtime error [..]: (/) /: division by zero',
+    ])
+  })
+})
+
+describe('quotient/modulo/remainder reject a zero divisor cleanly (#258)', () => {
+  test('quotient by zero errors instead of returning Infinity', async () => {
+    expect(stripRange(await runProgram('(quotient 1 0)'))).toEqual([
+      'Runtime error [..]: (quotient) quotient: division by zero',
+    ])
+  })
+
+  test('modulo by zero errors instead of returning NaN', async () => {
+    expect(stripRange(await runProgram('(modulo 1 0)'))).toEqual([
+      'Runtime error [..]: (modulo) modulo: division by zero',
+    ])
+  })
+
+  test('remainder by zero errors instead of returning NaN', async () => {
+    expect(stripRange(await runProgram('(remainder 1 0)'))).toEqual([
+      'Runtime error [..]: (remainder) remainder: division by zero',
+    ])
+  })
+})
+
+describe('valid divisions are unaffected (#258)', () => {
+  test('/, quotient, modulo, remainder still compute normally', async () => {
+    expect(
+      await runProgram(`
+      (/ 6 2)
+      (/ 5 2)
+      (/ 12 2 3)
+      (/ 4)
+      (modulo 7 3)
+      (quotient 7 2)
+      (remainder 7 3)
+      `),
+    ).toEqual(['3', '2.5', '2', '0.25', '1', '3', '1'])
+  })
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

## The bug (#258)

When the divisor was zero, Scamper's division operators silently produced IEEE `Infinity`/`NaN` and behaved inconsistently across operators:

| Expression | Old result |
|---|---|
| `(/ 1 0)` | `Infinity` |
| `(/ 0 0)` | `NaN` |
| `(/ -1 0)` | `-Infinity` |
| `(quotient 1 0)` | `Infinity` |
| `(modulo 1 0)` | `NaN` |
| `(remainder 1 0)` | `NaN` |

## Decided semantics (per maintainer)

All four operators — `/`, `quotient`, `modulo`, `remainder` — now raise a clean Scamper runtime error on a zero divisor. No `Infinity`/`NaN` is ever produced. Scamper numbers are all IEEE doubles, so `0` and `0.0` are the same value: a zero divisor errors regardless of how it is written, including `0/0`.

## Exact error messages

- `/: division by zero`
- `quotient: division by zero`
- `modulo: division by zero`
- `remainder: division by zero`

These follow the existing `<function>: <description>` convention (mirroring `list-ref`/`vector-ref` bounds errors).

## Edge cases covered

`/` is variadic and folds left-to-right, with unary `(/ x)` meaning `1/x`. The guard sits inside the fold step, so a zero divisor **anywhere** in the chain errors:

- variadic mid-chain: `(/ 5 0 2)` errors
- unary: `(/ 0)` (= `1/0`) errors
- `0/0`: `(/ 0 0)` errors (no NaN)
- negative dividend: `(/ -1 0)` errors (no `-Infinity`)
- `0.0` divisor: `(/ 1 0.0)` errors

Valid divisions are unaffected: `(/ 6 2)` → 3, `(/ 5 2)` → 2.5, `(/ 12 2 3)` → 2, `(modulo 7 3)` → 1, `(quotient 7 2)` → 3, `(remainder 7 3)` → 1.

## Tests

- New regression suite `test/regressions/division-by-zero.test.ts` — asserts clean errors for `(/ 1 0)`, `(/ 0 0)`, `(/ -1 0)`, `(/ 5 0 2)` (mid-chain), `(/ 0)` (unary), `(/ 1 0.0)`, `(quotient 1 0)`, `(modulo 1 0)`, `(remainder 1 0)`, and that valid divisions still compute. Failing before, passing after.
- Flipped existing pinned tests in `test/libs/prelude.test.ts`:
  - `div-zero`: was `(/ 5 0)` → `'Infinity'`, now expects the `/: division by zero` error.
  - `quotient-negative-zero`: dropped the `(quotient 5 0)` → `'Infinity'` line and added a separate assertion expecting the `quotient: division by zero` error; the valid negative cases are unchanged.
  - `nanQ-actual-nan`: previously produced NaN via `(/ 0.0 0.0)`, which now errors; switched the NaN source to `(sqrt -1)` (unrelated to a zero divisor, so `nan?` is still exercised — no regression to #116).

`npm run validate` passes: typecheck PASS, test PASS, lint PASS (0 errors; ~1076 pre-existing warnings, none new).

Fixes #258
