### PR TITLE
Fix #77: document the test-result constructors

### DIFF
--- a/src/lib/test.scm
+++ b/src/lib/test.scm
@@ -1,9 +1,32 @@
+;;; (test-result-ok desc) -> test-result?
+;;;  desc : string?
+;;; Returns a test result indicating that the test named `desc` passed.
+;;; @category testing
 (define test-result-ok (js-var "test_testResultOk"))
 
+;;; (test-result-error-expected desc expected actual) -> test-result?
+;;;  desc : string?
+;;;  expected : any
+;;;  actual : any
+;;; Returns a test result indicating that the test named `desc` failed because
+;;; it produced `actual` instead of the `expected` value.
+;;; @category testing
 (define test-result-error-expected (js-var "test_testResultErrorExpected"))
 
+;;; (test-result-error-exn desc exn) -> test-result?
+;;;  desc : string?
+;;;  exn : any
+;;; Returns a test result indicating that the test named `desc` failed because
+;;; it raised the unexpected exception `exn`.
+;;; @category testing
 (define test-result-error-exn (js-var "test_testResultErrorExn"))
 
+;;; (test-result-error-gen desc reason) -> test-result?
+;;;  desc : string?
+;;;  reason : string?
+;;; Returns a test result indicating that the test named `desc` failed for the
+;;; given `reason`. (This constructor was formerly named `test-error`.)
+;;; @category testing
 (define test-result-error-gen (js-var "test_testResultErrorGeneric"))
 
 ;;; (test-result? v) -> boolean?

--- a/test/regressions/test-result-docstrings.test.ts
+++ b/test/regressions/test-result-docstrings.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import * as A from '../../src/scheme/ast'
+import { parseProgramFromSource } from '../../src/scheme/lezer-bridge'
+import { parseFunctionDocFromComments } from '../../src/scheme/docstring/docstring'
+import { isCategoryTag } from '../../src/scheme/docstring/tags/category-tag'
+import { ScamperDiagnostic } from '../../src/scheme/diagnostic'
+
+// Regression test for #77: "test-error doesn't work as documented". The `test`
+// library's result constructors (test-result-ok / -error-expected /
+// -error-exn / -error-gen) had no docstrings, so they never appeared on the
+// docs site. Users therefore reached for the old, documented `test-error` name
+// -- renamed to `test-result-error-gen` in 3.4.0 -- which no longer exists.
+// Documenting the constructors resolves the confusion.
+
+const DOCUMENTED = [
+  'test-result-ok',
+  'test-result-error-expected',
+  'test-result-error-exn',
+  'test-result-error-gen',
+]
+
+function definesByName(): Map<string, A.Define> {
+  const src = readFileSync(resolve(__dirname, '../../src/lib/test.scm'), 'utf-8')
+  const diagnostics: ScamperDiagnostic[] = []
+  const prog = parseProgramFromSource(diagnostics, src)
+  expect(diagnostics.map((d) => d.message)).toEqual([])
+  const byName = new Map<string, A.Define>()
+  for (const s of prog) {
+    if (s.tag === 'define') {
+      byName.set(s.name.name, s)
+    }
+  }
+  return byName
+}
+
+describe('#77: test result constructors are documented', () => {
+  const defs = definesByName()
+
+  test.each(DOCUMENTED)(
+    '%s has a valid, testing-categorized docstring',
+    (name) => {
+      const def = defs.get(name)
+      expect(def, `expected a define for ${name}`).toBeDefined()
+      expect(def?.docComments, `${name} should have a docstring`).toBeTruthy()
+
+      const { doc, diagnostics } = parseFunctionDocFromComments(def!.docComments!)
+      expect(diagnostics.map((d) => d.message)).toEqual([])
+      expect(doc).toBeDefined()
+      expect(doc?.signature.function.head.name).toBe(name)
+
+      const categories = (doc?.tags ?? [])
+        .filter(isCategoryTag)
+        .flatMap((t) => t.contents)
+      expect(categories).toContain('testing')
+    },
+  )
+})


### PR DESCRIPTION
_(Co-created with Claude Code)_

Fixes #77.

## Root cause
`test-error` was renamed to `test-result-error-gen` in 3.4.0, and the underlying contract bug the issue reported was already resolved by the `.scm` conversion (js-var bindings carry no contract). But the four `test` result constructors — `test-result-ok`, `test-result-error-expected`, `test-result-error-exn`, `test-result-error-gen` — had **no docstrings**, so they never appeared on the docs site. Users kept reaching for the old, documented `test-error` name, which no longer exists — hence "test-error doesn't work as documented".

## Fix
Add docstrings (with `@category testing`) to all four constructors, matching the format of `test-case`/`test-exn`. `test-result-error-gen`'s docstring notes it was formerly named `test-error`, so a search for the old name surfaces the current one.

## Verification
- New regression test `test/regressions/test-result-docstrings.test.ts`: parses `src/lib/test.scm` and asserts each constructor has a valid, `testing`-categorized docstring (no docstring diagnostics). Fails before this change (no docstrings), passes after.
- Regenerated the gitignored `src/lib/generated/sources.ts` (`npm run generate-lib-sources`); the `generated-sources-freshness` test passes.
- `npm run validate` passes (typecheck, full test suite, lint).

Note: this documents the current API. Whether to also restore a `test-error` **alias** for backward compatibility is a separate naming decision (a one-line `(define test-error (js-var "test_testResultErrorGeneric"))` if desired) — left to you.