### PR TITLE
Fix autosave-vs-delete race that blocked file deletion (#184)

### DIFF
--- a/src/app/web/components/IdeApp.vue
+++ b/src/app/web/components/IdeApp.vue
@@ -13,6 +13,7 @@ import { provideScamperSession } from '../composables/use-scamper-session'
 import Scamper from '../../../scamper'
 import * as FS from '../../../fs'
 import { FileEntry } from '../../../fs/fs'
+import { FileSession } from '../file-session'
 import QueryGhostLine from './query/QueryGhostLine.vue'
 import ExpandedQueryModal from './query/ExpandedQueryModal.vue'
 
@@ -35,7 +36,7 @@ const appVersion = `(${APP_VERSION})`
 // ---------- mutable IDE state (non-reactive where not needed in template) ----
 
 let fs: FS.t | null = null
-let autosaveId = -1
+let fileSession: FileSession | null = null
 let config: Config = DEFAULT_CONFIG
 let isLoadingFile = false
 
@@ -93,16 +94,11 @@ async function loadConfig() {
 // ---------- autosave ----------
 
 function startAutosaving() {
-  if (autosaveId === -1) {
-    autosaveId = window.setInterval(() => {
-      void saveCurrentFile()
-    }, 3000)
-  }
+  fileSession?.startAutosave()
 }
 
 function stopAutosaving() {
-  window.clearInterval(autosaveId)
-  autosaveId = -1
+  fileSession?.stopAutosave()
 }
 
 // ---------- dirty tracking ----------
@@ -123,13 +119,15 @@ function isEditorLoaded(): boolean {
 }
 
 async function saveCurrentFile() {
-  if (!currentFile.value || !fs || isLoadingFile) return
-  if (!isEditorLoaded()) return
-  try {
-    await fs.saveFile(currentFile.value, editor().getDoc())
-  } catch (e) {
-    if (e instanceof Error) displayError(e.message)
-  }
+  if (!fileSession || isLoadingFile) return
+  await fileSession.save()
+}
+
+// Keeps the reactive `currentFile` ref (read by the template) in sync with the
+// file session's notion of the open file (used by its race-safe save/delete).
+function setCurrentFile(filename: string | null) {
+  currentFile.value = filename
+  fileSession?.setCurrentFile(filename)
 }
 
 async function switchToFile(filename: string): Promise<void> {
@@ -139,9 +137,9 @@ async function switchToFile(filename: string): Promise<void> {
   session.stopAll()
   if (currentFile.value !== null) await saveCurrentFile()
 
-  currentFile.value = filename
+  setCurrentFile(filename)
   try {
-    const src = await fs.loadFile(currentFile.value)
+    const src = await fs.loadFile(filename)
     editor().initializeDoc(src)
   } catch (e) {
     if (e instanceof Error) displayError(`${e.message}\n\n${e.stack ?? ''}`)
@@ -203,37 +201,40 @@ async function handleCreate() {
 }
 
 async function handleUploadFile(file: File) {
+  if (!fs || !fileSession) return
   const content = await file.text()
   const filename = file.name
-  if (await fs?.fileExists(filename)) {
+  if (await fs.fileExists(filename)) {
     const ok = confirm(
       `File "${filename}" already exists. Do you want to overwrite it?`,
     )
     if (!ok) return
-    stopAutosaving()
-    await fs?.deleteFile(filename)
+    // Serialize the overwrite against any in-flight save so the writable is
+    // closed before the file is removed (see file-session.ts).
+    await fileSession.deleteFile(filename)
   }
-  await fs?.saveFile(filename, content)
-  currentFile.value = null
+  await fs.saveFile(filename, content)
+  setCurrentFile(null)
   await switchToFile(filename)
 }
 
 async function handleFileDrop(droppedFiles: FileList) {
+  if (!fs || !fileSession) return
   stopAutosaving()
   for (const file of droppedFiles) {
     try {
       const content = await file.text()
       const filename = file.name
-      if (await fs?.fileExists(filename)) {
+      if (await fs.fileExists(filename)) {
         const ok = confirm(
           `File "${filename}" already exists. Do you want to overwrite it?`,
         )
         if (!ok) continue
-        stopAutosaving()
-        await fs?.deleteFile(filename)
+        // Serialize the overwrite against any in-flight save (see above).
+        await fileSession.deleteFile(filename)
       }
-      await fs?.saveFile(filename, content)
-      currentFile.value = null
+      await fs.saveFile(filename, content)
+      setCurrentFile(null)
       await switchToFile(filename)
     } catch (e) {
       if (e instanceof Error)
@@ -243,18 +244,19 @@ async function handleFileDrop(droppedFiles: FileList) {
 }
 
 async function handleRename() {
-  if (!currentFile.value) return
-  const newName = prompt(`Enter a new filename for ${currentFile.value}`)
-  if (newName === null || newName === currentFile.value) return
+  if (!currentFile.value || !fileSession) return
+  const from = currentFile.value
+  const newName = prompt(`Enter a new filename for ${from}`)
+  if (newName === null || newName === from) return
   if (await fs?.fileExists(newName)) {
     alert(`File ${newName} already exists!`)
   } else {
     try {
-      stopAutosaving()
       // N.B., renaming closes the fs worker's handle to the current file,
-      // so we load it fresh afterwards.
-      await fs?.renameFile(currentFile.value, newName)
-      currentFile.value = null
+      // so we load it fresh afterwards. The session serializes against any
+      // in-flight save first.
+      await fileSession.renameFile(from, newName)
+      setCurrentFile(null)
       await switchToFile(newName)
     } catch (e) {
       if (e instanceof Error) displayError(e.message)
@@ -263,12 +265,19 @@ async function handleRename() {
 }
 
 async function handleDelete() {
-  if (!currentFile.value) return
-  const ok = confirm(`Are you sure you want to delete ${currentFile.value}?`)
+  if (!currentFile.value || !fileSession) return
+  const target = currentFile.value
+  const ok = confirm(`Are you sure you want to delete ${target}?`)
   if (!ok) return
-  stopAutosaving()
-  await fs?.deleteFile(currentFile.value)
-  currentFile.value = null
+  try {
+    // The session stops autosave and awaits any in-flight save before removing
+    // the file, so an open OPFS writable can't block the delete (issue #184).
+    await fileSession.deleteFile(target)
+  } catch (e) {
+    if (e instanceof Error) displayError(`Failed to delete ${target}: ${e.message}`)
+    return
+  }
+  setCurrentFile(null)
   editor().initializeDummyDoc()
   config.lastOpenedFilename = null
   session.stopAll()
@@ -334,6 +343,15 @@ const beforeUnloadWrapper = (e: Event) => {
 onMounted(async () => {
   await FS.initialize()
   fs = FS.getFS()
+  fileSession = new FileSession(
+    fs,
+    { getDoc: () => editor().getDoc(), isEditorLoaded },
+    {
+      onSaveError: (message) => {
+        displayError(message)
+      },
+    },
+  )
 
   const obtainedLock = await Lock.acquireLockFile(fs)
   if (!obtainedLock) {

--- a/src/app/web/file-session.ts
+++ b/src/app/web/file-session.ts
@@ -1,0 +1,159 @@
+import type * as FS from '../../fs'
+
+/**
+ * The FileSession owns the IDE's file lifecycle: which file is currently open,
+ * the autosave timer, and the save/delete/rename operations that read from the
+ * editor and write to the file system.
+ *
+ * The key invariant it enforces is that a delete (or a delete-before-overwrite
+ * during rename/upload) always waits for any in-flight save to settle before
+ * removing the file. On OPFS, an in-flight save holds a writable lock on the
+ * file, so removing it mid-save throws `NoModificationAllowedError` and the
+ * delete silently fails. Serializing here fixes both file-system backends
+ * uniformly (see issue #184).
+ *
+ * The session depends only on an injected `FS.t` and small editor callbacks, so
+ * it is framework-free and unit-testable without mounting a Vue component.
+ */
+
+/** Editor callbacks the session reads from when saving. */
+export interface EditorHooks {
+  /** @returns the current document text in the editor */
+  getDoc: () => string
+  /** @returns true iff the editor is loaded and safe to read from */
+  isEditorLoaded: () => boolean
+}
+
+export interface FileSessionOptions {
+  /** Autosave interval in milliseconds. */
+  autosaveIntervalMs?: number
+  /** Called when a save fails so the host can surface the error. */
+  onSaveError?: (message: string) => void
+}
+
+const DEFAULT_AUTOSAVE_INTERVAL_MS = 3000
+
+export class FileSession {
+  private fs: FS.t
+  private editor: EditorHooks
+  private autosaveIntervalMs: number
+  private onSaveError?: (message: string) => void
+
+  private currentFile: string | null = null
+  private autosaveId: ReturnType<typeof setInterval> | null = null
+  // The promise of the save currently writing to disk, if any. Delete/rename
+  // await this so the writable is closed before the file is removed.
+  private inFlightSave: Promise<void> | null = null
+
+  constructor(
+    fs: FS.t,
+    editor: EditorHooks,
+    options: FileSessionOptions = {},
+  ) {
+    this.fs = fs
+    this.editor = editor
+    this.autosaveIntervalMs =
+      options.autosaveIntervalMs ?? DEFAULT_AUTOSAVE_INTERVAL_MS
+    this.onSaveError = options.onSaveError
+  }
+
+  /** @returns the name of the currently open file, or null if none. */
+  getCurrentFile(): string | null {
+    return this.currentFile
+  }
+
+  /** Sets the currently open file without touching the file system. */
+  setCurrentFile(filename: string | null): void {
+    this.currentFile = filename
+  }
+
+  // ---------- autosave ----------
+
+  /** Starts the autosave timer if it isn't already running. */
+  startAutosave(): void {
+    this.autosaveId ??= setInterval(() => {
+      void this.save()
+    }, this.autosaveIntervalMs)
+  }
+
+  /**
+   * Stops the autosave timer. Note this does NOT wait for an in-flight save;
+   * callers that need the save to finish should `await settle()`.
+   */
+  stopAutosave(): void {
+    if (this.autosaveId !== null) {
+      clearInterval(this.autosaveId)
+      this.autosaveId = null
+    }
+  }
+
+  /** @returns true iff the autosave timer is currently running. */
+  isAutosaving(): boolean {
+    return this.autosaveId !== null
+  }
+
+  // ---------- saving ----------
+
+  /**
+   * Saves the current file, coalescing with any in-flight save so at most one
+   * write is outstanding at a time. Resolves once the write has settled.
+   */
+  async save(): Promise<void> {
+    if (this.inFlightSave) {
+      await this.inFlightSave
+      return
+    }
+    const filename = this.currentFile
+    if (filename === null || !this.editor.isEditorLoaded()) return
+
+    const doc = this.editor.getDoc()
+    this.inFlightSave = (async () => {
+      try {
+        await this.fs.saveFile(filename, doc)
+      } catch (e) {
+        if (e instanceof Error) this.onSaveError?.(e.message)
+      }
+    })()
+    try {
+      await this.inFlightSave
+    } finally {
+      this.inFlightSave = null
+    }
+  }
+
+  /** Awaits any in-flight save so its writable is closed. */
+  async settle(): Promise<void> {
+    if (this.inFlightSave) await this.inFlightSave
+  }
+
+  // ---------- deleting ----------
+
+  /**
+   * Deletes `filename`, first stopping autosave and awaiting any in-flight save
+   * so its writable is closed (otherwise OPFS's `removeEntry` throws
+   * `NoModificationAllowedError`). Nulls the current file before the removal so
+   * a save that starts afterwards no-ops and cannot recreate the file. Errors
+   * are surfaced (rethrown) rather than swallowed.
+   */
+  async deleteFile(filename: string): Promise<void> {
+    this.stopAutosave()
+    await this.settle()
+    if (this.currentFile === filename) this.currentFile = null
+    await this.fs.deleteFile(filename)
+  }
+
+  // ---------- renaming ----------
+
+  /**
+   * Renames the current file to `newName`, serializing against any in-flight
+   * save the same way `deleteFile` does (renaming closes the fs handle to the
+   * source file). Updates the current file to the new name on success.
+   */
+  async renameFile(from: string, to: string): Promise<void> {
+    this.stopAutosave()
+    await this.settle()
+    if (this.currentFile === from) this.currentFile = null
+    await this.fs.renameFile(from, to)
+    this.currentFile = to
+  }
+}

--- a/test/apps/web/file-session.test.ts
+++ b/test/apps/web/file-session.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import type { FileEntry, FS } from '../../../src/fs/fs'
+import { FileSession } from '../../../src/app/web/file-session'
+
+/** A deferred promise handle used to control when a save "settles". */
+function defer(): { promise: Promise<void>; resolve: () => void; reject: (e: unknown) => void } {
+  let resolve!: () => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+/**
+ * An in-memory fake FS whose `saveFile` can be held pending to model an open
+ * writable stream. When `lockOnSave` is true it behaves like OPFS: while a save
+ * is in flight (writable open) the file is locked, and `deleteFile` throws
+ * `NoModificationAllowedError`. When false it behaves like Node's lock-free
+ * `fs.unlink`, so the module can be proven filesystem-agnostic.
+ */
+class FakeFS implements FS {
+  files = new Map<string, string>()
+  // The pending save currently holding the writable open, if any.
+  private openSave: { filename: string; deferred: ReturnType<typeof defer> } | null = null
+  saveCalls: string[] = []
+  deleteCalls: string[] = []
+
+  constructor(private lockOnSave: boolean) {}
+
+  /** Resolves the currently-open save, closing its writable. */
+  closeOpenSave(): void {
+    this.openSave?.deferred.resolve()
+  }
+
+  hasOpenSave(): boolean {
+    return this.openSave !== null
+  }
+
+  async getFileList(): Promise<FileEntry[]> {
+    return [...this.files.keys()].map((name) => ({
+      name,
+      preview: null,
+      isDirectory: false,
+    }))
+  }
+
+  async fileExists(filename: string): Promise<boolean> {
+    return this.files.has(filename)
+  }
+
+  async loadFile(filename: string): Promise<string> {
+    const contents = this.files.get(filename)
+    if (contents === undefined) throw new Error(`No such file: ${filename}`)
+    return contents
+  }
+
+  async saveFile(filename: string, contents: string): Promise<void> {
+    this.saveCalls.push(filename)
+    const deferred = defer()
+    this.openSave = { filename, deferred }
+    // The write only commits once the "writable" is closed (deferred resolves).
+    await deferred.promise
+    this.files.set(filename, contents)
+    this.openSave = null
+  }
+
+  async deleteFile(filename: string): Promise<void> {
+    this.deleteCalls.push(filename)
+    if (this.lockOnSave && this.openSave?.filename === filename) {
+      const err = new Error('The file is locked.')
+      err.name = 'NoModificationAllowedError'
+      throw err
+    }
+    this.files.delete(filename)
+  }
+
+  async renameFile(from: string, to: string): Promise<void> {
+    if (this.lockOnSave && this.openSave?.filename === from) {
+      const err = new Error('The file is locked.')
+      err.name = 'NoModificationAllowedError'
+      throw err
+    }
+    const contents = this.files.get(from)
+    if (contents === undefined) throw new Error(`No such file: ${from}`)
+    this.files.set(to, contents)
+    this.files.delete(from)
+  }
+}
+
+const editor = {
+  getDoc: () => 'some contents',
+  isEditorLoaded: () => true,
+}
+
+describe.each([
+  { label: 'OPFS-like (save holds a writable lock)', lockOnSave: true },
+  { label: 'Node-like (lock-free)', lockOnSave: false },
+])('FileSession delete race — $label', ({ lockOnSave }) => {
+  let fs: FakeFS
+  let s: FileSession
+
+  beforeEach(() => {
+    fs = new FakeFS(lockOnSave)
+    s = new FileSession(fs, editor)
+  })
+
+  test('delete during an in-flight save waits for the save then removes the file', async () => {
+    fs.files.set('a.scm', 'old')
+    s.setCurrentFile('a.scm')
+
+    // Kick off a save whose writable stays open (models autosave firing).
+    const savePromise = s.save()
+    // Let the save begin so the writable is registered as open.
+    await Promise.resolve()
+    expect(fs.hasOpenSave()).toBe(true)
+
+    // Delete while the save is in flight. It must NOT reject/throw and must not
+    // leave the file behind. Close the writable shortly after so the delete's
+    // awaited settle() can proceed.
+    const deletePromise = s.deleteFile('a.scm')
+    fs.closeOpenSave()
+
+    await expect(deletePromise).resolves.toBeUndefined()
+    await savePromise
+
+    // The file is actually gone (the bug was that it persisted).
+    expect(fs.files.has('a.scm')).toBe(false)
+    // Delete waited for the save, so it was never attempted on a locked file.
+    expect(fs.deleteCalls).toEqual(['a.scm'])
+    // The current file was cleared.
+    expect(s.getCurrentFile()).toBeNull()
+    // Autosave was stopped by the delete.
+    expect(s.isAutosaving()).toBe(false)
+  })
+
+  test('normal delete with no in-flight save removes the file', async () => {
+    fs.files.set('a.scm', 'contents')
+    s.setCurrentFile('a.scm')
+
+    await s.deleteFile('a.scm')
+
+    expect(fs.files.has('a.scm')).toBe(false)
+    expect(s.getCurrentFile()).toBeNull()
+  })
+
+  test('a save that starts after delete does not recreate the file', async () => {
+    fs.files.set('a.scm', 'contents')
+    s.setCurrentFile('a.scm')
+
+    await s.deleteFile('a.scm')
+    expect(s.getCurrentFile()).toBeNull()
+
+    // Autosave fires again after the delete; with no current file it no-ops.
+    await s.save()
+    fs.closeOpenSave()
+
+    expect(fs.files.has('a.scm')).toBe(false)
+    expect(fs.saveCalls).toEqual([])
+  })
+
+  test('delete errors are surfaced, not swallowed', async () => {
+    fs.files.set('a.scm', 'contents')
+    s.setCurrentFile('a.scm')
+    const boom = new Error('disk on fire')
+    vi.spyOn(fs, 'deleteFile').mockRejectedValueOnce(boom)
+
+    await expect(s.deleteFile('a.scm')).rejects.toBe(boom)
+  })
+
+  test('overwrite-delete of a non-current file serializes against a save of the current file', async () => {
+    fs.files.set('current.scm', 'cur')
+    fs.files.set('victim.scm', 'old')
+    s.setCurrentFile('current.scm')
+
+    const savePromise = s.save()
+    await Promise.resolve()
+    expect(fs.hasOpenSave()).toBe(true)
+
+    // Deleting a different file (upload overwrite path) still awaits settle().
+    const deletePromise = s.deleteFile('victim.scm')
+    fs.closeOpenSave()
+    await expect(deletePromise).resolves.toBeUndefined()
+    await savePromise
+
+    expect(fs.files.has('victim.scm')).toBe(false)
+    // Deleting a non-current file leaves the current file intact.
+    expect(s.getCurrentFile()).toBe('current.scm')
+  })
+})
+
+describe('FileSession autosave lifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('start/stop autosave toggles the timer and fires saves', async () => {
+    const fs = new FakeFS(true)
+    fs.files.set('a.scm', 'x')
+    const s = new FileSession(fs, editor, { autosaveIntervalMs: 1000 })
+    s.setCurrentFile('a.scm')
+
+    expect(s.isAutosaving()).toBe(false)
+    s.startAutosave()
+    expect(s.isAutosaving()).toBe(true)
+    // Starting twice does not stack timers.
+    s.startAutosave()
+
+    vi.advanceTimersByTime(1000)
+    expect(fs.saveCalls).toEqual(['a.scm'])
+
+    s.stopAutosave()
+    expect(s.isAutosaving()).toBe(false)
+    vi.advanceTimersByTime(5000)
+    expect(fs.saveCalls).toEqual(['a.scm'])
+  })
+})
+
+describe('FileSession rename', () => {
+  test('rename during an in-flight save waits then renames and updates current file', async () => {
+    const fs = new FakeFS(true)
+    fs.files.set('a.scm', 'old')
+    const s = new FileSession(fs, editor)
+    s.setCurrentFile('a.scm')
+
+    const savePromise = s.save()
+    await Promise.resolve()
+    expect(fs.hasOpenSave()).toBe(true)
+
+    const renamePromise = s.renameFile('a.scm', 'b.scm')
+    fs.closeOpenSave()
+    await expect(renamePromise).resolves.toBeUndefined()
+    await savePromise
+
+    expect(fs.files.has('a.scm')).toBe(false)
+    expect(fs.files.has('b.scm')).toBe(true)
+    expect(s.getCurrentFile()).toBe('b.scm')
+    expect(s.isAutosaving()).toBe(false)
+  })
+})


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

## Problem

Deleting a file in the IDE while an autosave was in flight silently failed, so the file persisted across reloads (issue #184; the runner is incidental — it never writes files).

Autosave fires `void saveCurrentFile()` on a 3s timer (fire-and-forget). On OPFS, `saveFile` opens a `createWritable()` stream that **holds a lock on the file** until `close()`. The old `handleDelete` called `stopAutosaving()` (which only clears the interval — it does not wait for an in-flight save) and then `deleteFile`. If a save's writable was still open, OPFS's `removeEntry` threw **`NoModificationAllowedError`**, and because there was **no try/catch around the delete**, the error was swallowed and the UI proceeded as if the delete succeeded. Deterministic whenever a save is in flight at delete time.

## Fix

- Extract the IDE file lifecycle (current filename, autosave timer, in-flight-save promise, save/delete/rename) into a small, framework-free, unit-testable module: `src/app/web/file-session.ts` (`FileSession`). It depends only on an injected `FS.t` and two editor callbacks (`getDoc`, `isEditorLoaded`), so it can be tested without mounting a Vue component.
- `deleteFile`/`renameFile` now **stop autosave, await any in-flight save (so its writable is closed), then remove/rename the file**, and errors are **surfaced (rethrown), not swallowed**. The current file is nulled before removal so a save that starts afterwards no-ops and cannot recreate the file.
- `IdeApp.vue` routes **all** delete/overwrite/rename paths through the module: `handleDelete`, `handleRename`, `handleUploadFile`, `handleFileDrop`. `currentFile` stays reactive via a small `setCurrentFile` sync helper.
- The `FS.t` interface and the individual FS impls are unchanged. The serialization lives at the IDE lifecycle layer, so it is **filesystem-agnostic** — it fixes both backends (`src/fs/opfs.ts` and `src/fs/node.ts`) uniformly. (Node's `fs.unlink` has no lock, but serializing is still correct there and does not regress it.)

## Testing

- **Unit test** (`test/apps/web/file-session.test.ts`, part of `npm run validate`) drives a fake `FS.t` whose `saveFile` stays pending to model an open writable. It runs **parameterized against both an OPFS-like backend** (save holds a writable lock; `deleteFile` of a locked file throws `NoModificationAllowedError`) **and a Node-like lock-free backend**, proving the module is filesystem-agnostic. Cases:
  - delete during an in-flight save waits for the save, then actually removes the file (fake FS reports it gone) and clears the current file;
  - normal delete with no in-flight save;
  - a save that starts after delete does not recreate the file;
  - delete errors are surfaced, not swallowed;
  - overwrite-delete of a non-current file serializes against a save of the current file;
  - autosave start/stop lifecycle; and rename-during-in-flight-save.
  Reverting the `await settle()` serialization makes these tests fail, confirming they guard the fix.
- **Live Playwright re-verification** against the running dev server, reading OPFS via `navigator.storage.getDirectory()`:
  - OLD logic: `removeEntry` during an open writable throws `NoModificationAllowedError` and the file **is still present** (the bug).
  - FIXED logic: `FileSession.deleteFile` awaits the in-flight save, deletes cleanly (no error), and the file **is gone**; current file nulled.

`npm run validate` — typecheck: PASS, test: PASS, lint: PASS (0 errors).

Fixes #184
