### PR TITLE
Fix #283 & #284: mutually-recursive top-level scoping

### DIFF
--- a/src/scheme/scope.ts
+++ b/src/scheme/scope.ts
@@ -343,82 +343,149 @@ function scopeCheckFunctionDoc(
 }
 
 /**
- * Scope-checks a single top-level statement, extending `globals` with any
- * names it introduces (a define/struct binder, or an import's bindings).
+ * Resolves an import to the identifiers it exports, reporting a diagnostic (and
+ * returning undefined) if the module is an unknown built-in, a missing file, or
+ * a file that failed to parse.
  */
-async function scopeCheckStmt(
+async function resolveImport(
+  diagnostics: ScamperDiagnostic[],
+  s: A.Import,
+): Promise<A.Identifier[] | undefined> {
+  if (s.kind === 'builtin') {
+    const mod = SymbolDB.get(s.module)
+    if (mod === undefined) {
+      diagnostics.push(
+        mkDiagnostic(
+          'Scope',
+          'warning',
+          `No such built-in library: '${s.module}'`,
+          s.range,
+        ),
+      )
+    }
+    return mod
+  }
+
+  // File import. N.B., import '../fs' lazily -- a static import would pull the
+  // OPFS implementation into this module's (widely-imported) graph and disturb
+  // tests that mock the file system (see symbol-db.ts).
+  const { getFS } = await import('../fs')
+  if (!(await getFS().fileExists(s.module))) {
+    diagnostics.push(
+      mkDiagnostic('Scope', 'warning', `File '${s.module}' does not exist`, s.range),
+    )
+    return undefined
+  }
+  // Imported files' symbols were loaded into the DB before scope checking (see
+  // SymbolDB.loadTransitiveImports). A missing DB entry for a file that exists
+  // means it failed to parse.
+  const mod = SymbolDB.get(s.module)
+  if (mod === undefined) {
+    diagnostics.push(
+      mkDiagnostic('Scope', 'warning', `Could not load module '${s.module}'`, s.range),
+    )
+  }
+  return mod
+}
+
+/**
+ * First pass over the top level: records every binding a statement introduces
+ * (a define's name, or an import's exported names) into `globals`, so that all
+ * top-level definitions are mutually visible regardless of their order in the
+ * program. This matches Racket module semantics -- every module-level
+ * definition and import shares one mutually-recursive scope covering the whole
+ * body -- so top-level mutual recursion and forward references resolve.
+ *
+ * It also resolves imports (reporting a missing / unparseable / unknown module)
+ * and flags name collisions. A collision between two *user-introduced* names --
+ * define/define, define/import, or import/import -- is reported symmetrically,
+ * regardless of order (Racket: "an identifier can be either imported or defined
+ * ... but not both"). `sources` maps each user-introduced name to what
+ * introduced it (`null` for a define, else the module name), so re-importing
+ * the same module is idempotent and a library import that merely re-binds a
+ * standard-library name is not spuriously flagged.
+ */
+async function collectTopLevelBindings(
   diagnostics: ScamperDiagnostic[],
   globals: string[],
+  sources: Map<string, string | null>,
   s: A.Stmt,
-) {
+): Promise<void> {
   switch (s.tag) {
     case 'import': {
-      if (s.kind === 'builtin') {
-        const mod = SymbolDB.get(s.module)
-        if (mod !== undefined) {
-          for (const id of mod) {
-            globals.push(id.name)
-          }
-        } else {
+      const ids = await resolveImport(diagnostics, s)
+      if (ids === undefined) {
+        return
+      }
+      for (const { name } of ids) {
+        const prev = sources.get(name)
+        if (prev !== undefined && prev !== s.module) {
+          // Already introduced by a define (null) or a different module.
           diagnostics.push(
             mkDiagnostic(
               'Scope',
               'warning',
-              `No such built-in library: '${s.module}'`,
+              `Global variable '${name}' is already defined`,
               s.range,
             ),
           )
+        } else if (prev === undefined) {
+          if (!globals.includes(name)) {
+            globals.push(name)
+          }
+          sources.set(name, s.module)
         }
-        return
-      }
-
-      // File import. N.B., import '../fs' lazily -- a static import would pull
-      // the OPFS implementation into this module's (widely-imported) graph and
-      // disturb tests that mock the file system (see symbol-db.ts).
-      const { getFS } = await import('../fs')
-      if (!(await getFS().fileExists(s.module))) {
-        diagnostics.push(
-          mkDiagnostic(
-            'Scope',
-            'warning',
-            `File '${s.module}' does not exist`,
-            s.range,
-          ),
-        )
-        return
-      }
-      // Imported files' symbols were loaded into the DB before scope checking
-      // (see SymbolDB.loadTransitiveImports). A missing DB entry for a file
-      // that exists means it failed to parse.
-      const mod = SymbolDB.get(s.module)
-      if (mod === undefined) {
-        diagnostics.push(
-          mkDiagnostic(
-            'Scope',
-            'warning',
-            `Could not load module '${s.module}'`,
-            s.range,
-          ),
-        )
-      } else {
-        mod.forEach((id) => globals.push(id.name))
+        // prev === s.module: the same module re-imported; idempotent, skip.
       }
       return
     }
 
     case 'define': {
-      if (globals.includes(s.name.name)) {
+      const name = s.name.name
+      if (globals.includes(name)) {
         diagnostics.push(
           mkDiagnostic(
             'Scope',
             'warning',
-            `Global variable '${s.name.name}' is already defined`,
+            `Global variable '${name}' is already defined`,
             s.range,
           ),
         )
       } else {
-        globals.push(s.name.name)
+        globals.push(name)
       }
+      // Mark as user-introduced so a later import of the same name collides.
+      sources.set(name, null)
+      return
+    }
+
+    case 'display':
+    case 'stmtexp':
+      // Introduces no top-level binding.
+      return
+
+    default:
+      throw new ICE(
+        'collectTopLevelBindings',
+        `Non-core statement encountered ${s.tag}`,
+      )
+  }
+}
+
+/**
+ * Second pass over the top level: scope-checks each statement's bodies (and a
+ * define's docstring) against the fully-populated `globals`.
+ */
+function scopeCheckStmtBodies(
+  diagnostics: ScamperDiagnostic[],
+  globals: string[],
+  s: A.Stmt,
+): void {
+  switch (s.tag) {
+    case 'import':
+      return
+
+    case 'define': {
       scopeCheckExp(diagnostics, globals, [], s.value)
       if (s.docComments) {
         // A malformed docstring is collected as a "Docstring" warning, the
@@ -433,25 +500,27 @@ async function scopeCheckStmt(
       return
     }
 
-    case 'display': {
+    case 'display':
       scopeCheckExp(diagnostics, globals, [], s.value)
       return
-    }
 
-    case 'stmtexp': {
+    case 'stmtexp':
       scopeCheckExp(diagnostics, globals, [], s.expr)
       return
-    }
 
     default:
-      throw new ICE('scopeCheckStmt', `Non-core statement encountered ${s.tag}`)
+      throw new ICE(
+        'scopeCheckStmtBodies',
+        `Non-core statement encountered ${s.tag}`,
+      )
   }
 }
 
 /**
  * Scope-checks an (expanded) program, collecting diagnostics. Loads every
  * transitively-imported file's symbols first, seeds the runtime and prelude
- * globals, then checks each statement in order.
+ * globals, then checks it in two passes so top-level definitions are mutually
+ * recursive: collect all top-level bindings, then check every statement's body.
  */
 export async function scopeCheckProgram(
   diagnostics: ScamperDiagnostic[],
@@ -459,7 +528,7 @@ export async function scopeCheckProgram(
 ) {
   // Ensure every imported file's symbols are in the DB before we resolve names.
   // Failures found below the top level are reported here (a direct import's
-  // failure is reported by its own statement in scopeCheckStmt).
+  // failure is reported when it is resolved in collectTopLevelBindings).
   for (const f of await SymbolDB.loadTransitiveImports(prog)) {
     diagnostics.push(
       mkDiagnostic(
@@ -479,7 +548,14 @@ export async function scopeCheckProgram(
   for (const id of SymbolDB.get('prelude')!) {
     globals.push(id.name)
   }
+  // Two passes so that top-level definitions are mutually recursive: collect
+  // every top-level binding first (also resolving imports and flagging name
+  // collisions), then check each statement's bodies against the full set.
+  const sources = new Map<string, string | null>()
   for (const s of prog) {
-    await scopeCheckStmt(diagnostics, globals, s)
+    await collectTopLevelBindings(diagnostics, globals, sources, s)
+  }
+  for (const s of prog) {
+    scopeCheckStmtBodies(diagnostics, globals, s)
   }
 }

--- a/test/regressions/top-level-mutual-recursion.test.ts
+++ b/test/regressions/top-level-mutual-recursion.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as fs from '../../src/fs'
+import { scopeCheckProgram } from '../../src/scheme/scope'
+import { expandProgram } from '../../src/scheme/expansion'
+import { parseProgramFromSource } from '../../src/scheme/lezer-bridge'
+import { ScamperDiagnostic } from '../../src/scheme/diagnostic'
+
+// Regression test for #283 and #284.
+//
+// #283: scope checking flagged forward references between top-level definitions,
+// so mutual recursion at the top level was rejected even though it is legal.
+// #284: a name collision between a `define` and an `import` was an error in one
+// ordering but silently accepted in the other.
+//
+// Both are resolved by treating the top level as one mutually-recursive scope
+// (Racket module semantics: every module-level definition and import shares one
+// scope covering the whole body, so position is not significant, and "an
+// identifier can be either imported or defined ... but not both").
+
+function mockFS(files: Record<string, string>): void {
+  vi.spyOn(fs, 'getFS').mockReturnValue({
+    fileExists: (f: string) => Promise.resolve(f in files),
+    loadFile: (f: string) =>
+      f in files
+        ? Promise.resolve(files[f])
+        : Promise.reject(new Error(`no such file: ${f}`)),
+  } as unknown as ReturnType<typeof fs.getFS>)
+}
+
+async function scopeErrors(src: string): Promise<string[]> {
+  const errors: ScamperDiagnostic[] = []
+  const parseErrs: ScamperDiagnostic[] = []
+  const prog = parseProgramFromSource(parseErrs, src)
+  expect(parseErrs, 'test source should parse cleanly').toEqual([])
+  await scopeCheckProgram(errors, expandProgram(prog))
+  return errors.map((e) => e.message)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('#283: top-level definitions are mutually recursive', () => {
+  test('mutual recursion between two top-level defines is accepted', async () => {
+    // N.B., fresh names -- redefining prelude bindings (e.g. even?/odd?) is a
+    // separate, still-flagged collision.
+    expect(
+      await scopeErrors(
+        '(define my-even? (lambda (n) (if (zero? n) #t (my-odd? (- n 1)))))\n' +
+          '(define my-odd? (lambda (n) (if (zero? n) #f (my-even? (- n 1)))))',
+      ),
+    ).toEqual([])
+  })
+
+  test('a forward reference to a later define resolves', async () => {
+    expect(await scopeErrors('x\n(define x 1)')).toEqual([])
+  })
+
+  test('a still-undefined name is reported', async () => {
+    expect(await scopeErrors('(define f (lambda () (ghost)))')).toEqual([
+      "Undefined variable 'ghost'",
+    ])
+  })
+})
+
+describe('#284: define/import collisions are order-independent', () => {
+  test('import then same-named define collides', async () => {
+    mockFS({ 'utils.scm': '(define helper 1)' })
+    expect(
+      await scopeErrors('(import "utils.scm")\n(define helper 2)'),
+    ).toEqual(["Global variable 'helper' is already defined"])
+  })
+
+  test('define then same-named import collides (symmetric)', async () => {
+    mockFS({ 'utils.scm': '(define helper 1)' })
+    expect(
+      await scopeErrors('(define helper 1)\n(import "utils.scm")'),
+    ).toEqual(["Global variable 'helper' is already defined"])
+  })
+
+  test('two imports of the same name from different modules collide', async () => {
+    mockFS({ 'x.scm': '(define dup 1)', 'y.scm': '(define dup 2)' })
+    expect(await scopeErrors('(import "x.scm")\n(import "y.scm")')).toEqual([
+      "Global variable 'dup' is already defined",
+    ])
+  })
+
+  test('re-importing the same module is not a collision', async () => {
+    mockFS({ 'utils.scm': '(define helper 1)' })
+    expect(
+      await scopeErrors('(import "utils.scm")\n(import "utils.scm")'),
+    ).toEqual([])
+  })
+
+  test('a library import overlapping a standard-library name is not flagged', async () => {
+    // Only *user-introduced* collisions are flagged; importing a module whose
+    // export happens to match a prelude/runtime name must stay clean.
+    expect(await scopeErrors('(import image)')).toEqual([])
+  })
+})

--- a/test/scheme/scope.test.ts
+++ b/test/scheme/scope.test.ts
@@ -224,20 +224,30 @@ describe('scope checking', () => {
         await scopeErrors('(match (cons 1 2) [(cons a b) 0] [_ a])'),
       ).toEqual(["Undefined variable 'a'"])
     })
-    test('a forward reference to a later define', async () => {
-      // N.B., documents current behavior: top-level definitions are only in
-      // scope from their definition onward, so forward references (and thus
-      // mutual recursion between top-level defines) are flagged.
-      expect(await scopeErrors('x\n(define x 1)')).toEqual([
-        "Undefined variable 'x'",
-      ])
+  })
+
+  describe('top-level definitions are mutually recursive', () => {
+    // Top-level bindings share one mutually-recursive scope (Racket module
+    // semantics), so their order in the program does not affect visibility.
+    test('a forward reference to a later define resolves', async () => {
+      expect(await scopeErrors('x\n(define x 1)')).toEqual([])
     })
-    test('mutual recursion between top-level defines is flagged', async () => {
+    test('mutual recursion between top-level defines is allowed', async () => {
       expect(
         await scopeErrors(
           '(define f (lambda (n) (g n)))\n(define g (lambda (n) (f n)))',
         ),
-      ).toEqual(["Undefined variable 'g'"])
+      ).toEqual([])
+    })
+    test('a define may reference a name defined later', async () => {
+      expect(
+        await scopeErrors('(define a (lambda () (b)))\n(define b (lambda () 1))'),
+      ).toEqual([])
+    })
+    test('a genuinely undefined name is still flagged', async () => {
+      expect(await scopeErrors('(define f (lambda (n) (nope n)))')).toEqual([
+        "Undefined variable 'nope'",
+      ])
     })
   })
 
@@ -363,10 +373,24 @@ describe('scope checking', () => {
         await scopeErrors('(import "utils.scm")\n(define helper 2)'),
       ).toEqual(["Global variable 'helper' is already defined"])
     })
-    test('an import after a same-named define is not flagged (current behavior)', async () => {
+    test('an import after a same-named define is also flagged (symmetric)', async () => {
+      // A define/import name clash is an error regardless of order (Racket: an
+      // identifier can be either imported or defined, but not both).
       mockFS({ 'utils.scm': '(define helper 1)' })
       expect(
         await scopeErrors('(define helper 1)\n(import "utils.scm")'),
+      ).toEqual(["Global variable 'helper' is already defined"])
+    })
+    test('two imports exporting the same name collide', async () => {
+      mockFS({ 'x.scm': '(define dup 1)', 'y.scm': '(define dup 2)' })
+      expect(await scopeErrors('(import "x.scm")\n(import "y.scm")')).toEqual([
+        "Global variable 'dup' is already defined",
+      ])
+    })
+    test('re-importing the same module is idempotent (no collision)', async () => {
+      mockFS({ 'utils.scm': '(define helper 1)' })
+      expect(
+        await scopeErrors('(import "utils.scm")\n(import "utils.scm")\nhelper'),
       ).toEqual([])
     })
     test('a local binding may shadow an imported name', async () => {


### PR DESCRIPTION
_(Co-created with Claude Code)_

Fixes #283. Fixes #284.

## Problem
Scope checking treated the top level as a sequence — a name was only in scope from its own definition onward. Two bugs followed:
- **#283:** legal top-level mutual recursion / forward references were rejected (`(define f … g …)` then `(define g … f …)` → `Undefined variable 'g'`).
- **#284:** a `define`/`import` name collision was an error in one order but silently accepted in the other.

## Design (confirmed against Racket)
Per your steer, I checked Racket module semantics: module-level definitions and imports share **one mutually-recursive scope covering the whole body** — position is not significant ([Racket §3.1 Modules](https://docs.racket-lang.org/reference/module.html)) — and *"an identifier can be either imported or defined … but not both"* ([Racket §3.2 require](https://docs.racket-lang.org/reference/require.html)). R7RS top-level bodies are likewise `letrec*`. So: **all top-level bindings are mutually recursive, and a name clash is an error regardless of order.**

## Fix
`scopeCheckProgram` now runs two passes:
1. **Collect** every top-level binding (define names + import exports) into `globals`, resolving imports and flagging collisions.
2. **Check** each statement's body against the fully-populated `globals`.

- **#283:** top-level mutual recursion and forward references resolve; a genuinely undefined name is still flagged.
- **#284:** define/import and import/import clashes are flagged **symmetrically**, regardless of order. A `sources` map tracks what introduced each *user* name, so (a) re-importing the same module is idempotent, and (b) a library import that merely re-binds a standard-library name is **not** flagged. Redefining a prelude/runtime binding stays flagged, as before.

## Tests
- New regression suite `test/regressions/top-level-mutual-recursion.test.ts` (mutual recursion, forward ref, symmetric define/import + import/import collisions, re-import idempotence, library-overlap-not-flagged).
- Updated `test/scheme/scope.test.ts`: moved the two forward-reference/mutual-recursion cases into a new "mutually recursive" block asserting they resolve; flipped the define-then-import case to assert the symmetric collision; added import/import + re-import cases.
- `npm run validate` passes (typecheck, full test suite, lint). No builtin-library import collisions surfaced across the suite.

Note: scope checking is opt-in (CLI `--check`), so this does not change the default run path today.