### PR TITLE
Add a one-time patch-notes modal per version (#306)

### DIFF
--- a/src/app/web/components/IdeApp.vue
+++ b/src/app/web/components/IdeApp.vue
@@ -24,6 +24,8 @@ import {
   modalConfirm,
   modalPrompt,
 } from '../composables/use-modals'
+import PatchNotesModal from './PatchNotesModal.vue'
+import { compareVersions, patchNotesSince, type PatchNote } from '../patch-notes'
 
 // ---------- config ----------
 
@@ -45,7 +47,7 @@ const appVersion = `(${APP_VERSION})`
 
 let fs: FS.t | null = null
 let fileSession: FileSession | null = null
-let config: Config = DEFAULT_CONFIG
+let config: Config = { ...DEFAULT_CONFIG }
 let isLoadingFile = false
 
 // ---------- reactive state ----------
@@ -57,6 +59,8 @@ const isSidebarVisible = ref(true)
 const isLoading = ref(true)
 const loadingContent = ref('Loading Scamper...')
 const cursorStatus = ref<CursorStatus>({ line: 1, column: 1, path: [] })
+const patchNotesToShow = ref<PatchNote[]>([])
+const showPatchNotes = ref(false)
 
 // ---------- editor context + child component refs ----------
 
@@ -93,11 +97,43 @@ async function saveConfig() {
 async function loadConfig() {
   if (!fs) return
   if (await fs.fileExists(CONFIG_FILENAME)) {
-    config = JSON.parse(await fs.loadFile(CONFIG_FILENAME)) as Config
+    // Merge over the defaults so a config written by an older build (missing a
+    // newer field) still loads with sane values.
+    const stored = JSON.parse(await fs.loadFile(CONFIG_FILENAME)) as Partial<Config>
+    config = { ...DEFAULT_CONFIG, ...stored }
   } else {
-    config = DEFAULT_CONFIG
+    // A brand-new user starts already "caught up" to the current version, so
+    // they aren't greeted with a backlog of patch notes.
+    config = { ...DEFAULT_CONFIG, lastVersionAccessed: APP_VERSION }
     await saveConfig()
   }
+}
+
+// Records the current version as seen so its patch notes aren't shown again.
+// Only ever moves forward, so running an older build never rewinds the seen
+// version (which would re-show notes on a later re-upgrade).
+async function markVersionSeen() {
+  if (compareVersions(config.lastVersionAccessed, APP_VERSION) < 0) {
+    config.lastVersionAccessed = APP_VERSION
+    await saveConfig()
+  }
+}
+
+// Shows patch notes for any versions the user hasn't seen yet. The version is
+// recorded as seen as soon as the notes are shown (not on dismissal), so a user
+// who closes the tab without clicking through still isn't shown them again.
+async function showPatchNotesIfNeeded() {
+  const unseen = patchNotesSince(config.lastVersionAccessed, APP_VERSION)
+  await markVersionSeen()
+  if (unseen.length > 0) {
+    patchNotesToShow.value = unseen
+    showPatchNotes.value = true
+  }
+}
+
+function handlePatchNotesClose() {
+  showPatchNotes.value = false
+  patchNotesToShow.value = []
 }
 
 // ---------- autosave ----------
@@ -409,6 +445,8 @@ onMounted(async () => {
 
   isLoading.value = false
   Scamper.getInstance().calibrateScheduler()
+
+  await showPatchNotesIfNeeded()
 })
 
 onUnmounted(() => {
@@ -481,6 +519,11 @@ onUnmounted(() => {
     :query-id="expandedQueryId"
   />
   <ModalHost />
+  <PatchNotesModal
+    :open="showPatchNotes"
+    :notes="patchNotesToShow"
+    @close="handlePatchNotesClose"
+  />
 </template>
 
 <style scoped>

--- a/src/app/web/components/PatchNotesModal.vue
+++ b/src/app/web/components/PatchNotesModal.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import AppModal from './AppModal.vue'
+import type { PatchNote } from '../patch-notes'
+
+// A one-time "what's new" dialog (issue #306), shown when a user opens a version
+// of Scamper they haven't seen. Built on the generic AppModal (#305). The parent
+// (IdeApp) owns the `open` state and records the seen version on close.
+defineProps<{ open: boolean; notes: PatchNote[] }>()
+const emit = defineEmits<{ close: [] }>()
+</script>
+
+<template>
+  <AppModal :open="open" title="What's new in Scamper" @dismiss="emit('close')">
+    <div class="patch-notes">
+      <section v-for="note in notes" :key="note.version" class="patch-note">
+        <h3 class="patch-note__version">
+          Version {{ note.version
+          }}<span v-if="note.title"> — {{ note.title }}</span>
+        </h3>
+        <ul class="patch-note__list">
+          <li v-for="(item, i) in note.notes" :key="i">{{ item }}</li>
+        </ul>
+      </section>
+    </div>
+    <template #footer>
+      <button type="button" class="patch-notes__button" autofocus @click="emit('close')">
+        Got it
+      </button>
+    </template>
+  </AppModal>
+</template>
+
+<style scoped>
+.patch-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.patch-note__version {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.patch-note__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.patch-notes__button {
+  padding: 0.4rem 0.9rem;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background-color: var(--accent);
+  color: var(--accent-fg);
+  font: inherit;
+  cursor: pointer;
+}
+
+.patch-notes__button:hover {
+  filter: brightness(1.05);
+}
+</style>

--- a/src/app/web/patch-notes.ts
+++ b/src/app/web/patch-notes.ts
@@ -1,0 +1,67 @@
+// Patch notes shown to a user the first time they open a new version of Scamper
+// (issue #306). The IDE records the last version a user has seen in its config
+// file; on load it shows notes for every release between that version and the
+// current one, then records the current version so they are not shown again.
+//
+// To announce a release: add an entry here whose `version` matches the app
+// version (package.json). Keep `notes` short and user-facing -- these are what
+// students read, not a full changelog. Order does not matter; entries are
+// sorted newest-first when displayed.
+
+export interface PatchNote {
+  /** The release version these notes describe, e.g. '3.5.0'. */
+  version: string
+  /** An optional one-line headline for the release. */
+  title?: string
+  /** User-facing highlights, one bullet each. */
+  notes: string[]
+}
+
+export const patchNotes: PatchNote[] = [
+  {
+    version: '3.5.0',
+    title: 'Editor upgrades',
+    notes: [
+      'Hover a function name in the editor to read its documentation, jump to its definition, or find where it is used.',
+      'A status bar now shows the syntactic form enclosing your cursor.',
+      "In-app dialogs replace the browser's built-in pop-ups and follow the light/dark theme.",
+      'Inline comments inside an expression no longer cause spurious parse errors.',
+    ],
+  },
+]
+
+/**
+ * Compares two dotted numeric version strings (e.g. '3.5.0'). Only numeric
+ * components are supported; a non-numeric component compares as NaN, which
+ * makes patchNotesSince fall through to showing nothing (a safe default).
+ * @returns a negative number if a < b, 0 if equal, a positive number if a > b.
+ */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.')
+  const pb = b.split('.')
+  const len = Math.max(pa.length, pb.length)
+  for (let i = 0; i < len; i++) {
+    const da = Number(pa[i] ?? 0)
+    const db = Number(pb[i] ?? 0)
+    if (da !== db) return da - db
+  }
+  return 0
+}
+
+/**
+ * The patch notes a user should see, given the last version they saw and the
+ * current app version: every release newer than `lastSeen` and no newer than
+ * `current`, sorted newest-first.
+ */
+export function patchNotesSince(
+  lastSeen: string,
+  current: string,
+): PatchNote[] {
+  return patchNotes
+    .filter(
+      (n) =>
+        compareVersions(n.version, lastSeen) > 0 &&
+        compareVersions(n.version, current) <= 0,
+    )
+    .sort((x, y) => compareVersions(y.version, x.version))
+}

--- a/test/apps/web/ide-patch-notes.test.ts
+++ b/test/apps/web/ide-patch-notes.test.ts
@@ -1,0 +1,147 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { findByRole, getByRole, queryByRole } from '@testing-library/dom'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest'
+import IdeApp from '../../../src/app/web/components/IdeApp.vue'
+import * as FS from '../../../src/fs'
+import { MockFileSystem } from '../../stubs/mock-file-system'
+import { initialize } from '../../../src/scamper'
+
+vi.mock('../../../src/app/web/lockfile', () => ({
+  acquireLockFile: vi.fn(() => Promise.resolve(true)),
+  releaseLockFile: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock(
+  '../../../src/app/web/components/CodeMirrorEditor.vue',
+  () => import('../../stubs/MockCodeMirrorEditor.vue'),
+)
+
+vi.mock(
+  '../../../src/app/web/components/ResultsPane.vue',
+  () => import('../../stubs/MockResultsPane.vue'),
+)
+
+await initialize()
+
+const CONFIG_FILENAME = '.scamper.config'
+
+// Patch notes are shown on the first visit to a new version (issue #306). These
+// tests drive IdeApp against a seeded config to exercise the version gate.
+describe('IDE patch-notes gate', () => {
+  let fs: MockFileSystem
+
+  // These tests need a real dotted-numeric app version, which `npm test` (and
+  // validate-build) provide via npm_package_version. Fail fast with a clear
+  // message rather than a confusing timeout if it's the 'unknown' fallback.
+  beforeAll(() => {
+    expect(APP_VERSION).toMatch(/^\d+(\.\d+)*$/)
+  })
+
+  beforeEach(() => {
+    fs = new MockFileSystem()
+    FS.setFS(fs)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  async function readConfigVersion(): Promise<string> {
+    const raw = await fs.loadFile(CONFIG_FILENAME)
+    return (JSON.parse(raw) as { lastVersionAccessed: string })
+      .lastVersionAccessed
+  }
+
+  test('shows patch notes to a user upgrading from an older version', async () => {
+    await fs.saveFile(
+      CONFIG_FILENAME,
+      JSON.stringify({ lastOpenedFilename: null, lastVersionAccessed: '0.0.1' }),
+    )
+
+    const wrapper = mount(IdeApp, { attachTo: document.body })
+    try {
+      await findByRole(document.body, 'dialog', { name: /what's new/i })
+      const dialog = getByRole(document.body, 'dialog', { name: /what's new/i })
+      // The current release's notes are present.
+      expect(dialog.textContent).toContain('Version')
+
+      // The version is recorded as soon as the notes are shown -- so closing the
+      // tab without clicking through would not re-show them.
+      expect(await readConfigVersion()).toBe(APP_VERSION)
+
+      getByRole(dialog, 'button', { name: 'Got it' }).click()
+      await flushPromises()
+
+      // Dismissing closes it; it stays recorded, so it won't show again.
+      expect(
+        queryByRole(document.body, 'dialog', { name: /what's new/i }),
+      ).toBeNull()
+      expect(await readConfigVersion()).toBe(APP_VERSION)
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  test('treats a legacy config missing lastVersionAccessed as an upgrade', async () => {
+    // Configs written before this feature have no lastVersionAccessed; the
+    // default ('0.0.0') should make everything count as unseen.
+    await fs.saveFile(
+      CONFIG_FILENAME,
+      JSON.stringify({ lastOpenedFilename: null }),
+    )
+
+    const wrapper = mount(IdeApp, { attachTo: document.body })
+    try {
+      await findByRole(document.body, 'dialog', { name: /what's new/i })
+      expect(await readConfigVersion()).toBe(APP_VERSION)
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  test('does not show patch notes to a brand-new user', async () => {
+    // No config file exists.
+    const wrapper = mount(IdeApp, { attachTo: document.body })
+    try {
+      await findByRole(document.body, 'button', { name: 'Create file' })
+      await flushPromises()
+      expect(
+        queryByRole(document.body, 'dialog', { name: /what's new/i }),
+      ).toBeNull()
+      // A fresh user is recorded as already caught up to the current version.
+      expect(await readConfigVersion()).toBe(APP_VERSION)
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  test('does not show patch notes to a user already on the current version', async () => {
+    await fs.saveFile(
+      CONFIG_FILENAME,
+      JSON.stringify({
+        lastOpenedFilename: null,
+        lastVersionAccessed: APP_VERSION,
+      }),
+    )
+
+    const wrapper = mount(IdeApp, { attachTo: document.body })
+    try {
+      await findByRole(document.body, 'button', { name: 'Create file' })
+      await flushPromises()
+      expect(
+        queryByRole(document.body, 'dialog', { name: /what's new/i }),
+      ).toBeNull()
+    } finally {
+      wrapper.unmount()
+    }
+  })
+})

--- a/test/apps/web/patch-notes.test.ts
+++ b/test/apps/web/patch-notes.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import PatchNotesModal from '../../../src/app/web/components/PatchNotesModal.vue'
+import {
+  compareVersions,
+  patchNotes,
+  patchNotesSince,
+  type PatchNote,
+} from '../../../src/app/web/patch-notes'
+
+describe('compareVersions', () => {
+  test('orders dotted numeric versions', () => {
+    expect(Math.sign(compareVersions('3.5.0', '3.4.0'))).toBe(1)
+    expect(Math.sign(compareVersions('3.4.0', '3.5.0'))).toBe(-1)
+    expect(compareVersions('3.5.0', '3.5.0')).toBe(0)
+  })
+
+  test('compares numerically, not lexically', () => {
+    expect(Math.sign(compareVersions('3.10.0', '3.9.0'))).toBe(1)
+  })
+
+  test('treats missing trailing components as zero', () => {
+    expect(compareVersions('3.5', '3.5.0')).toBe(0)
+    expect(Math.sign(compareVersions('3.5.1', '3.5'))).toBe(1)
+  })
+})
+
+describe('patchNotesSince', () => {
+  test('shipped patch notes are internally well-formed', () => {
+    for (const note of patchNotes) {
+      expect(note.version).toMatch(/^\d+(\.\d+)*$/)
+      expect(note.notes.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('excludes versions at or below lastSeen and above current', () => {
+    // Already caught up to the newest release: nothing to show.
+    const newest = patchNotes
+      .map((n) => n.version)
+      .sort((a, b) => compareVersions(b, a))[0]
+    expect(patchNotesSince(newest, newest)).toEqual([])
+    // current below every note: nothing to show.
+    expect(patchNotesSince('0.0.0', '0.0.1')).toEqual([])
+  })
+
+  test('returns everything after lastSeen up to current, newest-first', () => {
+    const all = patchNotesSince('0.0.0', '999.0.0')
+    expect(all.length).toBe(patchNotes.length)
+    for (let i = 1; i < all.length; i++) {
+      // strictly descending
+      expect(compareVersions(all[i - 1].version, all[i].version)).toBeGreaterThan(0)
+    }
+    for (const note of all) {
+      expect(compareVersions(note.version, '0.0.0')).toBeGreaterThan(0)
+    }
+  })
+
+  test('the upper bound is inclusive (a note equal to current is shown)', () => {
+    const newest = patchNotesSince('0.0.0', '999.0.0')[0]
+    expect(patchNotesSince('0.0.0', newest.version)[0].version).toBe(
+      newest.version,
+    )
+  })
+})
+
+describe('PatchNotesModal', () => {
+  const notes: PatchNote[] = [
+    { version: '3.5.0', title: 'Editor upgrades', notes: ['Alpha', 'Beta'] },
+    { version: '3.4.0', notes: ['Gamma'] },
+  ]
+
+  test('renders each version, title, and bullet', () => {
+    const wrapper = mount(PatchNotesModal, { props: { open: true, notes } })
+    const text = wrapper.text()
+    expect(text).toContain('Version 3.5.0')
+    expect(text).toContain('Editor upgrades')
+    expect(text).toContain('Alpha')
+    expect(text).toContain('Beta')
+    expect(text).toContain('Version 3.4.0')
+    expect(text).toContain('Gamma')
+    expect(wrapper.findAll('li')).toHaveLength(3)
+    wrapper.unmount()
+  })
+
+  test('emits close when the "Got it" button is clicked', async () => {
+    const wrapper = mount(PatchNotesModal, { props: { open: true, notes } })
+    await wrapper.find('.patch-notes__button').trigger('click')
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  test('emits close when the dialog is dismissed (Esc/backdrop)', async () => {
+    const wrapper = mount(PatchNotesModal, { props: { open: true, notes } })
+    wrapper.find('dialog').element.dispatchEvent(new Event('close'))
+    await flushPromises()
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
Fixes #306. Adds a "What's new" dialog shown the first time a user opens a version of Scamper they haven't seen. Once seen, it isn't shown again. The seen-version state lives in the existing `.scamper.config` (`Config.lastVersionAccessed`, which was already declared but unused), and patch notes are declared per release in a data file.

## Design
- **`patch-notes.ts`** — the `PatchNote` data array plus `compareVersions` / `patchNotesSince(lastSeen, current)` (returns the notes strictly newer than `lastSeen` and no newer than `current`, newest-first). Seeded with 3.5.0 highlights; adding a future release is a one-object append (documented in the file header).
- **`PatchNotesModal.vue`** — renders the notes; built on the generic `AppModal` from #305, so it inherits theming, `::backdrop`, focus, Esc, and a11y.
- **`IdeApp.vue`** — after load, shows the modal for any unseen versions.
  - The seen version is recorded **as soon as the notes are shown** (not on dismissal), so closing the tab without clicking through won't re-show them.
  - `markVersionSeen` only moves the recorded version **forward** — running an older build never rewinds it.
  - A **brand-new user** is recorded as already caught up, so they don't get a backlog of notes.
  - `loadConfig` now merges over the defaults, so a config written by an older build (missing a field) still loads.

## Content honesty
The seeded 3.5.0 bullets map to actually-shipped work: LSP hover/goto-def/find-refs (#303), the enclosing-form status bar (#301), in-app themed dialogs (#305), and the inline-comment parse fix (#302).

## Testing
- `patch-notes.test.ts`: `compareVersions` (numeric vs lexical, missing components, inclusive upper bound), `patchNotesSince` range/sort, and the `PatchNotesModal` render/emit.
- `ide-patch-notes.test.ts`: mounts the **real IdeApp** against a seeded config — upgrading user sees the modal **and the version is recorded on display**; new user and already-current user stay silent; a legacy config missing the field is treated as an upgrade.
- **Verified end-to-end in a real browser**: upgrading user sees the modal, "Got it" records the version, and it does not reappear on reload.

## Validation
- Typecheck: PASS · Tests: 85 files / 1319 tests (`npm test`) · Lint: clean on changed files
- Independent code review performed; its should-fix (record-on-display vs on-dismiss) and nits (forward-only version, config aliasing, legacy-config test) are all addressed here.

_(Co-created with Claude Code)_