### PR TITLE
Fix #285: surface failures in deep transitive imports

### DIFF
--- a/src/scheme/scope.ts
+++ b/src/scheme/scope.ts
@@ -458,7 +458,18 @@ export async function scopeCheckProgram(
   prog: A.Prog,
 ) {
   // Ensure every imported file's symbols are in the DB before we resolve names.
-  await SymbolDB.loadTransitiveImports(prog)
+  // Failures found below the top level are reported here (a direct import's
+  // failure is reported by its own statement in scopeCheckStmt).
+  for (const f of await SymbolDB.loadTransitiveImports(prog)) {
+    diagnostics.push(
+      mkDiagnostic(
+        'Scope',
+        'warning',
+        `Could not load module '${f.filename}' (imported by '${f.importer}')`,
+        f.range,
+      ),
+    )
+  }
   const globals: string[] = []
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   for (const id of SymbolDB.get('runtime')!) {

--- a/src/scheme/symbol-db.ts
+++ b/src/scheme/symbol-db.ts
@@ -1,6 +1,7 @@
 import builtinLibs from '../lib'
 import * as A from './ast'
 import * as L from '../lpm/lang'
+import { Range } from '../lpm'
 import { ScamperDiagnostic, diagnosticToError } from './diagnostic.js'
 import { parseProgramFromSource } from './lezer-bridge'
 
@@ -81,15 +82,26 @@ export async function loadModuleFromFile(filename: string): Promise<void> {
   table().set(filename, moduleIdentifiers(await parseFile(filename)))
 }
 
+/** @returns the file-import statements in `prog`, in source order */
+function fileImportStmts(prog: A.Prog): A.Import[] {
+  return prog.filter(
+    (stmt): stmt is A.Import => stmt.tag === 'import' && stmt.kind === 'file',
+  )
+}
+
 /** @returns the file-system modules directly imported by `prog` */
 export function fileImports(prog: A.Prog): string[] {
-  const imports: string[] = []
-  for (const stmt of prog) {
-    if (stmt.tag === 'import' && stmt.kind === 'file') {
-      imports.push(stmt.module)
-    }
-  }
-  return imports
+  return fileImportStmts(prog).map((stmt) => stmt.module)
+}
+
+/** A file-import failure discovered while loading the transitive import graph. */
+export interface ImportFailure {
+  /** The module that could not be loaded or parsed. */
+  filename: string
+  /** The file whose import statement directly referenced it. */
+  importer: string
+  /** The range of the top-level import that transitively pulled it in. */
+  range: Range
 }
 
 /**
@@ -116,15 +128,33 @@ export async function transitiveFileImports(prog: A.Prog): Promise<string[]> {
 }
 
 /**
- * Loads every file transitively imported by `prog` into the DB, best-effort:
- * a module that is missing or fails to parse is skipped (its symbols simply
- * won't be available). Callers detect a skipped module by its absent DB entry
- * and report it with the import's own source range (see scope.ts).
+ * Loads every file transitively imported by `prog` into the DB. A module that
+ * is missing or fails to parse is skipped (its symbols won't be available).
+ *
+ * The top-level program's own direct-import failures are reported separately by
+ * scope checking (which detects them via the absent DB entry and the import's
+ * own range -- see scope.ts). This function therefore collects only the
+ * failures found *below* the top level -- inside an imported file -- which
+ * nothing else surfaces, and returns them so the caller can report them.
+ *
+ * @returns the transitive (non-top-level) import failures encountered
  */
-export async function loadTransitiveImports(prog: A.Prog): Promise<void> {
+export async function loadTransitiveImports(
+  prog: A.Prog,
+): Promise<ImportFailure[]> {
+  const failures: ImportFailure[] = []
   const seen = new Set<string>()
-  const visit = async (p: A.Prog): Promise<void> => {
-    for (const filename of fileImports(p)) {
+  // `importer` is the file currently being visited (undefined for the top-level
+  // program); `origin` is the top-level import statement whose subtree we're
+  // descending (undefined at the top level). Both are set together exactly when
+  // we are below the top level.
+  const visit = async (
+    p: A.Prog,
+    importer: string | undefined,
+    origin: A.Import | undefined,
+  ): Promise<void> => {
+    for (const stmt of fileImportStmts(p)) {
+      const filename = stmt.module
       if (seen.has(filename)) {
         continue
       }
@@ -132,13 +162,20 @@ export async function loadTransitiveImports(prog: A.Prog): Promise<void> {
       try {
         const imported = await parseFile(filename)
         table().set(filename, moduleIdentifiers(imported))
-        await visit(imported)
+        await visit(imported, filename, origin ?? stmt)
       } catch {
-        // Best-effort: skip a missing / unparseable module (see above).
+        // A missing / unparseable module. Skip it, but if it is below the top
+        // level record the failure: the diagnostic points at the top-level
+        // import that pulled it in (a location in the program being checked)
+        // and names the broken file and its direct importer.
+        if (importer !== undefined && origin !== undefined) {
+          failures.push({ filename, importer, range: origin.range })
+        }
       }
     }
   }
-  await visit(prog)
+  await visit(prog, undefined, undefined)
+  return failures
 }
 
 /** @returns the identifiers for the given module, or undefined if absent */

--- a/test/regressions/deep-transitive-import-failure.test.ts
+++ b/test/regressions/deep-transitive-import-failure.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as fs from '../../src/fs'
+import { scopeCheckProgram } from '../../src/scheme/scope'
+import { expandProgram } from '../../src/scheme/expansion'
+import { parseProgramFromSource } from '../../src/scheme/lezer-bridge'
+import { ScamperDiagnostic } from '../../src/scheme/diagnostic'
+
+// Regression test for #285: a missing or unparseable module deep in the import
+// graph was skipped silently and never reported, even though a *direct* import
+// failure is reported. Scope checking only re-derived diagnostics for the
+// top-level program's own imports, so a failure below the first level produced
+// no error at all -- names a deep module should export went missing with no
+// explanation, surfacing later only as confusing "Undefined variable" errors.
+//
+// The fix has loadTransitiveImports collect below-top-level failures and
+// scopeCheckProgram surface them, pointing at the top-level import that pulled
+// the broken module in.
+
+function mockFS(files: Record<string, string>): void {
+  vi.spyOn(fs, 'getFS').mockReturnValue({
+    fileExists: (f: string) => Promise.resolve(f in files),
+    loadFile: (f: string) =>
+      f in files
+        ? Promise.resolve(files[f])
+        : Promise.reject(new Error(`no such file: ${f}`)),
+  } as unknown as ReturnType<typeof fs.getFS>)
+}
+
+async function scopeErrors(src: string): Promise<string[]> {
+  const errors: ScamperDiagnostic[] = []
+  const errs: ScamperDiagnostic[] = []
+  const prog = parseProgramFromSource(errs, src)
+  expect(errs, 'test source should parse cleanly').toEqual([])
+  await scopeCheckProgram(errors, expandProgram(prog))
+  return errors.map((e) => e.message)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('#285: deep transitive import failures are surfaced', () => {
+  test('an unparseable module one level down is reported', async () => {
+    mockFS({ 'a.scm': '(import "c.scm")\n(define fromA 1)', 'c.scm': '(1 2' })
+    expect(await scopeErrors('(import "a.scm")\nfromA')).toEqual([
+      "Could not load module 'c.scm' (imported by 'a.scm')",
+    ])
+  })
+
+  test('a missing module one level down is reported', async () => {
+    mockFS({ 'a.scm': '(import "gone.scm")\n(define fromA 1)' })
+    expect(await scopeErrors('(import "a.scm")\nfromA')).toEqual([
+      "Could not load module 'gone.scm' (imported by 'a.scm')",
+    ])
+  })
+
+  test('the failure names its direct importer but points at the top-level import', async () => {
+    // prog -> a.scm -> b.scm -> c.scm(broken): c.scm's direct importer is
+    // b.scm, but the reported location is the top-level `(import "a.scm")`.
+    mockFS({
+      'a.scm': '(import "b.scm")\n(define fromA 1)',
+      'b.scm': '(import "c.scm")\n(define fromB 2)',
+      'c.scm': '(1 2',
+    })
+    expect(await scopeErrors('(import "a.scm")\nfromA')).toEqual([
+      "Could not load module 'c.scm' (imported by 'b.scm')",
+    ])
+  })
+
+  test('a healthy transitive graph still reports nothing', async () => {
+    mockFS({
+      'a.scm': '(import "b.scm")\n(define fromA 1)',
+      'b.scm': '(define fromB 2)',
+    })
+    expect(await scopeErrors('(import "a.scm")\nfromA')).toEqual([])
+  })
+})

--- a/test/scheme/scope.test.ts
+++ b/test/scheme/scope.test.ts
@@ -375,11 +375,14 @@ describe('scope checking', () => {
         await scopeErrors('(import "utils.scm")\n((lambda (helper) helper) 5)'),
       ).toEqual([])
     })
-    test('a failure in a deep transitive import is not surfaced by the importer', async () => {
+    test('a failure in a deep transitive import is surfaced by the importer', async () => {
       // N.B., the program imports only a.scm (which parses); the broken c.scm
-      // it transitively pulls in is skipped best-effort and not reported here.
+      // it transitively pulls in is reported, pointing at the top-level import
+      // that pulled it in.
       mockFS({ 'a.scm': '(import "c.scm")\n(define fromA 1)', 'c.scm': '(1 2' })
-      expect(await scopeErrors('(import "a.scm")\nfromA')).toEqual([])
+      expect(await scopeErrors('(import "a.scm")\nfromA')).toEqual([
+        "Could not load module 'c.scm' (imported by 'a.scm')",
+      ])
     })
   })
 


### PR DESCRIPTION
_(Co-created with Claude Code)_

Fixes #285.

## Problem
A missing or unparseable module deep in the import graph was skipped silently and never reported, even though a *direct* import failure IS reported. `loadTransitiveImports` (`src/scheme/symbol-db.ts`) loaded the whole transitive graph best-effort and its `catch` swallowed any module that was missing or failed to parse. Scope checking only re-derives diagnostics for the top-level program's own imports, so a failure below the first level produced no error at all — names a deep module should export went missing with no explanation, surfacing later only as confusing `Undefined variable` errors far from the real cause.

## Fix
- `loadTransitiveImports` now collects the *below-top-level* failures (the broken module's name, its direct importer, and the top-level import that transitively pulled it in) and returns them. Top-level direct-import failures are still reported by `scopeCheckStmt` as before, so there is no double-reporting.
- `scopeCheckProgram` surfaces each collected failure as a `Scope` diagnostic: `Could not load module '<broken>' (imported by '<direct importer>')`.
- `makeScopeTreeFromProgram` continues to call `loadTransitiveImports` and simply ignores the returned failures (it degrades gracefully, as before).

## ⚠️ Queued for your review — one diagnostic-design choice
The issue suggested attaching *"the originating import's source range"*. That range lives inside the transitively-imported file, not the program being checked, so rendering it against the top-level source would point at the wrong location. Instead, the diagnostic **anchors on the top-level import statement** (a real location in the checked program) and names the broken module + its direct importer in the message. Also, missing vs. unparseable deep modules share one message (the direct-import path distinguishes them; the transitive path does not, to avoid a re-probe). Both are judgment calls on diagnostic UX — happy to adjust wording/behavior to your preference.

## Verification
- New regression test `test/regressions/deep-transitive-import-failure.test.ts`: unparseable-deep, missing-deep, multi-level importer attribution, and healthy-graph cases.
- Flipped `test/scheme/scope.test.ts`'s `'a failure in a deep transitive import ...'` from documenting the swallowed behavior to asserting the reported diagnostic.
- `npm run validate` passes (typecheck, full test suite, lint).