### PR TITLE
Fix #116: real? returns #t on integers, #f on NaN/Infinity

### DIFF
--- a/src/js/prelude/index.ts
+++ b/src/js/prelude/index.ts
@@ -22,7 +22,7 @@ export function prelude_numberQ(x: any): boolean {
 }
 
 export function prelude_realQ(x: any): boolean {
-  return typeof x === 'number' && !Number.isInteger(x)
+  return typeof x === 'number' && Number.isFinite(x)
 }
 
 export function prelude_integerQ(x: any): boolean {

--- a/test/libs/prelude.test.ts
+++ b/test/libs/prelude.test.ts
@@ -1443,7 +1443,7 @@ test('real', async () => {
 (real? (/ 50 2))
 (real? (/ 51 2))
 `),
-  ).toEqual(['#f', '#t', '#f', '#f', '#t'])
+  ).toEqual(['#t', '#t', '#f', '#t', '#t'])
 })
 
 test('remainder-modulo', async () => {

--- a/test/regressions/real-predicate.test.ts
+++ b/test/regressions/real-predicate.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/116
+//
+// `real?` was defined as `typeof x === 'number' && !Number.isInteger(x)`,
+// which is backwards: it returned #t only for non-integer numbers (and, since
+// `Number.isInteger` is false for them, also for NaN/Infinity) and #f for
+// integers. The correct meaning is "finite number", so it is now
+// `typeof x === 'number' && Number.isFinite(x)`: #t for every finite number
+// (integer or not), #f for NaN, ±Infinity, and non-numbers.
+//
+// Scamper numbers are all IEEE doubles, so `5` and `5.0` are the same value.
+
+test('real? is #t for all finite numbers, #f for NaN/Infinity/non-numbers (#116)', async () => {
+  expect(await runProgram(`
+  (real? 5)
+  (real? 5.0)
+  (real? 2.5)
+  (real? -3)
+  (real? 0)
+  (real? (sqrt -1))
+  (real? (expt 10 1000))
+  (real? "x")
+  (real? (list))
+  (real? #t)
+  (real? null)
+  `)).toEqual([
+    '#t', // integer
+    '#t', // whole float (same value as 5)
+    '#t', // non-integer finite
+    '#t', // negative integer
+    '#t', // zero
+    '#f', // NaN
+    '#f', // Infinity
+    '#f', // string
+    '#f', // list
+    '#f', // boolean
+    '#f', // null
+  ])
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

## The bug (#116)
`real?` behaved backwards on two fronts:
1. It returned `#f` on integers (e.g. `(real? 5)` → `#f`) when it should return `#t`.
2. It returned `#t` on `NaN` and `Infinity`, which are not real numbers.

## Root cause
`prelude_realQ` in `src/js/prelude/index.ts` was:
```ts
return typeof x === 'number' && !Number.isInteger(x)
```
That is true only for **non-integer** numbers — and because `Number.isInteger` is false for `NaN`/`Infinity`, those slipped through as `#t` too — while every integer got `#f`.

The fix is the exact spec, "is a finite number":
```ts
return typeof x === 'number' && Number.isFinite(x)
```
`Number.isFinite` is `#t` for all finite numbers (integer and float), `#f` for `NaN`, `±Infinity`, and non-numbers. Scamper numbers are all IEEE doubles, so `5` and `5.0` are the same value.

## Target behavior
| Expression | Before | After |
|---|---|---|
| `(real? 5)` | `#f` | `#t` |
| `(real? 5.0)` | `#f` | `#t` |
| `(real? 2.5)` | `#t` | `#t` |
| `(real? (sqrt -1))` (NaN) | `#t` | `#f` |
| `(real? (expt 10 1000))` (Infinity) | `#t` | `#f` |
| `(real? "x")` | `#f` | `#f` |
| `(real? (list))` | `#f` | `#f` |

## Scope
Only `real?` changed. `number?` and `integer?` are untouched and already correct (`NaN` remains a `number?` per R7RS). `real?` is not used as a contract type on any parameter (confirmed by grep — its only source references are its own definition and docstring), so no other code needed changes.

## Tests
- New regression test `test/regressions/real-predicate.test.ts` asserting the full target behavior above plus negatives/zero/boolean/null. Verified failing-before, passing-after.
- Flipped the existing `real` case in `test/libs/prelude.test.ts` that encoded the old buggy expectations: `(real? 56)` and `(real? (/ 50 2))` (= 25, an integer) now expect `#t` instead of `#f`.

`npm run validate` passes: typecheck PASS, test PASS, lint PASS (0 errors).

Fixes #116
