### PR TITLE
Add IDE status bar showing the cursor's syntactic-form breadcrumb

### DIFF
--- a/src/app/web/codemirror/codemirror.ts
+++ b/src/app/web/codemirror/codemirror.ts
@@ -43,7 +43,11 @@ import { ScamperSupport } from './extensions/language'
 import makeScamperLinter from './extensions/linter'
 import { PrettierExtension } from './extensions/prettier'
 import { QueryExtension } from './extensions/query'
-import { cursorStatus, type CursorStatus } from './enclosing-form'
+import {
+  cursorStatus,
+  dedupeCursorStatus,
+  type CursorStatus,
+} from './enclosing-form'
 
 export const noLoadedFileText =
   '; Create and/or load a file from the left-hand sidebar!'
@@ -117,9 +121,11 @@ export interface EditorStateConfig {
 }
 
 function mkExtensions(config: EditorStateConfig): Extension {
-  // Deduped so redundant updates (e.g. an edit that leaves the cursor put) don't
-  // re-notify. Scoped per state (mkExtensions runs once per state creation).
-  let lastCursorKey: string | null = null
+  // Per-state deduper (mkExtensions runs once per state creation), so redundant
+  // updates -- e.g. an edit that leaves the cursor put -- don't re-notify.
+  const notifyCursor = config.onCursorChange
+    ? dedupeCursorStatus(config.onCursorChange)
+    : undefined
   return [
     // basicSetup
     lineNumbers(),
@@ -175,13 +181,8 @@ function mkExtensions(config: EditorStateConfig): Extension {
       if (update.docChanged) {
         config.dirtyAction()
       }
-      if (config.onCursorChange && (update.selectionSet || update.docChanged)) {
-        const status = cursorStatus(update.state)
-        const key = [status.line, status.column, ...status.path].join('|')
-        if (key !== lastCursorKey) {
-          lastCursorKey = key
-          config.onCursorChange(status)
-        }
+      if (notifyCursor && (update.selectionSet || update.docChanged)) {
+        notifyCursor(cursorStatus(update.state))
       }
     }),
     QueryExtension,
@@ -198,13 +199,16 @@ export function mkFreshEditorState(
   })
 }
 
-export function mkNoFileEditorState(): EditorState {
+export function mkNoFileEditorState(
+  onCursorChange?: (status: CursorStatus) => void,
+): EditorState {
   return EditorState.create({
     doc: noLoadedFileText,
     extensions: mkExtensions({
       dirtyAction: () => {
         /* empty */
       },
+      onCursorChange,
       isReadOnly: true,
     }),
   })

--- a/src/app/web/codemirror/codemirror.ts
+++ b/src/app/web/codemirror/codemirror.ts
@@ -43,6 +43,7 @@ import { ScamperSupport } from './extensions/language'
 import makeScamperLinter from './extensions/linter'
 import { PrettierExtension } from './extensions/prettier'
 import { QueryExtension } from './extensions/query'
+import { enclosingFormPath } from './enclosing-form'
 
 export const noLoadedFileText =
   '; Create and/or load a file from the left-hand sidebar!'
@@ -110,10 +111,15 @@ export const editorThemeCompartment = new Compartment()
 export interface EditorStateConfig {
   output?: HTMLElement
   dirtyAction: () => void
+  /** Notified with the enclosing-form breadcrumb whenever the cursor moves. */
+  onFormChange?: (path: string[]) => void
   isReadOnly: boolean
 }
 
 function mkExtensions(config: EditorStateConfig): Extension {
+  // Deduped so cursor movement within the same form doesn't re-notify on every
+  // keystroke. Scoped per state (mkExtensions runs once per state creation).
+  let lastFormKey: string | null = null
   return [
     // basicSetup
     lineNumbers(),
@@ -168,6 +174,14 @@ function mkExtensions(config: EditorStateConfig): Extension {
     EditorView.updateListener.of((update) => {
       if (update.docChanged) {
         config.dirtyAction()
+      }
+      if (config.onFormChange && (update.selectionSet || update.docChanged)) {
+        const path = enclosingFormPath(update.state)
+        const key = path.join(' ')
+        if (key !== lastFormKey) {
+          lastFormKey = key
+          config.onFormChange(path)
+        }
       }
     }),
     QueryExtension,

--- a/src/app/web/codemirror/codemirror.ts
+++ b/src/app/web/codemirror/codemirror.ts
@@ -43,7 +43,7 @@ import { ScamperSupport } from './extensions/language'
 import makeScamperLinter from './extensions/linter'
 import { PrettierExtension } from './extensions/prettier'
 import { QueryExtension } from './extensions/query'
-import { enclosingFormPath } from './enclosing-form'
+import { cursorStatus, type CursorStatus } from './enclosing-form'
 
 export const noLoadedFileText =
   '; Create and/or load a file from the left-hand sidebar!'
@@ -111,15 +111,15 @@ export const editorThemeCompartment = new Compartment()
 export interface EditorStateConfig {
   output?: HTMLElement
   dirtyAction: () => void
-  /** Notified with the enclosing-form breadcrumb whenever the cursor moves. */
-  onFormChange?: (path: string[]) => void
+  /** Notified with the cursor's status whenever the cursor moves or edits. */
+  onCursorChange?: (status: CursorStatus) => void
   isReadOnly: boolean
 }
 
 function mkExtensions(config: EditorStateConfig): Extension {
-  // Deduped so cursor movement within the same form doesn't re-notify on every
-  // keystroke. Scoped per state (mkExtensions runs once per state creation).
-  let lastFormKey: string | null = null
+  // Deduped so redundant updates (e.g. an edit that leaves the cursor put) don't
+  // re-notify. Scoped per state (mkExtensions runs once per state creation).
+  let lastCursorKey: string | null = null
   return [
     // basicSetup
     lineNumbers(),
@@ -175,12 +175,12 @@ function mkExtensions(config: EditorStateConfig): Extension {
       if (update.docChanged) {
         config.dirtyAction()
       }
-      if (config.onFormChange && (update.selectionSet || update.docChanged)) {
-        const path = enclosingFormPath(update.state)
-        const key = path.join(' ')
-        if (key !== lastFormKey) {
-          lastFormKey = key
-          config.onFormChange(path)
+      if (config.onCursorChange && (update.selectionSet || update.docChanged)) {
+        const status = cursorStatus(update.state)
+        const key = [status.line, status.column, ...status.path].join('|')
+        if (key !== lastCursorKey) {
+          lastCursorKey = key
+          config.onCursorChange(status)
         }
       }
     }),

--- a/src/app/web/codemirror/enclosing-form.ts
+++ b/src/app/web/codemirror/enclosing-form.ts
@@ -1,5 +1,5 @@
 import { syntaxTree } from '@codemirror/language'
-import type { EditorState } from '@codemirror/state'
+import type { EditorState, Text } from '@codemirror/state'
 import type { SyntaxNode, Tree } from '@lezer/common'
 
 // Lezer node names -> the short labels shown in the status-bar breadcrumb.
@@ -62,6 +62,19 @@ export function formPathAt(tree: Tree, pos: number): string[] {
   return path.reverse()
 }
 
+/**
+ * The 1-based line and 0-based column offset of `offset` within `doc`. The
+ * 0-based column matches Loc's convention; callers that display it (the status
+ * bar) add 1.
+ */
+export function lineColumnAt(
+  doc: Text,
+  offset: number,
+): { line: number; columnOffset: number } {
+  const line = doc.lineAt(offset)
+  return { line: line.number, columnOffset: offset - line.from }
+}
+
 /** The cursor's position and enclosing-form breadcrumb, for the status bar. */
 export interface CursorStatus {
   /** 1-based line number. */
@@ -78,10 +91,28 @@ export interface CursorStatus {
  */
 export function cursorStatus(state: EditorState): CursorStatus {
   const head = state.selection.main.head
-  const line = state.doc.lineAt(head)
+  const { line, columnOffset } = lineColumnAt(state.doc, head)
   return {
-    line: line.number,
-    column: head - line.from + 1,
+    line,
+    column: columnOffset + 1,
     path: formPathAt(syntaxTree(state), head),
+  }
+}
+
+/**
+ * Wraps `notify` so it fires only when the cursor status actually changes -- a
+ * cheap guard against redundant notifications (e.g. an edit that leaves the
+ * cursor put). Each call returns a fresh deduper with its own memory.
+ */
+export function dedupeCursorStatus(
+  notify: (status: CursorStatus) => void,
+): (status: CursorStatus) => void {
+  let lastKey: string | null = null
+  return (status) => {
+    const key = [status.line, status.column, ...status.path].join('|')
+    if (key !== lastKey) {
+      lastKey = key
+      notify(status)
+    }
   }
 }

--- a/src/app/web/codemirror/enclosing-form.ts
+++ b/src/app/web/codemirror/enclosing-form.ts
@@ -1,0 +1,69 @@
+import { syntaxTree } from '@codemirror/language'
+import type { EditorState } from '@codemirror/state'
+import type { SyntaxNode, Tree } from '@lezer/common'
+
+// Lezer node names -> the short labels shown in the status-bar breadcrumb.
+// Covers special forms, top-level statements, patterns, and leaf atoms. Node
+// types absent from this map (structural wrappers like Program/SExpr, brackets,
+// the specialized keyword tokens, and error nodes) are simply skipped when
+// building a path -- their meaningful ancestor/child still gets a crumb.
+const FORM_LABELS: Record<string, string> = {
+  // Statements
+  Define: 'define',
+  Display: 'display',
+  Struct: 'struct',
+  Import: 'import',
+  // Special forms
+  Lambda: 'lambda',
+  If: 'if',
+  Let: 'let',
+  LetStar: 'let*',
+  Cond: 'cond',
+  Match: 'match',
+  And: 'and',
+  Or: 'or',
+  Begin: 'begin',
+  Section: 'section',
+  Quote: 'quote',
+  Apply: 'apply',
+  WithHandler: 'with-handler',
+  Error: 'error',
+  JsVar: 'js-var',
+  Vector: 'vector',
+  Application: 'application',
+  // Patterns
+  PApp: 'pattern',
+  PVector: 'vector pattern',
+  // Atoms
+  Number: 'number',
+  String: 'string',
+  Boolean: 'boolean',
+  Char: 'char',
+  Identifier: 'identifier',
+  LineComment: 'comment',
+}
+
+/**
+ * Builds the breadcrumb of enclosing syntactic forms at a document offset.
+ * @param tree a Lezer parse tree of a Scamper program
+ * @param pos a document offset
+ * @returns short labels, outermost statement first down to the leaf at `pos`
+ */
+export function formPathAt(tree: Tree, pos: number): string[] {
+  const path: string[] = []
+  let node: SyntaxNode | null = tree.resolveInner(pos, -1)
+  while (node) {
+    const label = FORM_LABELS[node.name]
+    if (label !== undefined) path.push(label)
+    node = node.parent
+  }
+  return path.reverse()
+}
+
+/**
+ * The enclosing-form breadcrumb at the cursor, read off the editor's live
+ * (incrementally-maintained) syntax tree.
+ */
+export function enclosingFormPath(state: EditorState): string[] {
+  return formPathAt(syntaxTree(state), state.selection.main.head)
+}

--- a/src/app/web/codemirror/enclosing-form.ts
+++ b/src/app/web/codemirror/enclosing-form.ts
@@ -53,17 +53,35 @@ export function formPathAt(tree: Tree, pos: number): string[] {
   const path: string[] = []
   let node: SyntaxNode | null = tree.resolveInner(pos, -1)
   while (node) {
-    const label = FORM_LABELS[node.name]
+    // Record indexing is typed as `string`, but this is a partial map: node
+    // types with no label (wrappers, brackets, keyword tokens) return undefined.
+    const label = FORM_LABELS[node.name] as string | undefined
     if (label !== undefined) path.push(label)
     node = node.parent
   }
   return path.reverse()
 }
 
+/** The cursor's position and enclosing-form breadcrumb, for the status bar. */
+export interface CursorStatus {
+  /** 1-based line number. */
+  line: number
+  /** 1-based column number. */
+  column: number
+  /** Enclosing-form breadcrumb, outermost first (see {@link formPathAt}). */
+  path: string[]
+}
+
 /**
- * The enclosing-form breadcrumb at the cursor, read off the editor's live
- * (incrementally-maintained) syntax tree.
+ * Reads the cursor's line/column and enclosing-form breadcrumb off the editor's
+ * live (incrementally-maintained) syntax tree.
  */
-export function enclosingFormPath(state: EditorState): string[] {
-  return formPathAt(syntaxTree(state), state.selection.main.head)
+export function cursorStatus(state: EditorState): CursorStatus {
+  const head = state.selection.main.head
+  const line = state.doc.lineAt(head)
+  return {
+    line: line.number,
+    column: head - line.from + 1,
+    path: formPathAt(syntaxTree(state), head),
+  }
 }

--- a/src/app/web/components/CodeMirrorEditor.vue
+++ b/src/app/web/components/CodeMirrorEditor.vue
@@ -12,8 +12,9 @@ import {
   createCodeMirrorEditorAdapter,
 } from '../composables/codemirror-editor-adapter'
 import { useEditorRegistration } from '../composables/editor-context'
+import type { CursorStatus } from '../codemirror/enclosing-form'
 
-const emit = defineEmits<{ dirty: []; formChange: [path: string[]] }>()
+const emit = defineEmits<{ dirty: []; cursorChange: [status: CursorStatus] }>()
 
 const editorRegistration = useEditorRegistration()
 const containerRef = ref<HTMLDivElement | null>(null)
@@ -31,8 +32,8 @@ onMounted(() => {
     () => {
       emit('dirty')
     },
-    (path) => {
-      emit('formChange', path)
+    (status) => {
+      emit('cursorChange', status)
     },
   )
   editorRegistration.register(adapter)

--- a/src/app/web/components/CodeMirrorEditor.vue
+++ b/src/app/web/components/CodeMirrorEditor.vue
@@ -13,7 +13,7 @@ import {
 } from '../composables/codemirror-editor-adapter'
 import { useEditorRegistration } from '../composables/editor-context'
 
-const emit = defineEmits<{ dirty: [] }>()
+const emit = defineEmits<{ dirty: []; formChange: [path: string[]] }>()
 
 const editorRegistration = useEditorRegistration()
 const containerRef = ref<HTMLDivElement | null>(null)
@@ -26,9 +26,15 @@ onMounted(() => {
     state: mkNoFileEditorState(),
     parent: containerRef.value,
   })
-  adapter = createCodeMirrorEditorAdapter(editorView, () => {
-    emit('dirty')
-  })
+  adapter = createCodeMirrorEditorAdapter(
+    editorView,
+    () => {
+      emit('dirty')
+    },
+    (path) => {
+      emit('formChange', path)
+    },
+  )
   editorRegistration.register(adapter)
 })
 

--- a/src/app/web/components/CodeMirrorEditor.vue
+++ b/src/app/web/components/CodeMirrorEditor.vue
@@ -23,8 +23,11 @@ let adapter: CodeMirrorEditorAdapter | null = null
 
 onMounted(() => {
   if (!containerRef.value) return
+  const emitCursorChange = (status: CursorStatus) => {
+    emit('cursorChange', status)
+  }
   editorView = new EditorView({
-    state: mkNoFileEditorState(),
+    state: mkNoFileEditorState(emitCursorChange),
     parent: containerRef.value,
   })
   adapter = createCodeMirrorEditorAdapter(
@@ -32,9 +35,7 @@ onMounted(() => {
     () => {
       emit('dirty')
     },
-    (status) => {
-      emit('cursorChange', status)
-    },
+    emitCursorChange,
   )
   editorRegistration.register(adapter)
 })

--- a/src/app/web/components/IdeApp.vue
+++ b/src/app/web/components/IdeApp.vue
@@ -7,6 +7,7 @@ import IdeSidebar from './IdeSidebar.vue'
 import IdeHeader from './IdeHeader.vue'
 import ResultsPane from './ResultsPane.vue'
 import CodeMirrorEditor from './CodeMirrorEditor.vue'
+import IdeStatusBar from './IdeStatusBar.vue'
 import { provideEditor } from '../composables/editor-context'
 import type { ResultsPaneType } from '../composables/use-results-pane'
 import { provideScamperSession } from '../composables/use-scamper-session'
@@ -48,6 +49,7 @@ const files = ref<FileEntry[]>([])
 const isSidebarVisible = ref(true)
 const isLoading = ref(true)
 const loadingContent = ref('Loading Scamper...')
+const currentFormPath = ref<string[]>([])
 
 // ---------- editor context + child component refs ----------
 
@@ -106,6 +108,10 @@ function stopAutosaving() {
 function makeDirty() {
   isDirty.value = true
   session.invalidateAllQueries()
+}
+
+function handleFormChange(path: string[]) {
+  currentFormPath.value = path
 }
 
 // ---------- file operations ----------
@@ -416,7 +422,7 @@ onUnmounted(() => {
       <div class="content-area">
         <Splitpanes>
           <Pane :size="65" class="editor-pane">
-            <CodeMirrorEditor @dirty="makeDirty" />
+            <CodeMirrorEditor @dirty="makeDirty" @form-change="handleFormChange" />
           </Pane>
           <Pane :size="35" class="results-pane">
             <ResultsPane
@@ -431,6 +437,7 @@ onUnmounted(() => {
           </Pane>
         </Splitpanes>
       </div>
+      <IdeStatusBar :path="currentFormPath" />
     </div>
   </div>
   <div v-show="isLoading" class="loading">

--- a/src/app/web/components/IdeApp.vue
+++ b/src/app/web/components/IdeApp.vue
@@ -8,6 +8,7 @@ import IdeHeader from './IdeHeader.vue'
 import ResultsPane from './ResultsPane.vue'
 import CodeMirrorEditor from './CodeMirrorEditor.vue'
 import IdeStatusBar from './IdeStatusBar.vue'
+import type { CursorStatus } from '../codemirror/enclosing-form'
 import { provideEditor } from '../composables/editor-context'
 import type { ResultsPaneType } from '../composables/use-results-pane'
 import { provideScamperSession } from '../composables/use-scamper-session'
@@ -49,7 +50,7 @@ const files = ref<FileEntry[]>([])
 const isSidebarVisible = ref(true)
 const isLoading = ref(true)
 const loadingContent = ref('Loading Scamper...')
-const currentFormPath = ref<string[]>([])
+const cursorStatus = ref<CursorStatus>({ line: 1, column: 1, path: [] })
 
 // ---------- editor context + child component refs ----------
 
@@ -110,8 +111,8 @@ function makeDirty() {
   session.invalidateAllQueries()
 }
 
-function handleFormChange(path: string[]) {
-  currentFormPath.value = path
+function handleCursorChange(status: CursorStatus) {
+  cursorStatus.value = status
 }
 
 // ---------- file operations ----------
@@ -422,7 +423,7 @@ onUnmounted(() => {
       <div class="content-area">
         <Splitpanes>
           <Pane :size="65" class="editor-pane">
-            <CodeMirrorEditor @dirty="makeDirty" @form-change="handleFormChange" />
+            <CodeMirrorEditor @dirty="makeDirty" @cursor-change="handleCursorChange" />
           </Pane>
           <Pane :size="35" class="results-pane">
             <ResultsPane
@@ -437,7 +438,11 @@ onUnmounted(() => {
           </Pane>
         </Splitpanes>
       </div>
-      <IdeStatusBar :path="currentFormPath" />
+      <IdeStatusBar
+        :line="cursorStatus.line"
+        :column="cursorStatus.column"
+        :path="cursorStatus.path"
+      />
     </div>
   </div>
   <div v-show="isLoading" class="loading">

--- a/src/app/web/components/IdeStatusBar.vue
+++ b/src/app/web/components/IdeStatusBar.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-// Bottom bar showing the breadcrumb of syntactic forms enclosing the cursor,
-// outermost first (e.g. "define > lambda > cond > application > number").
-defineProps<{ path: string[] }>()
+// Bottom bar showing the cursor's line/column and the breadcrumb of syntactic
+// forms enclosing it, outermost first, e.g.
+// "Ln 4, Col 8: define > lambda > cond > application".
+defineProps<{ line: number; column: number; path: string[] }>()
 </script>
 
 <template>
   <div class="ide-statusbar">
+    <span class="pos">Ln {{ line }}, Col {{ column }}:</span>
     <span v-if="path.length === 0" class="muted">top level</span>
     <template v-for="(form, i) in path" :key="i">
       <span v-if="i > 0" class="sep" aria-hidden="true">›</span>
@@ -27,6 +29,10 @@ defineProps<{ path: string[] }>()
   line-height: 1.4;
   white-space: nowrap;
   overflow-x: auto;
+}
+
+.pos {
+  margin-right: 0.5em;
 }
 
 .sep {

--- a/src/app/web/components/IdeStatusBar.vue
+++ b/src/app/web/components/IdeStatusBar.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+// Bottom bar showing the breadcrumb of syntactic forms enclosing the cursor,
+// outermost first (e.g. "define > lambda > cond > application > number").
+defineProps<{ path: string[] }>()
+</script>
+
+<template>
+  <div class="ide-statusbar">
+    <span v-if="path.length === 0" class="muted">top level</span>
+    <template v-for="(form, i) in path" :key="i">
+      <span v-if="i > 0" class="sep" aria-hidden="true">›</span>
+      <span class="crumb">{{ form }}</span>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.ide-statusbar {
+  flex-shrink: 0;
+  background: var(--surface-muted);
+  color: var(--fg);
+  border-top: 1px solid var(--border-muted);
+  padding: 0.2em 0.6em;
+  font-family:
+    Menlo, Consolas, Monaco, "Liberation Mono", "Lucida Console", monospace;
+  font-size: 0.8em;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow-x: auto;
+}
+
+.sep {
+  margin: 0 0.4em;
+  opacity: 0.5;
+}
+
+.muted {
+  opacity: 0.6;
+  font-style: italic;
+}
+</style>

--- a/src/app/web/composables/codemirror-editor-adapter.ts
+++ b/src/app/web/composables/codemirror-editor-adapter.ts
@@ -5,7 +5,7 @@ import {
   mkFreshEditorState,
   mkNoFileEditorState,
 } from '../codemirror/codemirror'
-import type { CursorStatus } from '../codemirror/enclosing-form'
+import { lineColumnAt, type CursorStatus } from '../codemirror/enclosing-form'
 import { syncQueryDecorations } from '../codemirror/extensions/query'
 
 /** Cursor status reported when no code is under the cursor (top of document). */
@@ -50,14 +50,14 @@ export function createCodeMirrorEditorAdapter(
 
     initializeDummyDoc() {
       loaded = false
-      view.setState(mkNoFileEditorState())
+      view.setState(mkNoFileEditorState(onCursorChange))
       onCursorChange?.(TOP_LEVEL)
     },
 
     getCursorLoc() {
       const idx = view.state.selection.main.from
-      const line = view.state.doc.lineAt(idx)
-      return new Loc(line.number, idx - line.from, idx)
+      const { line, columnOffset } = lineColumnAt(view.state.doc, idx)
+      return new Loc(line, columnOffset, idx)
     },
 
     coordsAtIdx(idx: number) {

--- a/src/app/web/composables/codemirror-editor-adapter.ts
+++ b/src/app/web/composables/codemirror-editor-adapter.ts
@@ -5,12 +5,16 @@ import {
   mkFreshEditorState,
   mkNoFileEditorState,
 } from '../codemirror/codemirror'
+import type { CursorStatus } from '../codemirror/enclosing-form'
 import { syncQueryDecorations } from '../codemirror/extensions/query'
+
+/** Cursor status reported when no code is under the cursor (top of document). */
+const TOP_LEVEL: CursorStatus = { line: 1, column: 1, path: [] }
 
 export function createCodeMirrorEditorAdapter(
   view: EditorView,
   dirtyAction: () => void,
-  onFormChange?: (path: string[]) => void,
+  onCursorChange?: (status: CursorStatus) => void,
 ) {
   let loaded = false
   const scamper = Scamper.getInstance()
@@ -35,19 +39,19 @@ export function createCodeMirrorEditorAdapter(
       view.setState(
         mkFreshEditorState(src, {
           dirtyAction,
-          onFormChange,
+          onCursorChange,
           isReadOnly: false,
         }),
       )
       // setState doesn't fire update listeners; the cursor resets to the top of
-      // the document, so the enclosing form is "top level" (an empty path).
-      onFormChange?.([])
+      // the document, so report the top-level status.
+      onCursorChange?.(TOP_LEVEL)
     },
 
     initializeDummyDoc() {
       loaded = false
       view.setState(mkNoFileEditorState())
-      onFormChange?.([])
+      onCursorChange?.(TOP_LEVEL)
     },
 
     getCursorLoc() {

--- a/src/app/web/composables/codemirror-editor-adapter.ts
+++ b/src/app/web/composables/codemirror-editor-adapter.ts
@@ -10,6 +10,7 @@ import { syncQueryDecorations } from '../codemirror/extensions/query'
 export function createCodeMirrorEditorAdapter(
   view: EditorView,
   dirtyAction: () => void,
+  onFormChange?: (path: string[]) => void,
 ) {
   let loaded = false
   const scamper = Scamper.getInstance()
@@ -34,14 +35,19 @@ export function createCodeMirrorEditorAdapter(
       view.setState(
         mkFreshEditorState(src, {
           dirtyAction,
+          onFormChange,
           isReadOnly: false,
         }),
       )
+      // setState doesn't fire update listeners; the cursor resets to the top of
+      // the document, so the enclosing form is "top level" (an empty path).
+      onFormChange?.([])
     },
 
     initializeDummyDoc() {
       loaded = false
       view.setState(mkNoFileEditorState())
+      onFormChange?.([])
     },
 
     getCursorLoc() {

--- a/test/apps/web/enclosing-form.test.ts
+++ b/test/apps/web/enclosing-form.test.ts
@@ -1,12 +1,21 @@
 import { describe, expect, test } from 'vitest'
 import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
 import { ensureSyntaxTree } from '@codemirror/language'
 import { parser } from '../../../src/scheme/generated/parser.js'
 import { ScamperSupport } from '../../../src/app/web/codemirror/extensions/language'
+import { mkFreshEditorState } from '../../../src/app/web/codemirror/codemirror'
+import { initialize } from '../../../src/scamper'
 import {
   cursorStatus,
+  dedupeCursorStatus,
   formPathAt,
+  type CursorStatus,
 } from '../../../src/app/web/codemirror/enclosing-form'
+
+// mkFreshEditorState installs QueryExtension, whose state field reaches the
+// Scamper singleton; initialize it before building a real editor state.
+await initialize()
 
 // Cursor position is marked with a `|` placed strictly inside the target token
 // (so resolveInner's left-bias lands on that token, not an adjacent one). The
@@ -100,5 +109,79 @@ describe('cursorStatus', () => {
     expect(status.line).toBe(2)
     expect(status.column).toBe(4)
     expect(status.path).toEqual(['define', 'number'])
+  })
+})
+
+describe('dedupeCursorStatus', () => {
+  test('notifies only when the status key changes', () => {
+    const seen: CursorStatus[] = []
+    const notify = dedupeCursorStatus((s) => seen.push(s))
+    notify({ line: 1, column: 1, path: [] })
+    notify({ line: 1, column: 1, path: [] }) // identical -> skipped
+    notify({ line: 1, column: 2, path: [] }) // column changed
+    notify({ line: 1, column: 2, path: ['define'] }) // path changed
+    notify({ line: 2, column: 2, path: ['define'] }) // line changed
+    expect(seen).toEqual([
+      { line: 1, column: 1, path: [] },
+      { line: 1, column: 2, path: [] },
+      { line: 1, column: 2, path: ['define'] },
+      { line: 2, column: 2, path: ['define'] },
+    ])
+  })
+
+  test('a longer path at the same line/column still notifies', () => {
+    const seen: CursorStatus[] = []
+    const notify = dedupeCursorStatus((s) => seen.push(s))
+    notify({ line: 1, column: 2, path: ['a'] })
+    notify({ line: 1, column: 2, path: ['a', 'b'] })
+    expect(seen).toHaveLength(2)
+  })
+
+  test('each deduper keeps independent memory', () => {
+    const a: CursorStatus[] = []
+    const b: CursorStatus[] = []
+    const na = dedupeCursorStatus((s) => a.push(s))
+    const nb = dedupeCursorStatus((s) => b.push(s))
+    na({ line: 1, column: 1, path: [] })
+    nb({ line: 1, column: 1, path: [] })
+    expect(a).toHaveLength(1)
+    expect(b).toHaveLength(1)
+  })
+})
+
+describe('onCursorChange wiring (codemirror.ts)', () => {
+  // A real EditorView exercises the update-listener + dedup path end-to-end
+  // (jsdom is fine for dispatch; see query-decorations.test.ts).
+  function mountEditor(doc: string) {
+    const calls: CursorStatus[] = []
+    const view = new EditorView({
+      state: mkFreshEditorState(doc, {
+        dirtyAction: () => {
+          /* empty */
+        },
+        onCursorChange: (s) => calls.push(s),
+        isReadOnly: false,
+      }),
+      parent: document.createElement('div'),
+    })
+    return { view, calls }
+  }
+
+  test('notifies with 1-based line/column when the cursor moves', () => {
+    const doc = '(define x\n  10)'
+    const { view, calls } = mountEditor(doc)
+    view.dispatch({ selection: { anchor: doc.indexOf('10') + 1 } })
+    expect(calls.at(-1)).toMatchObject({ line: 2, column: 4 })
+    view.destroy()
+  })
+
+  test('does not re-notify when the cursor stays put', () => {
+    const doc = '(define x 10)'
+    const { view, calls } = mountEditor(doc)
+    view.dispatch({ selection: { anchor: 5 } })
+    const n = calls.length
+    view.dispatch({ selection: { anchor: 5 } }) // same position -> deduped
+    expect(calls).toHaveLength(n)
+    view.destroy()
   })
 })

--- a/test/apps/web/enclosing-form.test.ts
+++ b/test/apps/web/enclosing-form.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest'
+import { EditorState } from '@codemirror/state'
+import { ensureSyntaxTree } from '@codemirror/language'
+import { parser } from '../../../src/scheme/generated/parser.js'
+import { ScamperSupport } from '../../../src/app/web/codemirror/extensions/language'
+import {
+  enclosingFormPath,
+  formPathAt,
+} from '../../../src/app/web/codemirror/enclosing-form'
+
+// Cursor position is marked with a `|` placed strictly inside the target token
+// (so resolveInner's left-bias lands on that token, not an adjacent one). The
+// marker is stripped before parsing and its index is used as the offset.
+function pathAtCursor(marked: string): string[] {
+  const pos = marked.indexOf('|')
+  if (pos < 0) throw new Error('test source needs a | cursor marker')
+  const src = marked.slice(0, pos) + marked.slice(pos + 1)
+  return formPathAt(parser.parse(src), pos)
+}
+
+describe('formPathAt', () => {
+  test('breadcrumb from outermost statement down to a leaf atom', () => {
+    // Cursor inside the `10` in the cond branch.
+    expect(
+      pathAtCursor('(define f (lambda (num) (cond [(pos? num) 1|0] [else 20])))'),
+    ).toEqual(['define', 'lambda', 'cond', 'number'])
+  })
+
+  test('includes application and names the identifier under the cursor', () => {
+    // Cursor inside `num` within the application `(pos? num)`.
+    expect(
+      pathAtCursor('(define f (lambda (num) (cond [(pos? nu|m) 10] [else 20])))'),
+    ).toEqual(['define', 'lambda', 'cond', 'application', 'identifier'])
+  })
+
+  test('top-level whitespace yields an empty path', () => {
+    expect(pathAtCursor('(define x 10)\n|\n(define y 20)')).toEqual([])
+  })
+
+  test('names string literals', () => {
+    expect(pathAtCursor('(define s "hel|lo")')).toEqual(['define', 'string'])
+  })
+
+  test('skips the bare-expression wrapper and names booleans', () => {
+    expect(pathAtCursor('(if #|t 10 20)')).toEqual(['if', 'boolean'])
+  })
+
+  test('let binding value vs. body', () => {
+    expect(pathAtCursor('(let ([count 1|0]) count)')).toEqual(['let', 'number'])
+    expect(pathAtCursor('(let ([count 10]) cou|nt)')).toEqual([
+      'let',
+      'identifier',
+    ])
+  })
+
+  test('match branch patterns are labeled', () => {
+    expect(pathAtCursor('(match lst [(cons h|d tl) hd])')).toEqual([
+      'match',
+      'pattern',
+      'identifier',
+    ])
+  })
+
+  test('quoted list data', () => {
+    expect(pathAtCursor("(define q '(1 2 3|0))")).toEqual([
+      'define',
+      'quote',
+      'application',
+      'number',
+    ])
+  })
+})
+
+describe('enclosingFormPath', () => {
+  // Exercises the production path: the breadcrumb read off a real CodeMirror
+  // state configured with ScamperSupport, at state.selection.head. In the app
+  // the EditorView drives parsing; here ensureSyntaxTree forces it.
+  test('reads the cursor form from a live editor state', () => {
+    const doc = '(define f (lambda (num) (cond [(pos? num) 10] [else 20])))'
+    const state = EditorState.create({
+      doc,
+      selection: { anchor: doc.indexOf('10') + 1 },
+      extensions: [ScamperSupport()],
+    })
+    ensureSyntaxTree(state, doc.length, 5000)
+    expect(enclosingFormPath(state)).toEqual([
+      'define',
+      'lambda',
+      'cond',
+      'number',
+    ])
+  })
+})

--- a/test/apps/web/enclosing-form.test.ts
+++ b/test/apps/web/enclosing-form.test.ts
@@ -4,7 +4,7 @@ import { ensureSyntaxTree } from '@codemirror/language'
 import { parser } from '../../../src/scheme/generated/parser.js'
 import { ScamperSupport } from '../../../src/app/web/codemirror/extensions/language'
 import {
-  enclosingFormPath,
+  cursorStatus,
   formPathAt,
 } from '../../../src/app/web/codemirror/enclosing-form'
 
@@ -71,23 +71,34 @@ describe('formPathAt', () => {
   })
 })
 
-describe('enclosingFormPath', () => {
-  // Exercises the production path: the breadcrumb read off a real CodeMirror
-  // state configured with ScamperSupport, at state.selection.head. In the app
-  // the EditorView drives parsing; here ensureSyntaxTree forces it.
-  test('reads the cursor form from a live editor state', () => {
-    const doc = '(define f (lambda (num) (cond [(pos? num) 10] [else 20])))'
+describe('cursorStatus', () => {
+  // Exercises the production path: status read off a real CodeMirror state
+  // configured with ScamperSupport, at state.selection.head. In the app the
+  // EditorView drives parsing; here ensureSyntaxTree forces it.
+  function statusAt(doc: string, anchor: number) {
     const state = EditorState.create({
       doc,
-      selection: { anchor: doc.indexOf('10') + 1 },
+      selection: { anchor },
       extensions: [ScamperSupport()],
     })
     ensureSyntaxTree(state, doc.length, 5000)
-    expect(enclosingFormPath(state)).toEqual([
-      'define',
-      'lambda',
-      'cond',
-      'number',
-    ])
+    return cursorStatus(state)
+  }
+
+  test('reads breadcrumb plus 1-based line/column on a single line', () => {
+    const doc = '(define f (lambda (num) (cond [(pos? num) 10] [else 20])))'
+    const anchor = doc.indexOf('10') + 1
+    const status = statusAt(doc, anchor)
+    expect(status.path).toEqual(['define', 'lambda', 'cond', 'number'])
+    expect(status.line).toBe(1)
+    expect(status.column).toBe(anchor + 1)
+  })
+
+  test('computes 1-based line/column across multiple lines', () => {
+    const doc = '(define x\n  10)'
+    const status = statusAt(doc, doc.indexOf('10') + 1)
+    expect(status.line).toBe(2)
+    expect(status.column).toBe(4)
+    expect(status.path).toEqual(['define', 'number'])
   })
 })


### PR DESCRIPTION
_(Co-created with Claude Code)_

## Summary

Adds a bottom status bar to the web IDE that shows the cursor's **line/column** and the **breadcrumb of syntactic forms** enclosing it, updating live as the cursor moves or the document changes. Format:

```
Ln 4, Col 8: define › lambda › cond › application
```

## How it works

- **`enclosing-form.ts`** — `formPathAt(tree, pos)` walks the Lezer parse tree from the leaf at `pos` up to the outermost statement, mapping node types to short labels via `FORM_LABELS`. `cursorStatus(state)` wraps it, also returning the 1-based line/column. Both read CodeMirror's already-maintained incremental `syntaxTree(state)`, so there is no extra parsing and no coupling to the `lezer-bridge` compile path.
- **Wiring** — `codemirror.ts` gains an optional `onCursorChange` config, fired (deduped) from the editor's update listener on `selectionSet`/`docChanged`; it is threaded through the editor adapter and `CodeMirrorEditor.vue`, which emits `cursor-change`.
- **`IdeStatusBar.vue`** — small component rendering `Ln x, Col x:` followed by the breadcrumb (falls back to "top level"); `IdeApp.vue` docks it under the editor/results split, styled with the theme tokens.

Display choices: the full nesting **breadcrumb** (not just the innermost form), and leaf **atoms/literals are named** (number, string, identifier, …).

## Testing

- `test/apps/web/enclosing-form.test.ts`: `formPathAt` across define / lambda / cond / let / match / quote / if + atoms, and `cursorStatus` against a live `ScamperSupport` editor state — asserting the breadcrumb plus 1-based line/column on single- and multi-line documents.
- `npm run typecheck`, `npm run lint` (0 new warnings), and the full `vitest` suite (1227 passing) are green.
- Visually verified in-browser: the bar renders at the bottom, shows `Ln 1, Col 1: top level`, and updates live (`define › lambda › cond › string` / `… › application`) as the cursor moves.
