### PR TITLE
Fix #259: four arithmetic bugs in rgb color transforms

### DIFF
--- a/src/js/image/color.ts
+++ b/src/js/image/color.ts
@@ -57,9 +57,9 @@ export function image_rgb(...args: number[]): Rgb {
   if (args.length !== 3 && args.length !== 4) {
     throw new L.ScamperError('Runtime', `rgb: expects 3 or 4 arguments, but got ${args.length}`)
   }
-  const red = Math.min(args[0], 255)
-  const green = Math.min(args[1], 255)
-  const blue = Math.min(args[2], 255)
+  const red = Math.max(0, Math.min(args[0], 255))
+  const green = Math.max(0, Math.min(args[1], 255))
+  const blue = Math.max(0, Math.min(args[2], 255))
   const alpha = args[3] ?? 255
   return ({
     [L.scamperTag]: 'struct', [L.structKind]: 'rgba',
@@ -372,8 +372,8 @@ function fixHue(h: number): number {
 }
 
 export function image_rgbSaturation(r: Rgb): number {
-  return rgbSaturationHelper(Math.max(r.red, r.green, r.blue),
-                             Math.min(r.red, r.green, r.blue))
+  return rgbSaturationHelper(Math.min(r.red, r.green, r.blue),
+                             Math.max(r.red, r.green, r.blue))
 }
 
 function rgbSaturationHelper(min: number, max: number): number {
@@ -489,7 +489,7 @@ export function image_rgbPseudoComplement(rgba: Rgb): Rgb {
 // rgb-complement
 
 export function image_rgbGreyscale(rgba: Rgb): Rgb {
-  const avg = (0.30 * rgba.red + 0.59 * rgba.green + 0.11 * rgba.blue) / 3
+  const avg = 0.30 * rgba.red + 0.59 * rgba.green + 0.11 * rgba.blue
   return image_rgb(avg, avg, avg, rgba.alpha)
 }
 
@@ -512,7 +512,7 @@ export function image_rgbThin(rgba: Rgb): Rgb {
     rgba.red,
     rgba.green,
     rgba.blue,
-    Math.min(0, rgba.alpha - 32)
+    Math.max(0, rgba.alpha - 32)
   )
 }
 

--- a/test/libs/image.test.ts
+++ b/test/libs/image.test.ts
@@ -19,13 +19,13 @@ describe('color', () => {
     ).toEqual([
       '(rgba 255 0 0 255)',
       '(rgba 0 0 0 0)',
-      // r is only ever clamped from above (Math.min(r, 255)) -- out-of-range
-      // integers above 255 get silently clamped rather than rejected, since
-      // color's own docstring contract only checks integer?, not the
-      // 0-255 range its description mentions.
+      // Components are clamped from above (Math.min(r, 255)): an integer above
+      // 255 is silently clamped rather than rejected, since color's own
+      // docstring contract only checks integer?, not the 0-255 range.
       '(rgba 255 0 0 255)',
-      // ...and never clamped from below, so a negative integer passes through as-is.
-      '(rgba -10 0 0 255)',
+      // ...and now clamped from below too (Math.max(0, ...)), so a negative
+      // integer is clamped to 0 rather than passing through (#259).
+      '(rgba 0 0 0 255)',
       'Runtime error [6:1-6:15]: Arity mismatch in function call: expected 4 arguments, got 3',
       'Runtime error [22:1-22:37]: (error) expected an integer, received number',
     ])
@@ -331,11 +331,9 @@ describe('color', () => {
   })
 
   test('rgb-saturation', async () => {
-    // image_rgbSaturation passes (max, min) positionally into a helper
-    // whose parameters are named (min, max), so the helper's own "max === 0"
-    // early-out actually fires whenever the color's minimum channel is 0 --
-    // i.e. for most fully-saturated colors. This is real, current (buggy)
-    // behavior, not a formula error in this test -- see #259.
+    // #259: helper is 100*((max-min)/max) and now receives (min, max) in the
+    // correct order. Fully-saturated red -> 100, an achromatic grey -> 0, and
+    // (200,100,50) -> 100*((200-50)/200) = 75.
     expect(
       await runProgram(`
 (import image)
@@ -343,7 +341,7 @@ describe('color', () => {
 (rgb-saturation (rgb 100 100 100))
 (rgb-saturation (rgb 200 100 50))
 `),
-    ).toEqual(['0', '0', '-300'])
+    ).toEqual(['100', '0', '75'])
   })
 
   test('rgb-value', async () => {
@@ -460,9 +458,9 @@ describe('color', () => {
   })
 
   test('rgb-greyscale', async () => {
-    // BUG (#259): image_rgbGreyscale divides the luma sum by 3, but the Rec.601
-    // weights already sum to 1.0, so results come out ~3x too dark (white ->
-    // 85 instead of 255). These assertions pin the current buggy output.
+    // #259: the Rec.601 luma weights already sum to 1.0, so the greyscale
+    // value is 0.30r + 0.59g + 0.11b (no spurious /3). White -> 255, black ->
+    // 0, pure red -> 0.30*255 = 76.5.
     expect(
       await runProgram(`
 (import image)
@@ -470,7 +468,7 @@ describe('color', () => {
 (rgb-greyscale (rgb 0 0 0))
 (rgb-greyscale (rgb 255 0 0))
 `),
-    ).toEqual(['(rgba 85 85 85 255)', '(rgba 0 0 0 255)', '(rgba 25.5 25.5 25.5 255)'])
+    ).toEqual(['(rgba 255 255 255 255)', '(rgba 0 0 0 255)', '(rgba 76.5 76.5 76.5 255)'])
   })
 
   test('rgb-phaseshift', async () => {
@@ -493,16 +491,15 @@ describe('color', () => {
   })
 
   test('rgb-thin', async () => {
-    // BUG (#259): Math.min(0, alpha - 32) is at most 0 regardless of alpha
-    // (should be Math.max(0, ...)), so rgb-thin always drives alpha to 0 or
-    // below -- real, current buggy behavior, pinned here.
+    // #259: thinning lowers alpha by 32, clamped at 0 (Math.max(0, alpha-32)).
+    // 200 -> 168, and 0 stays clamped at 0.
     expect(
       await runProgram(`
 (import image)
 (rgb-thin (rgb 1 2 3 200))
 (rgb-thin (rgb 1 2 3 0))
 `),
-    ).toEqual(['(rgba 1 2 3 0)', '(rgba 1 2 3 -32)'])
+    ).toEqual(['(rgba 1 2 3 168)', '(rgba 1 2 3 0)'])
   })
 
   test('rgb-thicken', async () => {

--- a/test/regressions/rgb-transform-arithmetic.test.ts
+++ b/test/regressions/rgb-transform-arithmetic.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/259
+//
+// Four independent arithmetic bugs in src/js/image/color.ts, each pinned by a
+// regression case below with exact hand-computed expected values.
+
+describe('rgb-greyscale uses Rec.601 luma without a spurious /3 (#259)', () => {
+  // Rec.601 weights (0.30, 0.59, 0.11) sum to 1.0, so the greyscale value is
+  // just 0.30r + 0.59g + 0.11b. The old code divided by 3, so white came out
+  // at 85 instead of 255.
+  test('white maps to white (255), not ~85', async () => {
+    expect(await runProgram(`
+(import image)
+(rgb-greyscale (rgb 255 255 255))
+`)).toEqual(['(rgba 255 255 255 255)'])
+  })
+
+  test('pure red maps to 0.30*255 = 76.5', async () => {
+    expect(await runProgram(`
+(import image)
+(rgb-greyscale (rgb 255 0 0))
+`)).toEqual(['(rgba 76.5 76.5 76.5 255)'])
+  })
+})
+
+describe('rgb-saturation passes (min, max) in the right order (#259)', () => {
+  // Helper is 100*((max-min)/max). Args were swapped, so the "max === 0"
+  // early-out mis-fired and (max-min) could go negative.
+  test('fully-saturated red is 100, not 0', async () => {
+    expect(await runProgram(`
+(import image)
+(rgb-saturation (rgb 255 0 0))
+`)).toEqual(['100'])
+  })
+
+  test('(200 100 50) is 100*((200-50)/200) = 75, not -300', async () => {
+    expect(await runProgram(`
+(import image)
+(rgb-saturation (rgb 200 100 50))
+`)).toEqual(['75'])
+  })
+
+  test('an achromatic grey is 0', async () => {
+    expect(await runProgram(`
+(import image)
+(rgb-saturation (rgb 100 100 100))
+`)).toEqual(['0'])
+  })
+})
+
+describe('rgb-thin lowers alpha by 32 clamped at 0 (#259)', () => {
+  // Old code used Math.min(0, alpha-32), always <= 0. Correct is
+  // Math.max(0, alpha-32).
+  test('alpha 200 thins to 168, not 0', async () => {
+    expect(await runProgram(`
+(import image)
+(rgb-thin (rgb 1 2 3 200))
+`)).toEqual(['(rgba 1 2 3 168)'])
+  })
+
+  test('alpha 0 stays clamped at 0 (boundary)', async () => {
+    expect(await runProgram(`
+(import image)
+(rgb-thin (rgb 1 2 3 0))
+`)).toEqual(['(rgba 1 2 3 0)'])
+  })
+})
+
+describe('rgb/color clamps components on both ends of [0, 255] (#259)', () => {
+  // Old code only clamped from above (Math.min(x, 255)); negatives passed
+  // through into color math and CSS rendering.
+  test('a negative channel clamps to 0, not through', async () => {
+    expect(await runProgram(`
+(import image)
+(color -10 0 0 255)
+`)).toEqual(['(rgba 0 0 0 255)'])
+  })
+
+  test('an above-range channel still clamps to 255 (upper boundary)', async () => {
+    expect(await runProgram(`
+(import image)
+(color 300 0 0 255)
+`)).toEqual(['(rgba 255 0 0 255)'])
+  })
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

Fixes four independent, one-line arithmetic errors in `src/js/image/color.ts` (per #259). All four transforms route through `image_rgb`, so the corrected clamp also backstops them.

- **rgb-greyscale (~3x too dark).** Was `(0.30r + 0.59g + 0.11b) / 3`. The Rec.601 luma weights already sum to 1.0, so the `/ 3` darkened every result. Fix: drop the `/ 3`. Now `(rgb-greyscale (rgb 255 255 255))` -> `255` (was 85) and `(rgb 255 0 0)` -> `76.5` (was 25.5).

- **rgb-saturation (0/negative).** Helper is `max === 0 ? 0 : 100*((max-min)/max)` with params `(min, max)`, but was called `(Math.max(...), Math.min(...))` — args swapped. Fix: call `(Math.min(...), Math.max(...))`. Now `(rgb 255 0 0)` -> `100` (was 0) and `(rgb 200 100 50)` -> `100*((200-50)/200) = 75` (was -300).

- **rgb-thin (alpha forced to 0).** Was `Math.min(0, alpha - 32)`, always <= 0. Fix: `Math.max(0, alpha - 32)`, matching sibling `rgb-thicken`. Now `(rgb-thin (rgb 1 2 3 200))` -> alpha `168` (was 0); alpha 0 stays clamped at 0.

- **rgb/color component clamp (no lower bound).** Was `Math.min(x, 255)` only, so negative channels passed through into color math and CSS. Fix: `Math.max(0, Math.min(x, 255))`. Now `(color -10 0 0 255)` -> `(rgba 0 0 0 255)`; upper clamp of 300 -> 255 unchanged.

**Regression tests** — new `test/regressions/rgb-transform-arithmetic.test.ts`, one case per bug plus boundaries: greyscale (white=255, red=76.5), saturation (red=100, (200,100,50)=75, grey=0), thin (200->168, 0->0), clamp (-10->0, 300->255). Fails before / passes after.

**Flipped tests** — the four affected cases in `test/libs/image.test.ts` (`color`, `rgb-saturation`, `rgb-greyscale`, `rgb-thin`) previously asserted the buggy outputs; updated to the correct values with refreshed comments.

Out of scope: the separate colorsys ESM interop bug (#265) is untouched.

`npm run validate`: typecheck PASS, test PASS, lint PASS (0 errors; ~1076 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #259