### PR TITLE
Predicate audit: fix cross-module predicate contracts ("Variable not found") + normalize `-> void`

### DIFF
--- a/src/lib/canvas.scm
+++ b/src/lib/canvas.scm
@@ -3,6 +3,18 @@
 ;;; Returns `#t` if and only if `v` is a canvas.
 (define canvas? (js-var "canvas_canvasQ"))
 
+;;; (color? v) -> boolean?
+;;;  v : any
+;;; Returns `#t` if and only if `v` is a valid color: a string containing a named color, an `rgb` value, or an `hsv` value.
+;;; @category color, hsv, image, predicates, rgb, typecheck
+(define color? (js-var "image_colorQ"))
+
+;;; (image? v) -> boolean?
+;;;  v : any
+;;; Returns `#t` if and only `v` is an image.
+;;; @category image, predicates, typecheck
+(define image? (js-var "image_drawingQ"))
+
 ;;; (make-canvas width height) -> canvas?
 ;;;  width : integer?
 ;;;   positive

--- a/src/lib/music.scm
+++ b/src/lib/music.scm
@@ -160,21 +160,21 @@
 ;;; @category music, predicates, sound, typecheck
 (define composition? (js-var "music_compositionQ"))
 
-;;; (load-instrument prog) -> void
+;;; (load-instrument prog) -> void?
 ;;;  prog : integer?
 ;;;   a valid MIDI program number (0--127)
 ;;; Downloads and loads the requested MIDI instrument soundfont.
 ;;; @category instruments, music, sound
 (define load-instrument (js-var "music_loadInstrument"))
 
-;;; (load-percussion prog) -> void
+;;; (load-percussion prog) -> void?
 ;;;  prog : integer?
 ;;;   a valid MIDI program number (0--127)
 ;;; Loads the requested percussion MIDI instrument soundfont.
 ;;; @category instruments, music, sound
 (define load-percussion (js-var "music_loadPercussion"))
 
-;;; (use-high-quality-instruments enable) -> void
+;;; (use-high-quality-instruments enable) -> void?
 ;;;  enable : boolean?
 ;;;   whether to use high-quality MIDI instruments
 ;;; Enables (or disables) the use of high-quality MIDI instruments. Note that high-quality instruments are much bigger and take longer to load.
@@ -186,7 +186,7 @@
 ;;; @category music, note, sound
 (define make-note-handlers (js-var "music_makeNoteHandlers"))
 
-;;; (play-composition comp) -> void
+;;; (play-composition comp) -> void?
 ;;;  comp : composition?
 ;;; Plays the given composition. Note that this function must be triggered from some user action on the screen, _e.g._, a button click. Otherwise, the browser will silently block audio playback.
 ;;; @category music, sound

--- a/src/lib/prelude.scm
+++ b/src/lib/prelude.scm
@@ -706,7 +706,7 @@
 ;;; @category vectors
 (define vector-ref (js-var "prelude_vectorRef"))
 
-;;; (vector-set! v n x) -> void
+;;; (vector-set! v n x) -> void?
 ;;;  v : vector?
 ;;;  n : integer?
 ;;;   a valid index into v
@@ -715,7 +715,7 @@
 ;;; @category vectors, mutation, predicates
 (define vector-set! (js-var "prelude_vectorSet"))
 
-;;; (vector-fill! v x) -> void
+;;; (vector-fill! v x) -> void?
 ;;;  v : vector?
 ;;;  x : any
 ;;; Sets each element of vector `v` to `x`.
@@ -822,21 +822,21 @@
 ;;; @category vectors
 (define vector-map (js-var "prelude_vectorMap"))
 
-;;; (vector-map! f v) -> void
+;;; (vector-map! f v) -> void?
 ;;;  f : procedure?
 ;;;  v : vector?
 ;;; Mutates v1 with the results of results of applying `f` to each element of `v1`, ..., `vk` in a element-wise fashion.
 ;;; @category vectors, mutation, predicates
 (define vector-map! (js-var "prelude_vectorMapBang"))
 
-;;; (vector-for-each f v) -> void
+;;; (vector-for-each f v) -> void?
 ;;;  f : procedure?
 ;;;  v : vector?
 ;;; Runs `f` on each element of `v1`, ..., `vk` in a element-wise fashion. `f` takes `k+1` arguments where the first argument is the current index and the remaining arguments are the elements of each vector at that index.
 ;;; @category vectors
 (define vector-for-each (js-var "prelude_vectorForEach"))
 
-;;; (for-range beg end f) -> void
+;;; (for-range beg end f) -> void?
 ;;;  beg : number?
 ;;;  end : number?
 ;;;  f : procedure?
@@ -909,13 +909,13 @@
 ;;; @category other
 (define with-handler (js-var "prelude_withHandler"))
 
-;;; (ignore v) -> void
+;;; (ignore v) -> void?
 ;;;  v : any
 ;;; Suppresses the output of value `v` to the page.
 ;;; @category other
 (define ignore (js-var "prelude_ignore"))
 
-;;; (set-maximum-recursion-depth! n) -> void
+;;; (set-maximum-recursion-depth! n) -> void?
 ;;;  n : any
 ;;;   number? n >= 0
 ;;; Sets the maximum recursion depth of Scamper to n. Note that tail call-optimized functions do _not_ count towards this limit.
@@ -946,7 +946,7 @@
 ;;; @category other
 (define deref (js-var "prelude_deref"))
 
-;;; (ref-set! r v) -> void
+;;; (ref-set! r v) -> void?
 ;;;  r : ref?
 ;;;  v : any
 ;;; Sets the value contained in reference cell `r` to `v`.
@@ -973,19 +973,19 @@
 ;;; @category math, algebra, constants
 (define π (js-var "prelude_piConst"))
 
-;;; (void) -> void
+;;; (void) -> void?
 ;;; The void value.
 ;;; @category constants
 (define void (js-var "prelude_voidConst"))
 
-;;; (with-file filename fn) -> void
+;;; (with-file filename fn) -> void?
 ;;;  filename : string?
 ;;;  fn : procedure?
 ;;; Loads `filename` from browser storage and passes its contents to `fn` as input. The output of `fn` is then rendered to the screen.
 ;;; @category other
 (define with-file (js-var "prelude_withFile"))
 
-;;; (with-file-chooser fn) -> void
+;;; (with-file-chooser fn) -> void?
 ;;;  fn : procedure?
 ;;; Renders a file chooser widget. When the user selects a file, its contents are passed to `fn` as input. The output of `fn` is then rendered to the screen.
 ;;; @category interactive

--- a/src/lib/reactive.scm
+++ b/src/lib/reactive.scm
@@ -3,6 +3,11 @@
 ;;; Returns `#t` if and only if `v` is an HTML element.
 (define html? (js-var "html_isElement"))
 
+;;; (button? v) -> boolean?
+;;;  v : any
+;;; Returns `#t` if and only if `v` is a button.
+(define button? (js-var "html_buttonQ"))
+
 ;;; (subscription? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a subscription.

--- a/test/libs/canvas.test.ts
+++ b/test/libs/canvas.test.ts
@@ -75,7 +75,30 @@ describe('canvas-onclick!', () => {
   test.skip('invokes the Scamper callback with click coordinates')
 })
 
-test.todo('canvas-rectangle!')
+// Regression: color? and image? are used in canvas.scm's drawing-function
+// contracts but defined in image.scm. canvas.scm must re-export them; otherwise
+// every drawing call runs `(color? ...)` / `(image? ...)` against an unbound
+// name and throws "Variable not found" unless the user also imports image.
+describe('cross-module predicates (color?, image?) resolve with only canvas imported', () => {
+  test('color? and image? are in scope', async () => {
+    expect(await runProgram(`
+    (import canvas)
+    (color? "red")
+    (color? 5)
+    (image? 5)
+    `)).toEqual(['#t', '#f', '#f'])
+  })
+
+  test('canvas-rectangle! contract fires cleanly on a bad color', async () => {
+    const out = (await runProgram(`
+    (import canvas)
+    (canvas-rectangle! (make-canvas 10 10) 0 0 5 5 "solid" 42)
+    `)).join('\n')
+    expect(out).toContain('expected a color')
+    expect(out).not.toContain('Variable not found')
+  })
+})
+
 test.todo('canvas-ellipse!')
 test.todo('canvas-circle!')
 test.todo('canvas-text!')

--- a/test/libs/reactive.test.ts
+++ b/test/libs/reactive.test.ts
@@ -2,13 +2,35 @@
 // directly to the DOM event system, which needs a browser-API mocking
 // strategy that is a separate, larger effort. Until that lands, this file
 // just tracks which functions still need real tests.
-import { test } from 'vitest'
+import { describe, expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// Regression: button? is used in reactive.scm's on-button-click contract but
+// defined in html.scm. reactive.scm must re-export it; otherwise on-button-click
+// runs `(button? ...)` against an unbound name and throws "Variable not found"
+// unless the user also imports html.
+describe('button? resolves with only reactive imported', () => {
+  test('button? is in scope', async () => {
+    expect(await runProgram(`
+    (import reactive)
+    (button? 5)
+    `)).toEqual(['#f'])
+  })
+
+  test('on-button-click contract fires cleanly on a non-button', async () => {
+    const out = (await runProgram(`
+    (import reactive)
+    (on-button-click 42)
+    `)).join('\n')
+    expect(out).toContain('expected a button')
+    expect(out).not.toContain('Variable not found')
+  })
+})
 
 test.todo('html?')
 test.todo('subscription?')
 test.todo('reactive-canvas')
 test.todo('reactive-container')
-test.todo('on-button-click')
 test.todo('on-mouse-click')
 test.todo('on-mouse-hover')
 test.todo('on-key-down')


### PR DESCRIPTION
_(Co-created with Claude Code)_

## Predicate audit of standard-library docstrings

Exhaustive audit of every predicate used in the standard library's docstrings — both **parameter types** and **return types** — across all 12 modules in `src/lib/*.scm`. The audit surfaced **one real runtime bug** and one documentation inconsistency.

### 🐛 Fix 1 — cross-module predicate contracts threw "Variable not found"

Three predicates were used as **parameter contracts** in modules that don't define them and don't have them in scope:

| predicate | used in | defined only in |
|-----------|---------|-----------------|
| `color?`  | `canvas` | `image` |
| `image?`  | `canvas` | `image` |
| `button?` | `reactive` | `html` |

Contract predicates resolve against the **caller's** import environment (implicit `prelude` + `runtime`, plus whatever the user explicitly imported). So unless the user *also* imported `image` / `html`, every call to the affected functions ran the predicate against an unbound name and raised **`Variable not found: color?`** — even on **valid** arguments, because the `(color? x)` check runs on every call.

**Affected functions:** `canvas-rectangle!`, `canvas-ellipse!`, `canvas-circle!`, `canvas-text!`, `canvas-path!`, `canvas-drawing!`, and `on-button-click`. The gap went unnoticed because these functions' tests are browser-only placeholders.

**Fix:** re-export the three predicates from the consuming modules, matching the codebase's existing convention (`canvas?` is defined in both `canvas` and `image`; `html?` in `image`, `lab`, and `reactive`). Added regression tests that each predicate resolves with only its consuming module imported, and that the previously-broken functions now raise a clean contract error rather than "Variable not found".

### Fix 2 — normalize `-> void` return types to `-> void?`

`void` — the void **value** — was used in return-type position **15×** where the predicate `void?` is meant (11 sites already used `void?`). Documentation-only (return types aren't runtime-checked); normalized for consistency.

### Audit method & the rest of the result

Every predicate was extracted three ways and cross-referenced: the **real docstring parser** (`docRegistry`), an **independent raw text pass**, and an **end-to-end resolution probe** that actually calls the affected functions. Beyond the three predicates above, all remaining predicates resolve correctly at their point of use (verified by the passing library suite, where param predicates compile to live `(pred arg)` checks).

### Deliberately left as-is (per discussion)

- `any` and `or/p` — used as annotations but have no doc entry of their own. Intentional meta-predicates (universal-value annotation and a predicate combinator).
- `null`'s docstring `(null) -> list?` fails to parse (`"Expected an identifier"`). Not a predicate issue (`list?` exists).

### Validation

`npm run test` (1169 passed, +4 new regression tests, incl. the generated-sources freshness guard) · `npm run typecheck` (0 errors) · `npm run lint` (0 errors).
