### PR TITLE
Fix #287: wire a Node file system into the CLI so imports resolve

### DIFF
--- a/src/app/cli/index.ts
+++ b/src/app/cli/index.ts
@@ -1,9 +1,12 @@
 import fs from 'fs'
+import path from 'node:path'
 import { parseArgs } from 'node:util'
 
 import type { ScamperDiagnostic } from '../../scheme/diagnostic'
 import { ConsoleOutput } from '../../lpm/output'
 import { compile } from '../../scheme'
+import { setFS } from '../../fs'
+import NodeFileSystem from '../../fs/node'
 import Scamper, { initialize } from '../../scamper'
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -41,6 +44,11 @@ if (values.help || positionals.length !== 1) {
 const filename = positionals[0]
 
 const src = fs.readFileSync(filename, 'utf-8')
+
+// Wire a Node-backed file system rooted at the checked file's directory so
+// scope checking and execution can resolve the program's sibling file imports
+// (getFS() is otherwise uninitialized outside the browser -- see #287).
+setFS(await NodeFileSystem.create(path.dirname(path.resolve(filename))))
 
 await initialize()
 

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -12,6 +12,15 @@ export async function initialize(): Promise<void> {
 }
 
 /**
+ * Installs `fs` as the global file system, replacing any existing instance.
+ * Used by non-browser hosts (e.g. the CLI) to wire in a file system other than
+ * the browser-only OPFS default.
+ */
+export function setFS(fs: FS): void {
+  instance = fs
+}
+
+/**
  * @returns a handle to the global file system, assumes that it has already
  *          been successfully initialized
  */

--- a/test/regressions/cli-check-file-imports.test.ts
+++ b/test/regressions/cli-check-file-imports.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { compile } from '../../src/scheme'
+import { setFS } from '../../src/fs'
+import NodeFileSystem from '../../src/fs/node'
+
+// Regression test for #287: `scamper --check foo.scm` (compile with
+// { scopeCheck: true }) could not scope-check any program that used a file
+// import. Scope checking resolves file imports through getFS(), but the CLI
+// never initialized a file system outside the browser, so getFS() threw "File
+// system not initialized" and the check bailed out without running.
+//
+// The fix lets a non-browser host install its own file system (setFS) and wires
+// a NodeFileSystem into the CLI, rooted at the checked file's directory. This
+// test exercises that path directly: with a Node-backed FS installed, a
+// file-importing program scope-checks like any other.
+
+describe('#287: scope-checking file imports outside the browser', () => {
+  let dir: string
+
+  beforeAll(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'scamper-287-'))
+    await writeFile(path.join(dir, 'bar.scm'), '(define helper 1)\n', 'utf-8')
+    // Mirror the CLI: install a Node-backed FS rooted at the file's directory.
+    setFS(await NodeFileSystem.create(dir))
+  })
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  test('a file import resolves and its names are in scope', async () => {
+    const { diagnostics } = await compile('(import "bar.scm")\n(display helper)', {
+      scopeCheck: true,
+    })
+    expect(diagnostics.map((d) => d.message)).toEqual([])
+  })
+
+  test('a name the imported file does not define is still flagged', async () => {
+    const { diagnostics } = await compile('(import "bar.scm")\n(display nope)', {
+      scopeCheck: true,
+    })
+    expect(diagnostics.map((d) => d.message)).toEqual([
+      "Undefined variable 'nope'",
+    ])
+  })
+})


### PR DESCRIPTION
_(Co-created with Claude Code)_

Fixes #287.

## Problem
`scamper --check foo.scm` runs the optional scope-check pass, which resolves file imports through `getFS()`. The CLI never initialized a file system outside the browser (`src/fs/index.ts`'s `initialize()` only creates a browser-only OPFS instance), so `getFS()` threw `File system not initialized` and any program containing a file import failed to check with `check failed: File system not initialized`. Import-free programs checked fine, so the common teaching case worked, but `--check` silently could not handle any file import.

## Fix
- Add `setFS(fs)` to the `fs` singleton (`src/fs/index.ts`) so a non-browser host can install its own file system.
- In the CLI (`src/app/cli/index.ts`), install a `NodeFileSystem` rooted at the checked file's directory before compiling. This also lets the CLI resolve imports when *running* programs, not just `--check`.

## Verification
- New regression test `test/regressions/cli-check-file-imports.test.ts`: with a Node-backed FS installed, a file-importing program scope-checks cleanly and an undefined name is still flagged.
- End-to-end: `scamper --check` on a program that imports a sibling file now exits 0 with no diagnostics; a genuine undefined-variable reference is still reported at the correct location with exit 1.
- `npm run validate` passes (typecheck, full test suite, lint).