### PR TITLE
Fix colorsys ESM interop breaking rgb->hsv and hsv->rgb (#265)

### DIFF
--- a/src/js/image/color.ts
+++ b/src/js/image/color.ts
@@ -1,6 +1,6 @@
 import * as L from '../../lpm'
 
-import * as colorsys from 'colorsys'
+import colorsys from 'colorsys'
 
 // NOTE: throughout the image library, we standardize on the `Rgb` struct as
 //       the representation for colors. It is the responsibility of the various

--- a/test/apps/cli/cli.test.ts
+++ b/test/apps/cli/cli.test.ts
@@ -43,4 +43,17 @@ describe('scamper CLI', () => {
     expect(result.stdout).toContain('Usage: scamper')
     expect(result.status).toBe(0)
   })
+
+  // Regression for #265: colorsys is CommonJS, so under the CLI's Node/tsx ESM
+  // interop a namespace import left rgb->hsv/hsv->rgb calling
+  // colorsys.rgbToHsv/hsvToRgb, which were undefined ("... is not a function").
+  // This tier runs the real tsx path where that surfaced; the fix is a default
+  // import in color.ts.
+  test('rgb->hsv and hsv->rgb resolve colorsys under Node/tsx (#265)', () => {
+    const result = runCli([fixture('colorsys.scm')])
+
+    expect(result.stdout).toBe('(hsv 0 100 100 255)\n(rgba 255 0 0 255)\n')
+    expect(result.stderr).toBe('')
+    expect(result.status).toBe(0)
+  })
 })

--- a/test/apps/cli/fixtures/colorsys.scm
+++ b/test/apps/cli/fixtures/colorsys.scm
@@ -1,0 +1,9 @@
+; Regression for #265: colorsys is a CommonJS module, and under the CLI's
+; Node/tsx ESM interop its exports land on the namespace default. rgb->hsv and
+; hsv->rgb both route through colorsys, so they threw
+; "colorsys.rgbToHsv is not a function" here until color.ts switched to a
+; default import. This tier is the one that actually exercises that path (the
+; Vite/jsdom suite resolves colorsys regardless).
+(import image)
+(rgb->hsv (rgb 255 0 0))
+(hsv->rgb (hsv 0 100 100))

--- a/test/libs/image.test.ts
+++ b/test/libs/image.test.ts
@@ -384,7 +384,28 @@ describe('color', () => {
     test.skip('hsv-alpha')
     test.skip('hsv-complement')
     test.skip('hsv->string')
-    test.skip('hsv->rgb')
+  })
+
+  // Regression for #265: hsv->rgb routes through the CommonJS colorsys module.
+  // With #250's hsv? binding fixed the contract layer is reachable, and with
+  // color.ts's default import colorsys resolves -- so the full Scamper-level
+  // path converts a fully-saturated red hue back to rgb red. (This runs in the
+  // Vite/jsdom tier, which resolves colorsys regardless; the CLI tier in
+  // test/apps/cli exercises the Node/tsx path that the import fix actually
+  // repaired.)
+  test('hsv->rgb', async () => {
+    expect(
+      await runProgram(`
+(import image)
+(hsv->rgb (hsv 0 100 100))
+(hsv->rgb (hsv 0 100 100 128))
+(hsv->rgb 5)
+`),
+    ).toEqual([
+      '(rgba 255 0 0 255)',
+      '(rgba 255 0 0 128)',
+      'Runtime error [196:1-196:43]: (error) expected a hsv, received number',
+    ])
   })
 
   test('rgb-darker', async () => {


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

**The bug:** `colorsys` is a CommonJS module. Under the Node/tsx ESM interop the CLI uses, `import * as colorsys from 'colorsys'` places the module's exports on the namespace's `default` binding, so `colorsys.rgbToHsv` / `colorsys.hsvToRgb` are `undefined` (the functions live on `colorsys.default`). `rgb->hsv` and `hsv->rgb` therefore threw `TypeError: colorsys.rgbToHsv is not a function` at runtime. The Vite/browser tier already resolved colorsys, so only the Node/tsx (CLI) path was broken.

**The fix:** switch `src/js/image/color.ts` to a default import — `import colorsys from 'colorsys'` — which binds `colorsys` to the CJS `module.exports` object where the functions actually live. The two call sites (`image_rgbToHsv`, `image_hsvToRgb`) are unchanged. `esModuleInterop` synthesizes the default binding from the existing `colorsys.d.ts` named exports, so no `.d.ts` change was needed and `npm run typecheck` is clean.

Before → after for `(rgb->hsv (rgb 255 0 0))`: `TypeError: colorsys.rgbToHsv is not a function` → `(hsv 0 100 100 255)`. Likewise `(hsv->rgb (hsv 0 100 100))`: `colorsys.hsvToRgb is not a function` → `(rgba 255 0 0 255)`.

**Regression tests:**
- CLI tier (the path the fix actually repaired): new fixture `test/apps/cli/fixtures/colorsys.scm` + test `rgb->hsv and hsv->rgb resolve colorsys under Node/tsx (#265)` in `test/apps/cli/cli.test.ts`, which spawns the real `tsx src/app/cli/index.ts`. Verified this test fails on the old `import * as` and passes on the fix.
- jsdom tier: un-skipped the `hsv->rgb` case in `test/libs/image.test.ts` (previously a bodiless `test.skip` under "blocked by #250") — now that #250's `hsv?` binding is fixed the Scamper contract path is reachable, so it asserts the full `(hsv->rgb (hsv 0 100 100))` → red conversion. (The pre-existing active `rgb->hsv` test already covered that direction in this tier.) The remaining #250 placeholder skips are left for that issue.

**Validation:**
- `npm run validate`: typecheck PASS, test PASS (989 passed / 2 expected-fail / 29 skipped / 64 todo), lint PASS (0 errors; ~1063 pre-existing warnings).
- `npm run test:browser`: 59 passed / 3 skipped under Chromium — the browser tier's `rgb->hsv`, `hsv->rgb`, and `colorToRgb via colorsys` tests all pass, confirming the fix works in both tiers.

Fixes #265