### PR TITLE
Add a light/dark theme (dark mode) to the web UI

### DIFF
--- a/public/css/scamper-hljs.css
+++ b/public/css/scamper-hljs.css
@@ -5,7 +5,7 @@ pre code.hljs {
 }
 
 pre.hljs {
-  border: 1px solid black;
+  border: 1px solid var(--border);
   padding: 0.5em;
 }
 
@@ -23,8 +23,8 @@ pre.hljs {
   Current colors taken from GitHub's CSS
 */
 .hljs {
-  color: #24292e;
-  background: #fafafa
+  color: var(--fg);
+  background: var(--surface-muted)
 }
 .hljs-doctag,
 .hljs-keyword,

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -1,0 +1,83 @@
+/*
+ * Scamper theme tokens (light / dark).
+ *
+ * Every UI color is a CSS custom property resolved with light-dark(), so a
+ * single declaration carries both themes. Which one applies is driven by the
+ * `color-scheme` property:
+ *   - no [data-theme]      -> `light dark` -> follows the OS (prefers-color-scheme)
+ *   - [data-theme="light"] -> forces light
+ *   - [data-theme="dark"]  -> forces dark
+ * A tiny inline <head> script sets [data-theme] from localStorage before first
+ * paint (see the app HTML files), so an explicit choice never flashes.
+ *
+ * JS surfaces that can't read CSS variables (canvas fills, Chart.js) resolve
+ * these same tokens via readColorToken() in src/theme/index.ts, keeping one
+ * source of truth.
+ */
+:root {
+  color-scheme: light dark;
+
+  /* Surfaces */
+  --bg: light-dark(#ffffff, #0d1117);
+  --fg: light-dark(#333333, #e6edf3);
+  --surface: light-dark(#ffffff, #161b22);
+  --surface-muted: light-dark(#f6f8fa, #0d1117);
+  --surface-sidebar: light-dark(#f6f6f6, #161b22);
+  --surface-hover: light-dark(#e0e0e0, #21262d);
+
+  /* Borders */
+  --border: light-dark(#d0d7de, #30363d);
+  --border-muted: light-dark(#dddddd, #30363d);
+
+  /* Header / toolbar */
+  --header-bg: light-dark(#eeeeee, #161b22);
+  --header-fg: light-dark(#333333, #e6edf3);
+
+  /* Accent (active items, run badge) */
+  --accent: light-dark(#008000, #2ea043);
+  --accent-fg: light-dark(#ffffff, #ffffff);
+
+  /* Modals */
+  --modal-bg: light-dark(#fefefe, #161b22);
+  --modal-border: light-dark(#888888, #30363d);
+  --overlay: light-dark(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.6));
+
+  /* Test results */
+  --test-ok-bg: light-dark(#e5ffe5, #10251b);
+  --test-error-bg: light-dark(#ffe5e5, #2d1517);
+  --test-border: light-dark(#000000, #30363d);
+
+  /* Links */
+  --link: light-dark(#0969da, #58a6ff);
+
+  /* Error accent (docs/search) */
+  --error-accent: light-dark(#ffacac, #f85149);
+
+  /* Splitpanes splitter */
+  --splitter-bg: light-dark(#eeeeee, #30363d);
+
+  /* Canvas / chart surfaces (read from JS via readColorToken) */
+  --canvas-surface: light-dark(#ffffff, #161b22);
+  --canvas-ink: light-dark(#000000, #e6edf3);
+  --audio-wave: light-dark(rgb(200, 200, 200), rgb(80, 80, 80));
+  --chart-fg: light-dark(#666666, #adbac7);
+  --chart-grid: light-dark(rgba(0, 0, 0, 0.1), rgba(255, 255, 255, 0.12));
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+}
+
+/* Base page colors so every app has a themed background/text by default. */
+body {
+  background-color: var(--bg);
+  color: var(--fg);
+}
+
+a {
+  color: var(--link);
+}

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -33,8 +33,9 @@
   --header-bg: light-dark(#eeeeee, #161b22);
   --header-fg: light-dark(#333333, #e6edf3);
 
-  /* Accent (active items, run badge) */
-  --accent: light-dark(#008000, #2ea043);
+  /* Accent (active items, run badge). Dark value darkened so white text meets
+   * WCAG AA contrast (#2ea043 was ~3.4:1). */
+  --accent: light-dark(#008000, #238636);
   --accent-fg: light-dark(#ffffff, #ffffff);
 
   /* Modals */

--- a/src/app/docs/ApiEntries.vue
+++ b/src/app/docs/ApiEntries.vue
@@ -60,7 +60,7 @@ const entries = computed<Entry[]>(() => {
 .index {
   margin: 1em;
   padding: 1em;
-  background-color: #ddd;
+  background-color: var(--surface-muted);
   font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
   width: 17em;
   flex-shrink: 0;

--- a/src/app/docs/DocEntry.vue
+++ b/src/app/docs/DocEntry.vue
@@ -30,7 +30,7 @@ const descSpans = computed<TextSpan[]>(() => {
 
 <style scoped>
 .entry {
-  border: 1px solid black;
+  border: 1px solid var(--border);
   padding: 1em;
   margin: 1em;
   font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui,

--- a/src/app/docs/DocsApp.vue
+++ b/src/app/docs/DocsApp.vue
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 const appVersion = APP_VERSION
 import ModuleList from './ModuleList.vue'
 import ApiEntries from './ApiEntries.vue'
+import ThemeToggle from '../shared/ThemeToggle.vue'
 import { docRegistry } from '../../lib'
 import type { FunctionDoc } from '../../scheme/docstring/docstring'
 
@@ -51,6 +52,8 @@ function searchForFunction(searchTerm: string) {
 
       </div>
       <div class="header-right">
+        <ThemeToggle />
+        ⋅
         <a href="https://github.com/slag-plt/scamper"
           ><i class="fa-brands fa-github"></i
         ></a>
@@ -107,8 +110,8 @@ body,
 }
 
 .header {
-  background: #eee;
-  color: #333;
+  background: var(--header-bg);
+  color: var(--header-fg);
   padding: 0.5em;
   flex: 0 0 auto;
   display: flex;
@@ -118,7 +121,10 @@ body,
 }
 
 .header-right {
-  color: #333;
+  color: var(--header-fg);
+  display: flex;
+  align-items: center;
+  gap: 0.25em;
 }
 
 .docs {

--- a/src/app/docs/docs.html
+++ b/src/app/docs/docs.html
@@ -4,7 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Cache-Control" content="no-store" />
+  <!-- Apply the persisted theme before first paint to avoid a flash. -->
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('scamper-theme')
+        if (t === 'light' || t === 'dark') {
+          document.documentElement.setAttribute('data-theme', t)
+        }
+      } catch (e) {}
+    })()
+  </script>
   <link href="/css/normalize.css" rel="stylesheet">
+  <link href="/css/theme.css" rel="stylesheet">
   <!-- Fontawesome (brands + solid) -->
   <link href="/css/fontawesome.css" rel="stylesheet">
   <link href="/css/brands.css" rel="stylesheet">

--- a/src/app/search/ApiEntries.vue
+++ b/src/app/search/ApiEntries.vue
@@ -352,7 +352,7 @@ const types = ref([
 .index {
   margin: 1em;
   padding: 1em;
-  background-color: #ddd;
+  background-color: var(--surface-muted);
   font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
   width: 17em;
   flex-shrink: 0;
@@ -409,7 +409,7 @@ const types = ref([
   margin: 24px;
   font-size: 40px;
   font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;
-  color: #ffacac;
+  color: var(--error-accent);
 }
 
 .flex-box {

--- a/src/app/search/DocEntry.vue
+++ b/src/app/search/DocEntry.vue
@@ -30,7 +30,7 @@ const descSpans = computed<TextSpan[]>(() => {
 
 <style scoped>
 .entry {
-  border: 1px solid black;
+  border: 1px solid var(--border);
   padding: 1em;
   margin: 1em;
   font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui,

--- a/src/app/search/DocsApp.vue
+++ b/src/app/search/DocsApp.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import ApiEntries from './ApiEntries.vue'
+import ThemeToggle from '../shared/ThemeToggle.vue'
 const appVersion = APP_VERSION
 
 const search = ref('')
@@ -24,6 +25,8 @@ const searched: string | null = urlParams.get('search')
 
       </div>
       <div class="header-right">
+        <ThemeToggle />
+        ⋅
         <a href="https://github.com/slag-plt/scamper"
           ><i class="fa-brands fa-github"></i
         ></a>
@@ -87,8 +90,8 @@ body,
 }
 
 .header {
-  background: #ffacac;
-  color: #333;
+  background: var(--error-accent);
+  color: var(--header-fg);
   padding: 0.5em;
   flex: 0 0 auto;
   display: flex;
@@ -98,7 +101,10 @@ body,
 }
 
 .header-right {
-  color: #333;
+  color: var(--header-fg);
+  display: flex;
+  align-items: center;
+  gap: 0.25em;
 }
 
 .docs {

--- a/src/app/search/search.html
+++ b/src/app/search/search.html
@@ -4,7 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Cache-Control" content="no-store" />
+  <!-- Apply the persisted theme before first paint to avoid a flash. -->
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('scamper-theme')
+        if (t === 'light' || t === 'dark') {
+          document.documentElement.setAttribute('data-theme', t)
+        }
+      } catch (e) {}
+    })()
+  </script>
   <link href="/css/normalize.css" rel="stylesheet">
+  <link href="/css/theme.css" rel="stylesheet">
   <!-- Fontawesome (brands + solid) -->
   <link href="/css/fontawesome.css" rel="stylesheet">
   <link href="/css/brands.css" rel="stylesheet">

--- a/src/app/shared/ThemeToggle.vue
+++ b/src/app/shared/ThemeToggle.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { currentTheme, toggleTheme } from '../../theme'
+
+const isDark = computed(() => currentTheme.value === 'dark')
+const label = computed(() =>
+  isDark.value ? 'Switch to light theme' : 'Switch to dark theme',
+)
+</script>
+
+<template>
+  <button
+    class="fa-solid"
+    :class="isDark ? 'fa-sun' : 'fa-moon'"
+    :aria-label="label"
+    :title="label"
+    @click="toggleTheme()"
+  ></button>
+</template>

--- a/src/app/web/codemirror/codemirror.ts
+++ b/src/app/web/codemirror/codemirror.ts
@@ -13,15 +13,18 @@ import {
   lineNumbers,
   rectangularSelection,
 } from '@codemirror/view'
-import { EditorState, Extension } from '@codemirror/state'
+import { Compartment, EditorState, Extension } from '@codemirror/state'
 import {
   bracketMatching,
   defaultHighlightStyle,
   foldGutter,
   foldKeymap,
+  HighlightStyle,
   indentOnInput,
   syntaxHighlighting,
 } from '@codemirror/language'
+import { tags as t } from '@lezer/highlight'
+import { currentTheme, type Theme } from '../../../theme'
 import {
   defaultKeymap,
   history,
@@ -44,6 +47,66 @@ import { QueryExtension } from './extensions/query'
 export const noLoadedFileText =
   '; Create and/or load a file from the left-hand sidebar!'
 
+// Editor theme. Light keeps CodeMirror's default light chrome + highlight; dark
+// is a GitHub-dark-inspired theme covering the tags assigned in
+// extensions/language.ts. The active theme lives in a Compartment so it can be
+// swapped live (see CodeMirrorEditor.vue) without rebuilding editor state.
+const lightThemeExtension: Extension = syntaxHighlighting(defaultHighlightStyle, {
+  fallback: true,
+})
+
+const darkHighlightStyle = HighlightStyle.define([
+  { tag: t.keyword, color: '#ff7b72' },
+  { tag: t.variableName, color: '#e6edf3' },
+  { tag: [t.bool, t.null, t.atom], color: '#79c0ff' },
+  { tag: t.number, color: '#79c0ff' },
+  { tag: [t.string, t.character], color: '#a5d6ff' },
+  { tag: [t.lineComment, t.comment], color: '#8b949e', fontStyle: 'italic' },
+  { tag: [t.paren, t.squareBracket, t.brace, t.punctuation], color: '#c9d1d9' },
+])
+
+const darkEditorTheme = EditorView.theme(
+  {
+    '&': { color: '#e6edf3', backgroundColor: '#0d1117' },
+    '.cm-content': { caretColor: '#e6edf3' },
+    '.cm-cursor, .cm-dropCursor': { borderLeftColor: '#e6edf3' },
+    '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection':
+      { backgroundColor: '#264f78' },
+    '.cm-gutters': {
+      backgroundColor: '#0d1117',
+      color: '#6e7681',
+      border: 'none',
+    },
+    '.cm-activeLine': { backgroundColor: 'rgba(110, 118, 129, 0.1)' },
+    '.cm-activeLineGutter': { backgroundColor: 'rgba(110, 118, 129, 0.1)' },
+    '.cm-foldPlaceholder': {
+      backgroundColor: 'transparent',
+      border: 'none',
+      color: '#8b949e',
+    },
+    '.cm-tooltip': {
+      backgroundColor: '#161b22',
+      border: '1px solid #30363d',
+      color: '#e6edf3',
+    },
+    '.cm-tooltip-autocomplete ul li[aria-selected]': {
+      backgroundColor: '#264f78',
+      color: '#e6edf3',
+    },
+  },
+  { dark: true },
+)
+
+const darkThemeExtension: Extension = [darkEditorTheme, syntaxHighlighting(darkHighlightStyle)]
+
+/** The editor theme+highlight extension for a given app theme. */
+export function editorThemeExtension(theme: Theme): Extension {
+  return theme === 'dark' ? darkThemeExtension : lightThemeExtension
+}
+
+/** Compartment holding the active editor theme, for live reconfiguration. */
+export const editorThemeCompartment = new Compartment()
+
 export interface EditorStateConfig {
   output?: HTMLElement
   dirtyAction: () => void
@@ -65,7 +128,7 @@ function mkExtensions(config: EditorStateConfig): Extension {
     dropCursor(),
     EditorState.allowMultipleSelections.of(true),
     indentOnInput(),
-    syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+    editorThemeCompartment.of(editorThemeExtension(currentTheme.value)),
     bracketMatching(),
     closeBrackets(),
     autocompletion(),

--- a/src/app/web/components/CodeMirrorEditor.vue
+++ b/src/app/web/components/CodeMirrorEditor.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 import { EditorView } from '@codemirror/view'
-import { mkNoFileEditorState } from '../codemirror/codemirror'
+import {
+  editorThemeCompartment,
+  editorThemeExtension,
+  mkNoFileEditorState,
+} from '../codemirror/codemirror'
+import { currentTheme } from '../../../theme'
 import {
   type CodeMirrorEditorAdapter,
   createCodeMirrorEditorAdapter,
@@ -25,6 +30,13 @@ onMounted(() => {
     emit('dirty')
   })
   editorRegistration.register(adapter)
+})
+
+// Live-swap the editor theme when the app theme changes.
+watch(currentTheme, (theme) => {
+  editorView?.dispatch({
+    effects: editorThemeCompartment.reconfigure(editorThemeExtension(theme)),
+  })
 })
 
 onUnmounted(() => {

--- a/src/app/web/components/IdeApp.vue
+++ b/src/app/web/components/IdeApp.vue
@@ -458,7 +458,7 @@ onUnmounted(() => {
 .sidebar-wrapper {
   width: 250px;
   flex-shrink: 0;
-  border-right: 1px solid #ddd;
+  border-right: 1px solid var(--border-muted);
 }
 
 .ide-main {
@@ -475,18 +475,18 @@ onUnmounted(() => {
 }
 
 .editor-pane {
-  background-color: white;
+  background-color: var(--surface);
   overflow: hidden;
 }
 
 .results-pane {
-  background-color: white;
+  background-color: var(--surface);
   display: flex;
   flex-direction: column;
 }
 
 :deep(.splitpanes__splitter) {
-  background-color: #eee;
+  background-color: var(--splitter-bg);
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==");
   background-repeat: no-repeat;
   background-position: 50%;
@@ -504,14 +504,14 @@ onUnmounted(() => {
   width: 100%;
   height: 100%;
   overflow: auto;
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: var(--overlay);
 }
 
 .loading-content {
-  background-color: #fefefe;
+  background-color: var(--modal-bg);
   margin: auto;
   padding: 20px;
-  border: 1px solid #888;
+  border: 1px solid var(--modal-border);
   width: 80%;
 }
 </style>

--- a/src/app/web/components/IdeHeader.vue
+++ b/src/app/web/components/IdeHeader.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useScamperSession } from '../composables/use-scamper-session'
+import ThemeToggle from '../../shared/ThemeToggle.vue'
 
 defineProps<{
   currentFile?: string | null
@@ -90,6 +91,8 @@ function searchOpenWindow(searchTerm: string) {
       >
     </div>
     <div class="header-right">
+      <ThemeToggle />
+      ⋅
       <a
         href="https://github.com/slag-plt/scamper"
         role="button"
@@ -108,8 +111,8 @@ function searchOpenWindow(searchTerm: string) {
 
 <style scoped>
 .ide-header {
-  background: #eee;
-  color: #333;
+  background: var(--header-bg);
+  color: var(--header-fg);
   padding: 0.5em;
   display: flex;
   flex-direction: row;

--- a/src/app/web/components/IdeSidebar.vue
+++ b/src/app/web/components/IdeSidebar.vue
@@ -131,12 +131,12 @@ async function handleFileInputChange(event: Event) {
   flex-direction: column;
   flex: 1;
   height: 100%;
-  background: #f6f6f6;
+  background: var(--surface-sidebar);
 }
 
 .ide-sidebar.drag-over {
   opacity: 0.5;
-  background: #e0e0e0;
+  background: var(--surface-hover);
   transition:
     opacity 0.2s ease,
     background 0.2s ease;
@@ -173,7 +173,7 @@ async function handleFileInputChange(event: Event) {
 }
 
 .file.selected {
-  background: green;
-  color: white;
+  background: var(--accent);
+  color: var(--accent-fg);
 }
 </style>

--- a/src/app/web/components/OutputPane.vue
+++ b/src/app/web/components/OutputPane.vue
@@ -63,8 +63,8 @@ defineExpose({ display, reset, scrollToBottom })
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: #f6f8fa;
-  border: 0.1em solid #d0d7de;
+  background-color: var(--surface-muted);
+  border: 0.1em solid var(--border);
   border-bottom: none;
   border-top-left-radius: 0.5em;
   border-top-right-radius: 0.5em;
@@ -82,9 +82,9 @@ defineExpose({ display, reset, scrollToBottom })
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: #f6f8fa;
-  border-left: 0.1em solid #d0d7de;
-  border-right: 0.1em solid #d0d7de;
+  background-color: var(--surface-muted);
+  border-left: 0.1em solid var(--border);
+  border-right: 0.1em solid var(--border);
   z-index: -1;
 }
 
@@ -99,8 +99,8 @@ defineExpose({ display, reset, scrollToBottom })
   bottom: 0.25em;
   left: 0;
   right: 0;
-  background-color: #f6f8fa;
-  border: 0.1em solid #d0d7de;
+  background-color: var(--surface-muted);
+  border: 0.1em solid var(--border);
   border-top: none;
   border-bottom-left-radius: 0.5em;
   border-bottom-right-radius: 0.5em;
@@ -119,9 +119,9 @@ defineExpose({ display, reset, scrollToBottom })
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: #f6f8fa;
-  border-left: 0.1em solid #d0d7de;
-  border-right: 0.1em solid #d0d7de;
+  background-color: var(--surface-muted);
+  border-left: 0.1em solid var(--border);
+  border-right: 0.1em solid var(--border);
   z-index: -2;
 }
 .trace-steps-top::after {
@@ -131,8 +131,8 @@ defineExpose({ display, reset, scrollToBottom })
   bottom: 0;
   left: 1em;
   right: 1em;
-  background-color: #ffffff;
-  border: 0.1em dashed #d0d7de;
+  background-color: var(--surface);
+  border: 0.1em dashed var(--border);
   border-bottom: none;
   border-top-left-radius: 0.5em;
   border-top-right-radius: 0.5em;
@@ -150,9 +150,9 @@ defineExpose({ display, reset, scrollToBottom })
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: #f6f8fa;
-  border-left: 0.1em solid #d0d7de;
-  border-right: 0.1em solid #d0d7de;
+  background-color: var(--surface-muted);
+  border-left: 0.1em solid var(--border);
+  border-right: 0.1em solid var(--border);
   z-index: -2;
 }
 .trace-steps-item::after {
@@ -162,9 +162,9 @@ defineExpose({ display, reset, scrollToBottom })
   bottom: 0;
   left: 1em;
   right: 1em;
-  background-color: #ffffff;
-  border-left: 0.1em dashed #d0d7de;
-  border-right: 0.1em dashed #d0d7de;
+  background-color: var(--surface);
+  border-left: 0.1em dashed var(--border);
+  border-right: 0.1em dashed var(--border);
   z-index: -1;
 }
 
@@ -179,9 +179,9 @@ defineExpose({ display, reset, scrollToBottom })
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: #f6f8fa;
-  border-left: 0.1em solid #d0d7de;
-  border-right: 0.1em solid #d0d7de;
+  background-color: var(--surface-muted);
+  border-left: 0.1em solid var(--border);
+  border-right: 0.1em solid var(--border);
   z-index: -2;
 }
 .trace-steps-bottom::after {
@@ -191,8 +191,8 @@ defineExpose({ display, reset, scrollToBottom })
   bottom: 0.25em;
   left: 1em;
   right: 1em;
-  background-color: #ffffff;
-  border: 0.1em dashed #d0d7de;
+  background-color: var(--surface);
+  border: 0.1em dashed var(--border);
   border-top: none;
   border-bottom-left-radius: 0.5em;
   border-bottom-right-radius: 0.5em;

--- a/src/app/web/components/ResultsPane.vue
+++ b/src/app/web/components/ResultsPane.vue
@@ -44,7 +44,7 @@ defineExpose({
 .output-container {
   flex: 1;
   min-height: 0;
-  background: #fff;
-  color: #333;
+  background: var(--surface);
+  color: var(--fg);
 }
 </style>

--- a/src/app/web/components/RunnerApp.vue
+++ b/src/app/web/components/RunnerApp.vue
@@ -5,6 +5,7 @@ import { ScamperError } from '../../../lpm/error'
 import OutputPane from './OutputPane.vue'
 import type { OutputPaneType } from '../composables/use-output-pane'
 import Scamper from '../../../scamper'
+import ThemeToggle from '../../shared/ThemeToggle.vue'
 
 const outputPaneRef = shallowRef<OutputPaneType | null>(null)
 const version = shallowRef('')
@@ -45,7 +46,8 @@ onMounted(async () => {
 <template>
   <div class="runner">
     <div class="header">
-      Scamper <span>{{ version }}</span> ⋅ <span>{{ currentFile }}</span>
+      <span>Scamper <span>{{ version }}</span> ⋅ <span>{{ currentFile }}</span></span>
+      <ThemeToggle />
     </div>
     <div id="output" class="output-wrapper">
       <OutputPane ref="outputPaneRef" />
@@ -86,16 +88,20 @@ body {
 }
 
 .header {
-  background: #eee;
-  color: #333;
+  background: var(--header-bg);
+  color: var(--header-fg);
   padding: 0.5em;
   flex: 0 0 auto;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .output-wrapper {
   flex: 1;
   min-height: 0;
-  background: #fff;
-  color: #333;
+  background: var(--surface);
+  color: var(--fg);
 }
 </style>

--- a/src/app/web/components/query/ExpandedQueryModal.vue
+++ b/src/app/web/components/query/ExpandedQueryModal.vue
@@ -65,13 +65,13 @@ onBeforeUnmount(() => {
   transform: translate(-50%, -50%);
   height: fit-content;
   width: fit-content;
-  background: gray;
 
   display: flex;
   justify-content: space-between;
   box-sizing: border-box;
   box-shadow: 0 0 v-bind("ModalVerticalPadding") rgba(0, 0, 0, 0.3);
-  background-color: white;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
   min-width: 0;
   padding: v-bind("ModalOverallPadding");
 }

--- a/src/app/web/components/query/modal/QueryModal.vue
+++ b/src/app/web/components/query/modal/QueryModal.vue
@@ -50,7 +50,8 @@ const contentsRef = useTemplateRef('contents-ref')
   justify-content: space-between;
   box-sizing: border-box;
   box-shadow: 0 0 v-bind("ModalVerticalPadding") rgba(0, 0, 0, 0.3);
-  background-color: white;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
   width: v-bind("ModalWidth");
   min-width: 0;
   padding: v-bind("ModalOverallPadding");

--- a/src/app/web/index.html
+++ b/src/app/web/index.html
@@ -4,7 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Cache-Control" content="no-store" />
+  <!-- Apply the persisted theme before first paint to avoid a flash. -->
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('scamper-theme')
+        if (t === 'light' || t === 'dark') {
+          document.documentElement.setAttribute('data-theme', t)
+        }
+      } catch (e) {}
+    })()
+  </script>
   <link href="/css/normalize.css" rel="stylesheet">
+  <link href="/css/theme.css" rel="stylesheet">
   <!-- Fontawesome (brands + solid) -->
   <link href="/css/fontawesome.css" rel="stylesheet">
   <link href="/css/brands.css" rel="stylesheet">

--- a/src/app/web/runner.html
+++ b/src/app/web/runner.html
@@ -4,7 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Cache-Control" content="no-store" />
+  <!-- Apply the persisted theme before first paint to avoid a flash. -->
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('scamper-theme')
+        if (t === 'light' || t === 'dark') {
+          document.documentElement.setAttribute('data-theme', t)
+        }
+      } catch (e) {}
+    })()
+  </script>
   <link href="/css/normalize.css" rel="stylesheet">
+  <link href="/css/theme.css" rel="stylesheet">
   <link href="/css/fontawesome.css" rel="stylesheet">
   <link href="/css/brands.css" rel="stylesheet">
   <link href="/css/solid.css" rel="stylesheet">

--- a/src/js/audio/renderers/html.ts
+++ b/src/js/audio/renderers/html.ts
@@ -1,10 +1,27 @@
 import * as L from '../../../lpm'
 import HtmlRenderer from '../../../lpm/renderers/html.js'
 import { SampleNode, AudioPipeline, audio_getCtx } from '../index.js'
+import { onThemeChange, readColorToken } from '../../../theme'
 
 function throwError(msg: string): never {
   throw new L.ScamperError('Runtime', msg)
 }
+
+// Oscilloscope colors, resolved from theme tokens. Cached (the draw loop runs at
+// ~60fps) and invalidated on theme change so the waveform follows the theme live.
+let waveColors: { bg: string; ink: string } | null = null
+function getWaveColors() {
+  if (waveColors === null) {
+    waveColors = {
+      bg: readColorToken('--audio-wave'),
+      ink: readColorToken('--canvas-ink'),
+    }
+  }
+  return waveColors
+}
+onThemeChange(() => {
+  waveColors = null
+})
 
 export function drawOscilloscope(
   data: Uint8Array<ArrayBuffer>,
@@ -18,11 +35,12 @@ export function drawOscilloscope(
   const bufferLength = analyser.frequencyBinCount
   analyser.getByteTimeDomainData(data)
   const ctx = canvas.getContext('2d') ?? throwError('no canvas context')
-  ctx.fillStyle = 'rgb(200, 200, 200)'
+  const { bg, ink } = getWaveColors()
+  ctx.fillStyle = bg
   ctx.fillRect(0, 0, canvas.width, canvas.height)
 
   ctx.lineWidth = 2
-  ctx.strokeStyle = 'rgb(0, 0, 0)'
+  ctx.strokeStyle = ink
   ctx.beginPath()
   const sliceWidth = (canvas.width * 1.0) / bufferLength
   let x = 0

--- a/src/js/data/renderers/PlotRenderer.vue
+++ b/src/js/data/renderers/PlotRenderer.vue
@@ -1,14 +1,24 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 import Chart from 'chart.js/auto'
 import { Plot } from '../viz'
+import { onThemeChange, readColorToken } from '../../../theme'
 
 const props = defineProps<{ value: Plot }>()
 const canvas = ref<HTMLCanvasElement | null>(null)
 let chart: Chart | null = null
 
+// Theme axis/legend/title text and gridlines via Chart.js globals (user-supplied
+// dataset colors are untouched). Applied before each render so charts pick up the
+// current theme; re-render on theme change repaints existing charts.
+function applyThemeDefaults() {
+  Chart.defaults.color = readColorToken('--chart-fg')
+  Chart.defaults.borderColor = readColorToken('--chart-grid')
+}
+
 function renderChart() {
   if (canvas.value) {
+    applyThemeDefaults()
     if (chart) {
       chart.destroy()
     }
@@ -18,6 +28,12 @@ function renderChart() {
 
 onMounted(renderChart)
 watch(() => props.value, renderChart, { deep: true })
+const unsubscribe = onThemeChange(renderChart)
+onUnmounted(() => {
+  unsubscribe()
+  chart?.destroy()
+  chart = null
+})
 </script>
 
 <template>

--- a/src/js/image/drawing.ts
+++ b/src/js/image/drawing.ts
@@ -1,7 +1,6 @@
 import * as L from '../../lpm'
 import { Rgb, image_rgb, image_colorToRgb, image_rgbAverage, image_rgbToString } from './color.js'
 import { Font, image_font, image_fontQ, image_fontToFontString } from './font.js'
-import { onThemeChange, readColorToken } from '../../theme'
 
 /***** Core Functions *********************************************************/
 
@@ -645,12 +644,16 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
   }
 }
 
-export function image_clearDrawing (canvas: HTMLCanvasElement) {
+/**
+ * Clears `canvas` to a solid background before a drawing is rendered onto it.
+ * @param background the fill color (default 'white'). Callers rendering for
+ *   *display* pass a themed color (see DrawingRenderer.vue); the default keeps
+ *   off-screen/data uses (drawing->pixels, drawing->image) deterministic.
+ */
+export function image_clearDrawing (canvas: HTMLCanvasElement, background: string = 'white') {
   const ctx = canvas.getContext('2d')!
-  // Background/default stroke follow the app theme so a drawing blends into the
-  // page instead of being a bright white box on a dark background.
-  ctx.fillStyle = readColorToken('--canvas-surface')
-  ctx.strokeStyle = readColorToken('--canvas-ink')
+  ctx.fillStyle = background
+  ctx.strokeStyle = 'black'
   ctx.fillRect(0, 0, Math.ceil(canvas.width), Math.ceil(canvas.height))
 }
 
@@ -661,19 +664,7 @@ export function image_renderer (drawing: Drawing): HTMLElement {
   canvas.setAttribute('aria-label', image_canvasAriaLabel)
   canvas.width = Math.ceil(drawing.width)
   canvas.height = Math.ceil(drawing.height)
-  const paint = () => {
-    image_clearDrawing(canvas)
-    image_render(0, 0, drawing, canvas)
-  }
-  paint()
-  // Repaint on theme change. Self-unsubscribe once the canvas leaves the DOM
-  // (e.g. output cleared) so listeners don't accumulate across runs.
-  const unsubscribe = onThemeChange(() => {
-    if (!canvas.isConnected) {
-      unsubscribe()
-      return
-    }
-    paint()
-  })
+  image_clearDrawing(canvas)
+  image_render(0, 0, drawing, canvas)
   return canvas
 }

--- a/src/js/image/drawing.ts
+++ b/src/js/image/drawing.ts
@@ -1,6 +1,7 @@
 import * as L from '../../lpm'
 import { Rgb, image_rgb, image_colorToRgb, image_rgbAverage, image_rgbToString } from './color.js'
 import { Font, image_font, image_fontQ, image_fontToFontString } from './font.js'
+import { onThemeChange, readColorToken } from '../../theme'
 
 /***** Core Functions *********************************************************/
 
@@ -646,8 +647,10 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
 
 export function image_clearDrawing (canvas: HTMLCanvasElement) {
   const ctx = canvas.getContext('2d')!
-  ctx.fillStyle = 'white'
-  ctx.strokeStyle = 'black'
+  // Background/default stroke follow the app theme so a drawing blends into the
+  // page instead of being a bright white box on a dark background.
+  ctx.fillStyle = readColorToken('--canvas-surface')
+  ctx.strokeStyle = readColorToken('--canvas-ink')
   ctx.fillRect(0, 0, Math.ceil(canvas.width), Math.ceil(canvas.height))
 }
 
@@ -658,7 +661,19 @@ export function image_renderer (drawing: Drawing): HTMLElement {
   canvas.setAttribute('aria-label', image_canvasAriaLabel)
   canvas.width = Math.ceil(drawing.width)
   canvas.height = Math.ceil(drawing.height)
-  image_clearDrawing(canvas)
-  image_render(0, 0, drawing, canvas)
+  const paint = () => {
+    image_clearDrawing(canvas)
+    image_render(0, 0, drawing, canvas)
+  }
+  paint()
+  // Repaint on theme change. Self-unsubscribe once the canvas leaves the DOM
+  // (e.g. output cleared) so listeners don't accumulate across runs.
+  const unsubscribe = onThemeChange(() => {
+    if (!canvas.isConnected) {
+      unsubscribe()
+      return
+    }
+    paint()
+  })
   return canvas
 }

--- a/src/js/image/renderers/DrawingRenderer.vue
+++ b/src/js/image/renderers/DrawingRenderer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 import { Drawing, image_render, image_clearDrawing, image_canvasAriaLabel } from '../drawing'
+import { onThemeChange, readColorToken } from '../../../theme'
 
 const props = defineProps<{ value: Drawing }>()
 const canvas = ref<HTMLCanvasElement | null>(null)
@@ -9,13 +10,18 @@ function renderDrawing() {
   if (canvas.value) {
     canvas.value.width = Math.ceil(props.value.width)
     canvas.value.height = Math.ceil(props.value.height)
-    image_clearDrawing(canvas.value)
+    // Themed background for display so the drawing blends into the page instead
+    // of being a white box on a dark background.
+    image_clearDrawing(canvas.value, readColorToken('--canvas-surface'))
     image_render(0, 0, props.value, canvas.value)
   }
 }
 
 onMounted(renderDrawing)
 watch(() => props.value, renderDrawing, { deep: true })
+// Repaint on theme toggle (see PlotRenderer.vue for the same pattern).
+const unsubscribe = onThemeChange(renderDrawing)
+onUnmounted(unsubscribe)
 </script>
 
 <template>

--- a/src/js/image/renderers/HsvRenderer.vue
+++ b/src/js/image/renderers/HsvRenderer.vue
@@ -24,7 +24,7 @@ const displayText = computed(() => image_hsvToString(props.value))
       color: textColor,
       backgroundColor: backgroundColor,
       width: 'fit-content',
-      border: '1px solid black',
+      border: '1px solid var(--border)',
       padding: '0.25em',
     }"
   >

--- a/src/js/image/renderers/RgbRenderer.vue
+++ b/src/js/image/renderers/RgbRenderer.vue
@@ -14,7 +14,7 @@ const textColor = computed(() => image_rgbToString(image_rgbPseudoComplement(pro
       color: textColor,
       backgroundColor: backgroundColor,
       width: 'fit-content',
-      border: '1px solid black',
+      border: '1px solid var(--border)',
       padding: '0.25em',
     }"
   >

--- a/src/js/image/renderers/html.ts
+++ b/src/js/image/renderers/html.ts
@@ -12,7 +12,7 @@ function renderRgb (rgb: Rgb): HTMLElement {
   div.style.color = image_rgbToString(textColor)
   div.style.backgroundColor = image_rgbToString(rgb)
   div.style.width = 'fit-content'
-  div.style.border = '1px solid black'
+  div.style.border = '1px solid var(--border)'
   div.style.padding = '0.25em'
   div.textContent = image_rgbToString(rgb)
   return div
@@ -27,7 +27,7 @@ function renderHsv (hsv: Hsv): HTMLElement {
   div.style.color = image_rgbToString(textColor)
   div.style.backgroundColor = image_rgbToString(rgb)
   div.style.width = 'fit-content'
-  div.style.border = '1px solid black'
+  div.style.border = '1px solid var(--border)'
   div.style.padding = '0.25em'
   div.textContent = image_hsvToString(hsv)
   return div

--- a/src/js/test/renderers/TestResultRenderer.vue
+++ b/src/js/test/renderers/TestResultRenderer.vue
@@ -43,14 +43,14 @@ defineProps<{ value: Result }>()
   font-size: 1em;
   margin: 0.5em;
   padding: 0.25em;
-  border: dashed 1px black;
+  border: dashed 1px var(--test-border);
 }
 
 .test-result.ok {
-  background-color: #e5ffe5;
+  background-color: var(--test-ok-bg);
 }
 
 .test-result.error {
-  background-color: #ffe5e5;
+  background-color: var(--test-error-bg);
 }
 </style>

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,119 @@
+import { ref } from 'vue'
+
+/**
+ * Light/dark theme state, shared across every Scamper app.
+ *
+ * The source of truth for CSS is the `data-theme` attribute on <html> plus the
+ * `light-dark()` tokens in public/css/theme.css. This module keeps a reactive
+ * mirror for Vue components and resolves tokens for non-CSS surfaces (canvas,
+ * Chart.js). A no-flash inline <head> script applies the persisted choice
+ * before first paint; this module takes over once the app boots.
+ *
+ * N.B., this module is transitively imported by JS renderers that also load in
+ * non-browser environments (the Node CLI, jsdom tests), so every access to
+ * window / document / localStorage is guarded.
+ */
+
+export type Theme = 'light' | 'dark'
+
+const STORAGE_KEY = 'scamper-theme'
+
+const hasWindow = typeof window !== 'undefined'
+const hasDocument = typeof document !== 'undefined'
+
+function systemPrefersDark(): boolean {
+  if (!hasWindow || !window.matchMedia) {
+    return false
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+/** The user's explicit override, if any. */
+function storedTheme(): Theme | null {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY)
+    return v === 'light' || v === 'dark' ? v : null
+  } catch {
+    return null
+  }
+}
+
+/** The theme currently in effect: an explicit override, else the OS default. */
+export function effectiveTheme(): Theme {
+  return storedTheme() ?? (systemPrefersDark() ? 'dark' : 'light')
+}
+
+/** Reactive current theme, for Vue components (e.g. the toggle icon). */
+export const currentTheme = ref<Theme>(effectiveTheme())
+
+/** Applies and persists an explicit theme choice. */
+export function setTheme(theme: Theme): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, theme)
+  } catch {
+    // Ignore storage failures (e.g. private mode); the in-page theme still applies.
+  }
+  if (hasDocument) {
+    document.documentElement.setAttribute('data-theme', theme)
+  }
+  currentTheme.value = theme
+  if (hasWindow) {
+    window.dispatchEvent(new CustomEvent<Theme>('themechange', { detail: theme }))
+  }
+}
+
+/** Flips between light and dark. */
+export function toggleTheme(): void {
+  setTheme(currentTheme.value === 'dark' ? 'light' : 'dark')
+}
+
+/**
+ * Resolves a CSS color token (including `light-dark()`) to a concrete color
+ * string, for canvas / Chart.js which cannot consume CSS variables directly.
+ * @param name a custom-property name, e.g. '--canvas-surface'
+ * @returns a resolved color string, or '' when no DOM is available.
+ */
+export function readColorToken(name: string): string {
+  if (!hasDocument) {
+    return ''
+  }
+  const probe = document.createElement('span')
+  probe.style.color = `var(${name})`
+  probe.style.display = 'none'
+  document.documentElement.appendChild(probe)
+  const color = getComputedStyle(probe).color
+  probe.remove()
+  return color
+}
+
+/**
+ * Subscribes to theme changes (for non-Vue renderers that must repaint, e.g.
+ * canvas drawings and Chart.js). Fires on both explicit toggles and OS changes.
+ * @returns an unsubscribe function (a no-op when there is no window).
+ */
+export function onThemeChange(cb: (theme: Theme) => void): () => void {
+  if (!hasWindow) {
+    return () => {}
+  }
+  const handler = (e: Event) => cb((e as CustomEvent<Theme>).detail)
+  window.addEventListener('themechange', handler)
+  return () => window.removeEventListener('themechange', handler)
+}
+
+// Track OS changes while running: when the user hasn't set an explicit override,
+// follow the system preference live (CSS updates via color-scheme; this keeps
+// the Vue mirror and canvas renderers in sync).
+if (hasWindow && window.matchMedia) {
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', (e) => {
+      if (storedTheme() !== null) {
+        return
+      }
+      const theme: Theme = e.matches ? 'dark' : 'light'
+      currentTheme.value = theme
+      window.dispatchEvent(
+        new CustomEvent<Theme>('themechange', { detail: theme }),
+      )
+    })
+}


### PR DESCRIPTION
_(Co-created with Claude Code)_

Closes #296.

Adds a light/dark theme across the IDE, runner, docs, and search apps.

## Approach
- **One palette.** CSS custom properties resolved with `light-dark()` in `public/css/theme.css`; `color-scheme` drives OS-follow vs. an explicit `[data-theme]` override. A no-flash inline `<head>` script applies the persisted `localStorage` choice before first paint.
- **`src/theme/index.ts`** — runtime API: reactive `currentTheme`, `setTheme`/`toggleTheme`, a `themechange` event, and `readColorToken()` so canvas / Chart.js resolve the same tokens. Guarded for non-DOM environments (CLI, jsdom).
- **`src/app/shared/ThemeToggle.vue`** — sun/moon toggle in each app header.
- **CodeMirror** — dark editor theme + highlight style, swapped live via a `Compartment`.
- **Themed output** — test results, drawing/image canvas background, audio waveform, and Chart.js text/gridlines, repainting on theme change.

The embeddable widget deliberately inherits its host page rather than forcing a theme.

## Verification
- `npm run validate` (typecheck / test / lint) and `npm run build` pass.
- Verified in-browser (Playwright): light↔dark toggle, no-flash reload (`data-theme=dark`, dark background on first paint), themed editor / output / drawings / test results, docs light + dark, and drawings repainting on a live toggle (canvas background `rgb(255,255,255)` → `rgb(22,27,34)` without re-running).
