### PR TITLE
Force save of current file when switching files (#238)

### DIFF
--- a/src/app/web/components/IdeApp.vue
+++ b/src/app/web/components/IdeApp.vue
@@ -131,15 +131,17 @@ function setCurrentFile(filename: string | null) {
 }
 
 async function switchToFile(filename: string): Promise<void> {
-  if (!fs) return
+  if (!fs || !fileSession) return
   isLoadingFile = true
   stopAutosaving()
   session.stopAll()
-  if (currentFile.value !== null) await saveCurrentFile()
 
-  setCurrentFile(filename)
   try {
-    const src = await fs.loadFile(filename)
+    // Forces a save of the outgoing file before loading the new one so a quick
+    // edit is never lost on switch (issue #238). The guarded saveCurrentFile()
+    // would no-op here because isLoadingFile is already set.
+    const src = await fileSession.switchTo(filename)
+    currentFile.value = filename
     editor().initializeDoc(src)
   } catch (e) {
     if (e instanceof Error) displayError(`${e.message}\n\n${e.stack ?? ''}`)

--- a/src/app/web/file-session.ts
+++ b/src/app/web/file-session.ts
@@ -126,6 +126,24 @@ export class FileSession {
     if (this.inFlightSave) await this.inFlightSave
   }
 
+  // ---------- switching ----------
+
+  /**
+   * Switches the open file to `filename`, forcing a save of the outgoing file
+   * BEFORE the new one is loaded so a quick edit is never lost on switch (issue
+   * #238). The save is forced (not skipped like an incidental lifecycle save)
+   * and coalesces with any in-flight save. The editor still holds the outgoing
+   * file's doc at this point, so `save()` writes the correct contents; the
+   * caller loads the returned source into the editor afterwards.
+   * @returns the contents of the newly-opened file.
+   */
+  async switchTo(filename: string): Promise<string> {
+    if (this.currentFile !== null) await this.save()
+    const src = await this.fs.loadFile(filename)
+    this.currentFile = filename
+    return src
+  }
+
   // ---------- deleting ----------
 
   /**

--- a/test/apps/web/file-session.test.ts
+++ b/test/apps/web/file-session.test.ts
@@ -220,6 +220,77 @@ describe('FileSession autosave lifecycle', () => {
   })
 })
 
+describe('FileSession switchTo (issue #238)', () => {
+  test('forces a save of the outgoing file before loading the new one', async () => {
+    const fs = new FakeFS(false)
+    fs.files.set('a.scm', 'a on disk')
+    fs.files.set('b.scm', 'b on disk')
+
+    // The editor holds an unsaved edit to the OUTGOING file (a.scm).
+    const mutableEditor = {
+      getDoc: () => 'a edited',
+      isEditorLoaded: () => true,
+    }
+    const s = new FileSession(fs, mutableEditor)
+    s.setCurrentFile('a.scm')
+
+    // switchTo awaits the forced outgoing save, whose writable stays open until
+    // we close it; do so once the save is in flight so the switch can proceed.
+    const switchPromise = s.switchTo('b.scm')
+    await Promise.resolve()
+    fs.closeOpenSave()
+    const src = await switchPromise
+
+    // The outgoing file's edit was persisted before the switch (the bug lost it).
+    expect(fs.files.get('a.scm')).toBe('a edited')
+    // The new file's contents are returned for the caller to load.
+    expect(src).toBe('b on disk')
+    // The session now tracks the new file.
+    expect(s.getCurrentFile()).toBe('b.scm')
+  })
+
+  test('saves the outgoing file BEFORE reading the new one', async () => {
+    const events: string[] = []
+    const fs = new FakeFS(false)
+    fs.files.set('a.scm', 'a on disk')
+    fs.files.set('b.scm', 'b on disk')
+    const saveSpy = vi.spyOn(fs, 'saveFile')
+    saveSpy.mockImplementation(async (filename: string, contents: string) => {
+      events.push(`save:${filename}`)
+      fs.files.set(filename, contents)
+    })
+    const loadSpy = vi.spyOn(fs, 'loadFile')
+    loadSpy.mockImplementation((filename: string) => {
+      events.push(`load:${filename}`)
+      return Promise.resolve(fs.files.get(filename) ?? '')
+    })
+
+    const s = new FileSession(fs, {
+      getDoc: () => 'a edited',
+      isEditorLoaded: () => true,
+    })
+    s.setCurrentFile('a.scm')
+
+    await s.switchTo('b.scm')
+
+    // The outgoing save must strictly precede the incoming load.
+    expect(events).toEqual(['save:a.scm', 'load:b.scm'])
+  })
+
+  test('does not save when no file is currently open', async () => {
+    const fs = new FakeFS(false)
+    fs.files.set('b.scm', 'b on disk')
+    const s = new FileSession(fs, editor)
+    // No current file (e.g. after a delete): nothing to save on switch.
+
+    const src = await s.switchTo('b.scm')
+
+    expect(fs.saveCalls).toEqual([])
+    expect(src).toBe('b on disk')
+    expect(s.getCurrentFile()).toBe('b.scm')
+  })
+})
+
 describe('FileSession rename', () => {
   test('rename during an in-flight save waits then renames and updates current file', async () => {
     const fs = new FakeFS(true)


### PR DESCRIPTION
_(This fix and report was created using Claude Code.)_

## Bug (#238)
Switching files via the file drawer silently discarded a quick unsaved edit to the outgoing file. In `IdeApp.vue`, `switchToFile` set `isLoadingFile = true` **before** calling the guarded `saveCurrentFile()`. That guard (`if (!fileSession || isLoadingFile) return`) bails while `isLoadingFile` is set, so the pre-switch save was a **no-op** — the new file's doc replaced the editor before the outgoing edit was ever written to disk.

## Fix
Add `FileSession.switchTo(filename)`, which **forces** a save of the outgoing file (coalescing with any in-flight save via the same path autosave uses) **before** loading the new file, then updates the session's current file and returns the new contents. `switchToFile` now delegates its save+load to `switchTo`.

- `isLoadingFile = true` is still set first, preserving the re-entrancy guard used by `handleSelectFile` (`if (!isLoadingFile) await switchToFile(...)`).
- The other guarded `saveCurrentFile()` callers (`handleRunWindow`, `handleVisibilityChange`, `handlePageHide`, `handleBeforeUnload`) are **unchanged**, so incidental lifecycle saves still skip writing a half-loaded doc during a load.
- Since the editor still holds the outgoing file's doc when `switchTo` runs, the forced save writes the correct (old-file) contents; the swap into the editor happens afterward.

## Regression test — unit tier
`test/apps/web/file-session.test.ts` → `describe('FileSession switchTo (issue #238)')`:
- asserts the outgoing file's edit is persisted on switch,
- asserts the outgoing `saveFile` strictly precedes the incoming `loadFile` (`['save:a.scm', 'load:b.scm']`),
- asserts no save is attempted when no file is open.

Verified **fail-before / pass-after**: reverting `switchTo` to the old ordering (outgoing save skipped) fails 2 of the 3 new tests; with the fix all pass. Part of `npm run validate` (typecheck/test/lint all PASS, 0 errors).

Fixes #238
