### PR TITLE
Fix #253: rotate of an above drawing crashes with a ReferenceError

### DIFF
--- a/src/js/image/drawing.ts
+++ b/src/js/image/drawing.ts
@@ -283,7 +283,7 @@ function getDrawingPoints (drawing: Drawing): [number, number][] {
       })
       return points
     case 'above':
-      const yOffset = 0
+      let yOffset = 0
       drawing.drawings.forEach((subimage) => {
         const subPoints: [number, number][] = getDrawingPoints(subimage)
           .map(([x, y]) => [
@@ -296,7 +296,7 @@ function getDrawingPoints (drawing: Drawing): [number, number][] {
             y + yOffset
         ])
         points.push(...subPoints)
-        xOffset += subimage.width
+        yOffset += subimage.height
       })
       return points
     case 'overlay': {

--- a/test/libs/image.test.ts
+++ b/test/libs/image.test.ts
@@ -1642,17 +1642,11 @@ describe('getDrawingPoints (via rotate)', () => {
   test('beside', async () => {
     expect(await rotatedIsPositive('(beside (square 5 "solid" "red") (square 8 "solid" "blue"))')).toEqual(['#t', '#t'])
   })
-  // Rotating an `above` drawing currently crashes: getDrawingPoints' `above`
-  // case increments `xOffset` (a copy-paste slip from the `beside` case) which
-  // isn't in scope there, so it throws a ReferenceError
-  // (github.com/slag-plt/scamper#253). Asserting the throw documents the bug
-  // and covers the reachable portion of the branch.
-  test('above (broken -- see #253)', async () => {
-    const [err] = await runProgram(`
-(import image)
-(image-width (rotate 45 (above (square 5 "solid" "red") (square 8 "solid" "blue"))))
-`)
-    expect(err).toContain("Cannot access 'xOffset' before initialization")
+  // Regression for #253: getDrawingPoints' `above` case used to increment
+  // `xOffset` (a copy-paste slip from the `beside` case) which isn't in scope
+  // there, throwing a ReferenceError. Now fixed to accumulate `yOffset`.
+  test('above', async () => {
+    expect(await rotatedIsPositive('(above (square 5 "solid" "red") (square 8 "solid" "blue"))')).toEqual(['#t', '#t'])
   })
   test('overlay', async () => {
     expect(await rotatedIsPositive('(overlay (square 5 "solid" "red") (square 8 "solid" "blue"))')).toEqual(['#t', '#t'])
@@ -1699,6 +1693,11 @@ describe('rotation dimensions (getDrawingPoints correctness)', () => {
   })
   test('beside recurses into children (20x4 -> 4x20)', async () => {
     expect(await rounded90Dims('(beside (rectangle 10 4 "solid" "red") (rectangle 10 4 "solid" "blue"))')).toEqual(['4', '20'])
+  })
+  // #253: the `above` case must stack heights via `yOffset` -- two 4x10 boxes
+  // are 4x20 unrotated, so a 90-degree turn yields 20x4.
+  test('above stacks children heights (4x20 -> 20x4)', async () => {
+    expect(await rounded90Dims('(above (rectangle 4 10 "solid" "red") (rectangle 4 10 "solid" "blue"))')).toEqual(['20', '4'])
   })
 })
 

--- a/test/regressions/rotate-above.test.ts
+++ b/test/regressions/rotate-above.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/253
+//
+// getDrawingPoints' `above` case in src/js/image/drawing.ts incremented
+// `xOffset` -- a copy-paste slip from the sibling `beside` case, which is the
+// only place that name is declared. In the shared switch block that reference
+// hits the temporal dead zone, so `(rotate <angle> (above ...))` threw
+// `ReferenceError: Cannot access 'xOffset' before initialization` for any
+// `above` drawing (rotate calls getDrawingPoints). It also declared
+// `const yOffset = 0`, so vertical offsets never accumulated. The fix uses
+// `let yOffset` and increments `yOffset += subimage.height`.
+
+describe('rotate of an above drawing (#253)', () => {
+  // The crash: rotating an `above` produces a real drawing, not a runtime error.
+  test('does not throw a ReferenceError', async () => {
+    const result = await runProgram(`
+(import image)
+(rotate 45 (above (rectangle 20 20 "solid" "red") (rectangle 20 20 "solid" "blue")))
+`)
+    expect(result).toHaveLength(1)
+    expect(result[0]).not.toContain('ReferenceError')
+    expect(result[0]).toContain('rotate')
+  })
+
+  // The sibling `beside` case was never broken; keep it covered so a future
+  // edit to the shared switch block can't regress it.
+  test('the beside sibling still rotates cleanly', async () => {
+    const result = await runProgram(`
+(import image)
+(> (image-width (rotate 45 (beside (rectangle 20 20 "solid" "red") (rectangle 20 20 "solid" "blue")))) 0)
+`)
+    expect(result).toEqual(['#t'])
+  })
+
+  // Geometry, not just "doesn't throw": stacking a 20-tall and a 30-tall box
+  // (both 20 wide) is 20x50 unrotated, so `yOffset` must accumulate both
+  // heights. A 90-degree turn then swaps that to 50x20 -- the old
+  // `const yOffset = 0` would have collapsed the stack.
+  test('yOffset accumulates every child height', async () => {
+    expect(await runProgram(`
+(import image)
+(round (image-width (rotate 90 (above (rectangle 20 20 "solid" "red") (rectangle 20 30 "solid" "blue")))))
+(round (image-height (rotate 90 (above (rectangle 20 20 "solid" "red") (rectangle 20 30 "solid" "blue")))))
+`)).toEqual(['50', '20'])
+  })
+
+  // An `above` nested inside a `beside` inside a `rotate` exercises the branch
+  // recursively.
+  test('a nested above/beside combination rotates cleanly', async () => {
+    expect(await runProgram(`
+(import image)
+(> (image-width (rotate 30 (beside (above (square 5 "solid" "red") (square 8 "solid" "blue")) (square 4 "solid" "green")))) 0)
+`)).toEqual(['#t'])
+  })
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

## The crash

`(rotate <angle> (above ...))` threw a JavaScript error for any `above` drawing:

```
Runtime error: Unexpected error in Javascript function call: ReferenceError: Cannot access 'xOffset' before initialization
```

`rotate` computes a rotated bounding box via `getDrawingPoints`, which crashed on the `above` branch. `(rotate <angle> (beside ...))` worked fine, isolating the bug to the `above` case.

## Root cause

In `getDrawingPoints` (`src/js/image/drawing.ts`), the `above` case incremented `xOffset`:

```js
case 'above':
  const yOffset = 0
  drawing.drawings.forEach((subimage) => {
    ...
    xOffset += subimage.width   // <-- wrong variable
  })
```

`xOffset` is a copy-paste slip from the sibling `beside` case, which is the only place that name is declared (`let xOffset`). In the shared `switch` block the reference lands in the temporal dead zone, so it throws. Two bugs in one: the case also declared `const yOffset = 0`, so even once the reference was fixed the vertical offsets would never accumulate and the rotated point set would still be wrong.

## The fix

Two lines, matching the correct `beside` sibling and the `above` render path (which advances `y += d.height`):

- `const yOffset = 0` -> `let yOffset = 0`
- `xOffset += subimage.width` -> `yOffset += subimage.height`

Verified geometry, not just the absence of a throw: an `above` of a 20-tall and a 30-tall box (20x50 unrotated) rotated 90 degrees now yields 50x20, confirming `yOffset` accumulates every child height.

## Regression tests

- `test/regressions/rotate-above.test.ts` (new): `rotate of an above drawing (#253)` -- the crash no longer throws; the `beside` sibling still rotates; `yOffset` accumulates every child height (90-degree dimension check); a nested `above`/`beside` combination rotates cleanly. Confirmed failing-before / passing-after.
- `test/libs/image.test.ts`: flipped the `above (broken -- see #253)` case (which asserted the ReferenceError) to `above`, and added `above stacks children heights (4x20 -> 20x4)` to the 90-degree dimension-correctness block that previously only covered `beside`.

`npm run validate` -> typecheck: PASS, test: PASS, lint: PASS (0 errors; pre-existing warnings only).

Note: issue #102 ("at least 4 bugs with rotate") is broader and out of scope here; this ReferenceError may be one of its symptoms, but only the #253 crash is addressed.

Fixes #253