### PR TITLE
Fix rotate bounding-box geometry and overlay mutation (#102)

### DIFF
--- a/src/js/image/drawing.ts
+++ b/src/js/image/drawing.ts
@@ -237,119 +237,6 @@ interface Rotate extends L.Struct {
   drawing: Drawing
 }
 
-function getDrawingPoints (drawing: Drawing): [number, number][] {
-  const points: [number, number][] = []
-  switch(drawing[L.structKind]) {
-    case 'ellipse':
-      const n = 100
-      for (let i = 1; i < n; i++) {
-        const t = 2 * Math.PI * i / n
-        points.push([
-          0.5 * drawing.width * Math.cos(t),
-          0.5 * drawing.height * Math.sin(t)
-        ])
-      }
-      return points
-    case 'rectangle':
-      return [
-        [0, 0],
-        [drawing.width, 0],
-        [drawing.width, drawing.height],
-        [0, drawing.height]
-      ]
-    case 'triangle':
-      return [
-        [0, 0],
-        [0.5 * drawing.width, drawing.height],
-        [drawing.width, 0]
-      ]
-    case 'path':
-      return drawing.points
-    case 'beside':
-      let xOffset = 0
-      drawing.drawings.forEach((subimage) => {
-        const subPoints: [number, number][] = getDrawingPoints(subimage)
-          .map(([x, y]) => [
-            x + xOffset,
-            drawing.align === 'top'
-              ? y
-              : drawing.align === 'bottom'
-                ? y + drawing.height - subimage.height
-                // N.B., assumed to be 'center'
-                : y + (drawing.height - subimage.height) / 2
-        ])
-        points.push(...subPoints)
-        xOffset += subimage.width
-      })
-      return points
-    case 'above':
-      let yOffset = 0
-      drawing.drawings.forEach((subimage) => {
-        const subPoints: [number, number][] = getDrawingPoints(subimage)
-          .map(([x, y]) => [
-            drawing.align === 'left'
-              ? x
-              : drawing.align === 'right'
-                ? x + drawing.width - subimage.width
-                // N.B., assumed to be 'middle'
-                : x + (drawing.width - subimage.width) / 2,
-            y + yOffset
-        ])
-        points.push(...subPoints)
-        yOffset += subimage.height
-      })
-      return points
-    case 'overlay': {
-      return drawing.drawings.reverse().flatMap((d) => {
-        return getDrawingPoints(d)
-          .map(([x, y]): [number, number] => [
-            drawing.xAlign === 'left'
-            ? x
-            : drawing.xAlign === 'right'
-              ? x + drawing.width - d.width
-              // N.B., assumed to be 'middle'
-              : x + (drawing.width - d.width) / 2,
-          drawing.yAlign === 'top'
-            ? y
-            : drawing.yAlign === 'bottom'
-              ? y + drawing.height - d.height
-              // N.B., assumed to be 'center'
-              : y + (drawing.height - d.height) / 2
-          ])
-      })
-    }
-    case 'overlayOffset':
-      const x1 = drawing.dx > 0 ? 0 : Math.abs(drawing.dx)
-      const y1 = drawing.dy > 0 ? 0 : Math.abs(drawing.dy)
-      const x2 = drawing.dx > 0 ? drawing.dx : 0
-      const y2 = drawing.dy > 0 ? drawing.dy : 0
-      const d1Points: [number, number][] = getDrawingPoints(drawing.d1)
-        .map(([x, y]) => [x + x1, y + y1])
-      const d2Points: [number, number][] = getDrawingPoints(drawing.d2)
-        .map(([x, y]) => [x + x2, y + y2])
-      return d1Points.concat(d2Points)
-    case 'rotate':
-      const angle = drawing.angle * Math.PI / 180
-      const rotatedPoints = getDrawingPoints(drawing.drawing)
-        .map(([x, y]) => [
-          x * Math.cos(angle) - y * Math.sin(angle),
-          x * Math.sin(angle) + y * Math.cos(angle)
-        ])
-      const xMin = Math.min(...rotatedPoints.map(([x, _]) => x))
-      const yMin = Math.min(...rotatedPoints.map(([_, y]) => y))
-      return rotatedPoints.map(([x, y]) => [x - xMin, y - yMin])
-    case 'withDash':
-      return getDrawingPoints(drawing.drawing)
-    case 'text':
-      return [
-        [0, 0],
-        [drawing.width, 0],
-        [drawing.width, drawing.height],
-        [0, drawing.height]
-      ]
-  }
-}
-
 function calculateRotatedBox (points: [number, number][], degrees: number): { width: number, height: number, dx: number, dy: number } {
   // Calculate the rotated points
   const angle = degrees * Math.PI / 180
@@ -376,7 +263,16 @@ function calculateRotatedBox (points: [number, number][], degrees: number): { wi
 }
 
 export function image_rotate(angle: number, drawing: Drawing): Rotate {
-  const dims = calculateRotatedBox(getDrawingPoints(drawing), angle)
+  // Rotate the drawing's declared bounding-box corners. At angle 0 this is the
+  // identity for every shape (box = w x h, dx = dy = 0), so `rotate` never
+  // shifts, clips, or resizes a drawing it isn't actually turning.
+  const corners: [number, number][] = [
+    [0, 0],
+    [drawing.width, 0],
+    [drawing.width, drawing.height],
+    [0, drawing.height]
+  ]
+  const dims = calculateRotatedBox(corners, angle)
   return {
     [L.scamperTag]: 'struct', [L.structKind]: 'rotate',
     width: dims.width,

--- a/test/libs/image.browser.test.ts
+++ b/test/libs/image.browser.test.ts
@@ -77,6 +77,19 @@ function hasColoredPixel(canvas: HTMLCanvasElement): boolean {
   return false
 }
 
+// Count of fully-red, fully-opaque pixels -- a size-independent measure of how
+// much of a red shape actually landed on the canvas.
+function redPixelCount(canvas: HTMLCanvasElement): number {
+  const data = context2d(canvas).getImageData(0, 0, canvas.width, canvas.height).data
+  let count = 0
+  for (let i = 0; i < data.length; i += 4) {
+    if (data[i] === 255 && data[i + 1] === 0 && data[i + 2] === 0 && data[i + 3] === 255) {
+      count++
+    }
+  }
+  return count
+}
+
 // A no-op stand-in for a Scamper closure; L.callScamperFn throws before ever
 // looking at it (see #248), so its actual behavior doesn't matter here.
 const dummyScamperFn = ((..._args: L.Value[]) => undefined) as L.ScamperFn
@@ -235,6 +248,44 @@ describe('render per-shape branches', () => {
     expect(canvas.width).toBeGreaterThan(0)
     expect(canvas.height).toBeGreaterThan(0)
     expect(hasColoredPixel(canvas)).toBe(true)
+  })
+})
+
+// https://github.com/slag-plt/scamper/issues/102
+//
+// A rotate-0 turn is a no-op and must render identically to the un-rotated
+// drawing. The old bounding box came from a per-shape point set that disagreed
+// with the declared width/height, so `rotate` shifted, clipped, and reordered
+// even at angle 0. These pixel checks are the real proof the fix landed; the
+// jsdom suite (test/regressions/rotate-bounding-box.test.ts) covers dimensions.
+describe('rotate 0 is a no-op (#102)', () => {
+  // Bug A: an ellipse's points were center-origin while every other shape was
+  // top-left origin, so rotate-0 translated the circle down-right by its radius
+  // -- its center read as background and ~3/4 of its ink fell off the canvas.
+  test('does not shift or clip a circle', () => {
+    const circle = image_ellipse(20, 20, 'solid', 'red')
+    const plain = image_drawingToImage(circle)
+    const rotated = image_drawingToImage(image_rotate(0, circle))
+    // center pixel is red, not the white background it clipped to before
+    expect(pixel(rotated, 10, 10)).toEqual([255, 0, 0, 255])
+    // and about as much red survives as the un-rotated circle, not ~1/4
+    const plainRed = redPixelCount(plain)
+    expect(redPixelCount(rotated)).toBeGreaterThan(plainRed * 0.9)
+  })
+
+  // Bug B: the overlay case reversed the shared child array in place, so
+  // rotating an overlay flipped its z-order -- and mutated the caller's input.
+  test('does not reverse an overlay it wraps', () => {
+    const ov = image_overlay(
+      image_rectangle(20, 20, 'solid', 'red'),
+      image_rectangle(20, 20, 'solid', 'blue'),
+    )
+    // red is listed first, so it draws on top: the center is red
+    expect(pixel(image_drawingToImage(ov), 10, 10)).toEqual([255, 0, 0, 255])
+    // rotating the overlay must not touch `ov`...
+    image_rotate(0, ov)
+    // ...so re-rendering the SAME overlay still shows red on top
+    expect(pixel(image_drawingToImage(ov), 10, 10)).toEqual([255, 0, 0, 255])
   })
 })
 

--- a/test/libs/image.test.ts
+++ b/test/libs/image.test.ts
@@ -1614,11 +1614,11 @@ describe('image transforms', () => {
   })
 })
 
-// Rotating a drawing forces getDrawingPoints to compute a point set for the
-// wrapped shape (one switch case per drawing kind), then a rotated bounding
-// box. Asserting the box is a positive size exercises each case without
-// depending on the exact irrational post-rotation dimensions.
-describe('getDrawingPoints (via rotate)', () => {
+// Rotating a drawing turns its declared bounding-box corners into a new
+// axis-aligned box. Asserting the box is a positive size exercises every
+// drawing kind without depending on the exact irrational post-rotation
+// dimensions.
+describe('rotate produces a positive box for every shape', () => {
   async function rotatedIsPositive(shape: string): Promise<string[]> {
     return runProgram(`
 (import image)
@@ -1642,9 +1642,7 @@ describe('getDrawingPoints (via rotate)', () => {
   test('beside', async () => {
     expect(await rotatedIsPositive('(beside (square 5 "solid" "red") (square 8 "solid" "blue"))')).toEqual(['#t', '#t'])
   })
-  // Regression for #253: getDrawingPoints' `above` case used to increment
-  // `xOffset` (a copy-paste slip from the `beside` case) which isn't in scope
-  // there, throwing a ReferenceError. Now fixed to accumulate `yOffset`.
+  // Regression for #253: rotating an `above` used to throw a ReferenceError.
   test('above', async () => {
     expect(await rotatedIsPositive('(above (square 5 "solid" "red") (square 8 "solid" "blue"))')).toEqual(['#t', '#t'])
   })
@@ -1665,12 +1663,12 @@ describe('getDrawingPoints (via rotate)', () => {
   })
 })
 
-// The block above only proves each getDrawingPoints branch runs. These verify
-// its point sets are actually correct: rotating an asymmetric shape 90 degrees
-// should swap its width and height, which a wrong point set or swapped-axis
-// regression would break. (rounded to absorb the cos(90) float dust; the
-// exact-value path is covered by the `rotate` constructor test above.)
-describe('rotation dimensions (getDrawingPoints correctness)', () => {
+// The block above only proves each shape rotates. These verify the box is
+// actually correct: rotating an asymmetric shape 90 degrees should swap its
+// declared width and height, which a swapped-axis regression would break.
+// (rounded to absorb the cos(90) float dust; the exact-value path is covered
+// by the `rotate` constructor test above.)
+describe('rotation dimensions (declared-corner correctness)', () => {
   async function rounded90Dims(shape: string): Promise<string[]> {
     return runProgram(`
 (import image)

--- a/test/regressions/rotate-above.test.ts
+++ b/test/regressions/rotate-above.test.ts
@@ -3,14 +3,13 @@ import { runProgram } from '../harness.js'
 
 // https://github.com/slag-plt/scamper/issues/253
 //
-// getDrawingPoints' `above` case in src/js/image/drawing.ts incremented
-// `xOffset` -- a copy-paste slip from the sibling `beside` case, which is the
-// only place that name is declared. In the shared switch block that reference
-// hits the temporal dead zone, so `(rotate <angle> (above ...))` threw
-// `ReferenceError: Cannot access 'xOffset' before initialization` for any
-// `above` drawing (rotate calls getDrawingPoints). It also declared
-// `const yOffset = 0`, so vertical offsets never accumulated. The fix uses
-// `let yOffset` and increments `yOffset += subimage.height`.
+// `rotate` used to build its bounding box from a per-shape point set whose
+// `above` case referenced `xOffset` (a copy-paste slip from `beside`, the only
+// place that name was declared), hitting the temporal dead zone so
+// `(rotate <angle> (above ...))` threw `ReferenceError`. #102 later replaced
+// that point set with the drawing's declared bounding-box corners, which never
+// touches the `above` internals; these tests keep the guarantee that rotating
+// an `above` succeeds and preserves its stacked dimensions.
 
 describe('rotate of an above drawing (#253)', () => {
   // The crash: rotating an `above` produces a real drawing, not a runtime error.
@@ -35,10 +34,8 @@ describe('rotate of an above drawing (#253)', () => {
   })
 
   // Geometry, not just "doesn't throw": stacking a 20-tall and a 30-tall box
-  // (both 20 wide) is 20x50 unrotated, so `yOffset` must accumulate both
-  // heights. A 90-degree turn then swaps that to 50x20 -- the old
-  // `const yOffset = 0` would have collapsed the stack.
-  test('yOffset accumulates every child height', async () => {
+  // (both 20 wide) is 20x50 unrotated, so a 90-degree turn swaps that to 50x20.
+  test('a stacked above keeps its full height when rotated', async () => {
     expect(await runProgram(`
 (import image)
 (round (image-width (rotate 90 (above (rectangle 20 20 "solid" "red") (rectangle 20 30 "solid" "blue")))))

--- a/test/regressions/rotate-bounding-box.test.ts
+++ b/test/regressions/rotate-bounding-box.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/102
+//
+// `rotate` computed its post-rotation bounding box from a per-shape point set
+// (`getDrawingPoints`) that disagreed with each drawing's declared width and
+// height. Three bugs followed, all visible even at angle 0 (a no-op turn):
+//
+//   A. `ellipse` points were center-origin (+/-0.5w, +/-0.5h) while every
+//      other shape was top-left origin, so a rotate-0 circle was shifted and
+//      clipped and its width sampled as 99.90 instead of 100.
+//   B. the `overlay` case called `drawings.reverse()`, mutating the shared
+//      child array in place -- rotating an overlay flipped its z-order.
+//   C. `path` reported only its content extent, ignoring the declared
+//      width/height, so `(rotate 0 (path 200 200 ...))` shrank to its ink.
+//
+// The fix rotates the drawing's declared bounding-box corners instead, which
+// is the identity at angle 0 for every shape and never touches the children.
+
+describe('rotate bounding box (#102)', () => {
+  async function dims (shape: string): Promise<string[]> {
+    return runProgram(`
+(import image)
+(round (image-width ${shape}))
+(round (image-height ${shape}))
+`)
+  }
+
+  // Bug C: a rotate-0 path keeps the declared 200x200 box (was 20x10, the
+  // extent of its four points).
+  test('rotate 0 preserves a path\'s declared width/height', async () => {
+    expect(await dims(`
+      (rotate 0 (path 200 200
+        (list (pair 90 80) (pair 110 80) (pair 110 70) (pair 90 70) (pair 90 80))
+        "outline" "blue"))`)).toEqual(['200', '200'])
+  })
+
+  // Bug A: a rotate-0 circle is exactly its diameter, not the 99.90 that
+  // perimeter sampling produced.
+  test('rotate 0 gives a circle its exact 100x100 box', async () => {
+    expect(await dims('(rotate 0 (solid-circle 50 "red"))')).toEqual(['100', '100'])
+  })
+
+  // Control: rectangles were always correct and must stay correct.
+  test('rotate 0 leaves a rectangle unchanged', async () => {
+    expect(await dims('(rotate 0 (solid-rectangle 100 40 "red"))')).toEqual(['100', '40'])
+  })
+
+  // Sanity: a real 90-degree turn still swaps width and height.
+  test('rotate 90 swaps a rectangle\'s width and height', async () => {
+    expect(await dims('(rotate 90 (solid-rectangle 100 40 "red"))')).toEqual(['40', '100'])
+  })
+
+  // Bug B: rotating an overlay must not mutate the input. The overlay renders
+  // its children back-to-front, so the vector's child order is z-order; if
+  // `rotate` reversed it in place the second print would show them swapped.
+  test('rotate 0 does not reverse an overlay\'s children', async () => {
+    const [before, , after] = await runProgram(`
+(import image)
+(define ov (overlay (solid-square 20 "red") (solid-square 20 "blue")))
+ov
+(rotate 0 ov)
+ov
+`)
+    expect(after).toEqual(before)
+    expect(before).toContain('255 0 0 255')
+    // red must still precede blue in the child vector
+    expect(before.indexOf('255 0 0 255')).toBeLessThan(before.indexOf('0 0 255 255'))
+  })
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

Fixes three of the four bugs from #102, all rooted in `image_rotate` computing its post-rotation bounding box from `getDrawingPoints` — a per-shape point set that disagreed with each drawing's declared width/height. All three showed up even at angle 0, where `rotate` is a no-op and must render identically to its input.

## The bugs

- **A — circle shifts/clips even at angle 0.** `getDrawingPoints` returned center-origin points for `ellipse` (`±0.5w·cos, ±0.5h·sin`) while every other shape used top-left origin (`0..w`). So `dx = -xMin = +0.5w`, and the renderer translated the circle down-right by its radius (~3/4 clipped off-canvas). The perimeter sampling also made `image-width` read **99.90** instead of 100.
- **B — `(rotate 0 (overlay …))` mutates its input, flipping z-order.** The `overlay` case did `drawing.drawings.reverse()`, which reverses the shared array **in place**. Rotating an overlay flipped its child order (red-on-top became blue-on-top) and corrupted the caller's drawing.
- **C — `(rotate 0 (path …))` changes the bounding box.** For `path`, `getDrawingPoints` returned only `drawing.points` (the ink extent), ignoring the declared width/height, so `(rotate 0 (path 200 200 …))` shrank to **20×10**.

The fourth reported bug (ReferenceError when rotating an `above`) was already fixed in #253.

## The fix

`image_rotate` now rotates the drawing's **declared bounding-box corners** (`[0,0], [w,0], [w,h], [0,h]`) instead of `getDrawingPoints`. At angle 0 this is the identity for every shape (box = w×h, dx = dy = 0), which fixes A and C uniformly. `getDrawingPoints`' only caller was `image_rotate`, so it becomes dead code and is deleted — removing the `.reverse()` mutation and fixing B.

Confirmed via the CLI (before → after):
- path `(rotate 0 (path 200 200 …))`: **20×10 → 200×200**
- circle `(rotate 0 (solid-circle 50))`: width **99.90 → 100** (height was already 100)
- controls unchanged: `(rotate 0 rect 100×40)` → 100×40; `(rotate 90 rect 100×40)` → 40×100

## Regression tests (two tiers)

- **jsdom** — `test/regressions/rotate-bounding-box.test.ts`: rotate-0 path keeps 200×200 (C), rotate-0 circle is exactly 100×100 (A), rotate-0 rectangle unchanged, rotate-90 rectangle swaps, and a mutation guard asserting `(rotate 0 ov)` leaves the overlay's child order unchanged (B). Part of `npm run validate`.
- **browser (real Chromium)** — two per-pixel cases added to `test/libs/image.browser.test.ts` under `rotate 0 is a no-op (#102)`: a rotate-0 circle's center pixel is red and its red-pixel count is ~equal to the plain circle's (not ~1/4) (A); rendering an overlay, calling `image_rotate(0, ov)`, then re-rendering the same overlay still shows red on top (B). Both were verified to **fail on the old code and pass on the new**. The existing `rotate fills the interior of its grown bounding box` (90° rectangle) test still passes.

Stale `getDrawingPoints` references in `test/libs/image.test.ts` and `test/regressions/rotate-above.test.ts` were updated to describe the declared-corner mechanism (no behavior change; those tests still pass, since composite drawings carry correct declared dimensions).

`npm run validate` (typecheck + test + lint) and `npm run test:browser` both pass.

Fixes #102
