### PR TITLE
Fix parse-csv docstring return type (list?, not any)

### DIFF
--- a/src/lib/data.scm
+++ b/src/lib/data.scm
@@ -1,4 +1,4 @@
-;;; (parse-csv data) -> any
+;;; (parse-csv data) -> list?
 ;;;  data : string?
 ;;; Parses `data` as a CSV-formatted string and returns a list of rows where each row is a list of fields as strings.
 ;;; @category data, parse


### PR DESCRIPTION
## Summary
Fixes #286. The `parse-csv` docstring declared its return type as `any`, contradicting its own description ("returns a list of rows where each row is a list of fields as strings").

Verified against the implementation: `data_parseCsv` (`src/js/data/utils.ts`) returns `L.vectorToList(...)` — an `L.List`. Corrected the annotation to `list?`, matching sibling data functions (`string->chars`, `string->lines`, `tally-all`).

## Changes
- `src/lib/data.scm`: `(parse-csv data) -> any` → `-> list?`

## Validation
- Typecheck: PASS
- Tests: 82 files pass (1286 tests)
- Lint: 0 errors

_(Co-created with Claude Code)_