### PR TITLE
Use Clojure-style "&" for rest parameters, allowing zero fixed params (#272)

### DIFF
--- a/src/app/web/codemirror/extensions/language.ts
+++ b/src/app/web/codemirror/extensions/language.ts
@@ -40,7 +40,7 @@ export const ScamperLanguage = LRLanguage.define({
         '( )': t.paren,
         '[ ]': t.squareBracket,
         '{ }': t.brace,
-        RestDot: t.punctuation,
+        Amp: t.punctuation,
       }),
     ],
   }),

--- a/src/app/web/codemirror/lsp/signature.ts
+++ b/src/app/web/codemirror/lsp/signature.ts
@@ -37,7 +37,7 @@ export function signatureHelpAt(src: string, offset: number): SignatureHelp | nu
 }
 
 /**
- * Renders a signature label (`(name a b . rest) -> ret`, matching
+ * Renders a signature label (`(name a b & rest) -> ret`, matching
  * functionDocSignature) together with each parameter's `[start, end]` offset
  * range into that label, so the client can highlight the active argument.
  */
@@ -54,7 +54,7 @@ function buildSignature(
   const parameters: ParameterInformation[] = []
   params.forEach((p, i) => {
     const isRest = doc.restParam !== undefined && i === params.length - 1
-    label += isRest ? ' . ' : ' '
+    label += isRest ? ' & ' : ' '
     const start = label.length
     label += p.name
     const desc = p.description === undefined ? '' : ` — ${p.description}`

--- a/src/lib/audio.scm
+++ b/src/lib/audio.scm
@@ -32,7 +32,7 @@
 ;;; Returns `#t` if and only if `v` is an audio pipeline.
 (define pipeline? (js-var "audio_pipelineQ"))
 
-;;; (audio-pipeline ctx pipeline . n1) -> pipeline?
+;;; (audio-pipeline ctx pipeline & n1) -> pipeline?
 ;;;  ctx : context?
 ;;;  pipeline : audio-node?
 ;;;  n1 : audio-node?

--- a/src/lib/canvas.scm
+++ b/src/lib/canvas.scm
@@ -71,7 +71,7 @@
 ;;; @category canvas, mutation, predicates, shapes, canvas-rectangle!, canvas-ellipse!
 (define canvas-circle! (js-var "canvas_canvasCircle"))
 
-;;; (canvas-text! canvas x y text size mode color . font) -> void?
+;;; (canvas-text! canvas x y text size mode color & font) -> void?
 ;;;  canvas : canvas?
 ;;;  x : integer?
 ;;;  y : integer?

--- a/src/lib/data.scm
+++ b/src/lib/data.scm
@@ -50,14 +50,14 @@
 ;;; @category data, create, with-plot-options
 (define with-dataset-options (js-var "data_withDatasetOptions"))
 
-;;; (plot-linear . datasets) -> plot?
+;;; (plot-linear & datasets) -> plot?
 ;;;  datasets : any
 ;;;   list of datasets
 ;;; Creates a linear plot from the provided list of datasets. Valid datasets for this plot include line, bar, scatter, and bubble datasets.
 ;;; @category data, create, plot, plot-category, plot-radial
 (define plot-linear (js-var "data_plotLinear"))
 
-;;; (plot-category labels . datasets) -> plot?
+;;; (plot-category labels & datasets) -> plot?
 ;;;  labels : any
 ;;;   list of strings
 ;;;  datasets : any
@@ -66,7 +66,7 @@
 ;;; @category data, create, plot, plot-linear, plot-radial
 (define plot-category (js-var "data_plotCategory"))
 
-;;; (plot-radial labels . datasets) -> plot?
+;;; (plot-radial labels & datasets) -> plot?
 ;;;  labels : any
 ;;;   list of strings
 ;;;  datasets : any

--- a/src/lib/html.scm
+++ b/src/lib/html.scm
@@ -35,14 +35,14 @@
 ;;; @category html, button?
 (define button (js-var "html_button"))
 
-;;; (tag name . c) -> element?
+;;; (tag name & c) -> element?
 ;;;  name : string?
 ;;;  c : any
 ;;; Creates an HTML element with the given name and children.
 ;;; @category html, tag-set-children?
 (define tag (js-var "html_tag"))
 
-;;; (tag-set-children! elt . c) -> element?
+;;; (tag-set-children! elt & c) -> element?
 ;;;  elt : any
 ;;;   an HTML element
 ;;;  c : any

--- a/src/lib/image.scm
+++ b/src/lib/image.scm
@@ -41,7 +41,7 @@
 ;;; @category color, image, predicates, rgb, typecheck, rgb-func, color-func, rgb-component?, rgb-distance
 (define rgb? (js-var "image_isRgb"))
 
-;;; (rgb r g b . a) -> rgb?
+;;; (rgb r g b & a) -> rgb?
 ;;;  r : rgb-component?
 ;;;  g : rgb-component?
 ;;;  b : rgb-component?
@@ -112,7 +112,7 @@
 ;;; @category color, image, hsv, predicates, typecheck, hsv-func
 (define hsv? (js-var "image_isHsv"))
 
-;;; (hsv h s v . a) -> hsv?
+;;; (hsv h s v & a) -> hsv?
 ;;;  h : number?
 ;;;   0 <= h <= 360
 ;;;  s : number?
@@ -389,13 +389,13 @@
 ;;; @category image, path, with-dash
 (define path (js-var "image_path"))
 
-;;; (beside . d1) -> image?
+;;; (beside & d1) -> image?
 ;;;  d1 : image?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., beside each other (horizontally).
 ;;; @category composition/placement, image, beside/align, above, above/align, overlay, overlay/align, overlay/offset, rotate
 (define beside (js-var "image_beside"))
 
-;;; (beside/align align . d1) -> image?
+;;; (beside/align align & d1) -> image?
 ;;;  align : string?
 ;;;   either "top", "center", or "bottom"
 ;;;  d1 : image?
@@ -403,13 +403,13 @@
 ;;; @category composition/placement, image, beside, above, above/align, overlay, overlay/align, overlay/offset, rotate
 (define beside/align (js-var "image_besideAlign"))
 
-;;; (above . d1) -> image?
+;;; (above & d1) -> image?
 ;;;  d1 : image?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., above each other (vertically in descending order).
 ;;; @category composition/placement, image, beside, beside/align, above/align, overlay, overlay/align, overlay/offset, rotate
 (define above (js-var "image_above"))
 
-;;; (above/align align . d1) -> image?
+;;; (above/align align & d1) -> image?
 ;;;  align : string?
 ;;;   either "left", "middle", or "right"
 ;;;  d1 : image?
@@ -417,13 +417,13 @@
 ;;; @category composition/placement, image, beside, beside/align, above, overlay, overlay/align, overlay/offset, rotate
 (define above/align (js-var "image_aboveAlign"))
 
-;;; (overlay . d1) -> image?
+;;; (overlay & d1) -> image?
 ;;;  d1 : image?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., on top of each other. (`d1` is the topmost drawing).
 ;;; @category composition/placement, image, beside, beside/align, above, above/align, overlay/align, overlay/offset, rotate
 (define overlay (js-var "image_overlay"))
 
-;;; (overlay/align xAlign yAlign . d1) -> image?
+;;; (overlay/align xAlign yAlign & d1) -> image?
 ;;;  xAlign : string?
 ;;;   either "left", "middle", or "right"
 ;;;  yAlign : string?
@@ -458,7 +458,7 @@
 ;;; @category canvas, image, shapes, path-func
 (define with-dash (js-var "image_withDash"))
 
-;;; (text str size color . font) -> image?
+;;; (text str size color & font) -> image?
 ;;;  str : string?
 ;;;  size : any
 ;;;   number? A valid font size (in px)

--- a/src/lib/music.scm
+++ b/src/lib/music.scm
@@ -82,13 +82,13 @@
 ;;; @category constants, interactive, music, sound, composition?, empty, instrument, mod, note, note-event, note-freq, play-composition, repeat, rest
 (define trigger (js-var "music_trigger"))
 
-;;; (par . comp1) -> composition?
+;;; (par & comp1) -> composition?
 ;;;  comp1 : composition?
 ;;; Creates a new composition that plays `comp1`, `comp2`, ..., in parallel.
 ;;; @category music, sound, pickup, seq
 (define par (js-var "music_par"))
 
-;;; (seq . comp1) -> composition?
+;;; (seq & comp1) -> composition?
 ;;;  comp1 : composition?
 ;;; Creates a new composition that plays `comp1`, `comp2`, ..., in sequence.
 ;;; @category music, sound, par, pickup

--- a/src/lib/prelude.scm
+++ b/src/lib/prelude.scm
@@ -128,37 +128,37 @@
 ;;; @category math, comparator, predicates, integer?, negative?, number?, odd?, positive?, real?, zero?
 (define even? (js-var "prelude_evenQ"))
 
-;;; (max . v) -> number?
+;;; (max & v) -> number?
 ;;;  v : number?
 ;;; Returns the maximum of the given numbers.
 ;;; @category math, comparator, min, nan?, >=, >, <=, <, =
 (define max (js-var "prelude_max"))
 
-;;; (min . v) -> number?
+;;; (min & v) -> number?
 ;;;  v : number?
 ;;; Returns the minimum of the given numbers.
 ;;; @category math, comparator, max, nan?, >=, >, <=, <, =
 (define min (js-var "prelude_min"))
 
-;;; (+ . v1) -> number?
+;;; (+ & v1) -> number?
 ;;;  v1 : number?
 ;;; Returns the sum of `v1`, `v2`, ... .
 ;;; @category math, algebra, -, *, /, modulo, quotient, remainder 
 (define + (js-var "prelude_plus"))
 
-;;; (- . v1) -> number?
+;;; (- & v1) -> number?
 ;;;  v1 : number?
 ;;; Returns the difference of `v1`, `v2`, ... .
 ;;; @category math, algebra, +, *, /, modulo, quotient, remainder
 (define - (js-var "prelude_minus"))
 
-;;; (* . v1) -> number?
+;;; (* & v1) -> number?
 ;;;  v1 : number?
 ;;; Returns the product of `v1`, `v2`, ... .
 ;;; @category math, algebra, +, -, /, modulo, quotient, remainder
 (define * (js-var "prelude_times"))
 
-;;; (/ . v1) -> number?
+;;; (/ & v1) -> number?
 ;;;  v1 : number?
 ;;; Returns the quotient of `v1`, `v2`, ... .
 ;;; @category math, algebra, +, -, *, modulo, quotient, remainder
@@ -307,13 +307,13 @@
 ;;; @category typecheck, boolean/logic, predicates, char?, string?, integer?
 (define boolean? (js-var "prelude_booleanQ"))
 
-;;; (nand . v1) -> boolean?
+;;; (nand & v1) -> boolean?
 ;;;  v1 : boolean?
 ;;; Equivalent to `(not (and v1 v2 ...))`.
 ;;; @category boolean/logic, and, nor, not, xor, or
 (define nand (js-var "prelude_nand"))
 
-;;; (nor . v1) -> boolean?
+;;; (nor & v1) -> boolean?
 ;;;  v1 : boolean?
 ;;; Equivalent to `(not (or v1 v2 ...))`.
 ;;; @category boolean/logic, and, nand, not, xor, or
@@ -333,23 +333,23 @@
 ;;; @category boolean/logic, and, nand, nor, not, or
 (define xor (js-var "prelude_xor"))
 
-;;; (any-of . f1) -> procedure?
+;;; (any-of & f1) -> procedure?
 ;;;  f1 : any
 ;;;   procedure? that takes a value as input and returns a boolean.
 ;;; Returns a unary function that returns `#t` if and only one of `f1`, `f2`, ... is `#t` for its argument.
 ;;; @category function composition, boolean/logic, all-of, compose, =-eps, o, |>
 (define any-of
-  (lambda (f . fs)
+  (lambda (f & fs)
     (lambda (v)
       (some-satisfy? (lambda (g) (g v)) (cons f fs)))))
 
-;;; (all-of . f1) -> procedure?
+;;; (all-of & f1) -> procedure?
 ;;;  f1 : any
 ;;;   procedure? that takes a value as input and returns a boolean.
 ;;; Returns a unary function that returns `#t` if and only all of `f1`, `f2`, ... are `#t` for its argument.
 ;;; @category function composition, boolean/logic, any-of, compose, =-eps, o, |>
 (define all-of
-  (lambda (f . fs)
+  (lambda (f & fs)
     (lambda (v)
       (all-satisfy? (lambda (g) (g v)) (cons f fs)))))
 
@@ -423,7 +423,7 @@
 ;; cycle. Requires at least one predicate: the arglist grammar has no
 ;; zero-fixed-param rest form, and or/p over no predicates is never needed.
 (define or/p
-  (lambda (first . rest)
+  (lambda (first & rest)
     (lambda (x) (some-satisfy? (lambda (p) (p x)) (cons first rest)))))
 
 ;;; (car v) -> any
@@ -456,7 +456,7 @@
 ;;; @category typecheck, predicates
 (define nonempty-list? (js-var "prelude_nonemptyListQ"))
 
-;;; (list . v1) -> list?
+;;; (list & v1) -> list?
 ;;;  v1 : any
 ;;; Returns a new list containing `v1`, `v2`, ... .
 ;;; @category list, list creation, association list, pair, string, regex, vector, void
@@ -475,7 +475,7 @@
 ;;; @category list, list manipulation, index-of, range, string-length, vector-length, vector-range, vector-ref 
 (define length (js-var "prelude_length"))
 
-;;; (append . l1) -> list?
+;;; (append & l1) -> list?
 ;;;  l1 : list?
 ;;; Returns a new list containing the elements of lists `l1`, `l2`, ... in sequence.
 ;;; @category list, list manipulation, list-drop, list-tail, list-take, make-list, range, reverse, sort
@@ -633,7 +633,7 @@
 ;;; @category string, make-list, make-vector, string-append, string-map
 (define make-string (js-var "prelude_makeString"))
 
-;;; (string . c1) -> string?
+;;; (string & c1) -> string?
 ;;;  c1 : char?
 ;;; Returns a string consisting of the characters `c1`, `c2`, ...
 ;;; @category string, list, pair, rex, vector
@@ -678,7 +678,7 @@
 ;;; @category string, string-downcase, string-upcase, string-foldcase, string-split, string-split-vector
 (define substring (js-var "prelude_substring"))
 
-;;; (string-append . s1) -> string?
+;;; (string-append & s1) -> string?
 ;;;  s1 : string?
 ;;; Returns a string made by joining `s1`, `s2`, ... together.
 ;;; @category string, append, make-string, range, string-map
@@ -735,7 +735,7 @@
 ;;; @category typecheck, vectors, predicates, pair?, list?, null?, procedure?, ref?, rex?, void?
 (define vector? (js-var "prelude_vectorQ"))
 
-;;; (vector . v1) -> vector?
+;;; (vector & v1) -> vector?
 ;;;  v1 : any
 ;;; Returns a vector consisting of the values `v1`, `v2`, ...
 ;;; @category vectors, list, pair, string, regex, void
@@ -790,7 +790,7 @@
 ;;; @category list, list manipulation, association list, vectors, list->vector, vector->list
 (define list->vector (js-var "prelude_listToVector"))
 
-;;; (vector-range . args) -> vector?
+;;; (vector-range & args) -> vector?
 ;;;  args : integer?
 ;;; Can be called with one, two, or three arguments, all of which are integers.
 ;;; (vector-range end) returns a vector containing the numbers from 0 to `end` (exclusive).
@@ -801,7 +801,7 @@
 ;;; @category vectors,  index-of, length, range, string-length, vector-length, vector-ref 
 (define vector-range (js-var "prelude_vectorRange"))
 
-;;; (vector-append . v1) -> vector?
+;;; (vector-append & v1) -> vector?
 ;;;  v1 : vector?
 ;;; Returns a new vector containing the elements of `v1`, ..., `vk` in order.
 ;;; @category vectors, vector-fill!, vector-filter, vector-for-each, vector-map, vector-map!, vector-set!
@@ -837,13 +837,13 @@
         null
         (cons (cdr (car lsts)) (lists-cdrs (cdr lsts))))))
 
-;;; (map f . l) -> list?
+;;; (map f & l) -> list?
 ;;;  f : procedure?
 ;;;  l : list?
 ;;; Returns a new list containing the results of applying `f` to each element of `l`. When several lists are given, `f` is applied element-wise across them and all lists must have the same length.
 ;;; @category list, list manipulation, association list, reduce, reduce-right, set-maximum-recursion-depth!, string-map, vector-map, vector-map!
 (define map
-  (lambda (f . lsts)
+  (lambda (f & lsts)
     (cond
       [(null? lsts) null]
       [(some-satisfy? null? lsts)
@@ -919,13 +919,13 @@
       [(cons x null) x]
       [(cons x rest) (f x (reduce-right f rest))])))
 
-;;; (vector-map f . v) -> vector?
+;;; (vector-map f & v) -> vector?
 ;;;  f : procedure?
 ;;;  v : vector?
 ;;; Returns a new vector containing the results of applying `f` to each element of `v1`, ..., `vk` in a element-wise fashion.
 ;;; @category vectors, map, string-map, vector-append, vector-fill!, vector-filter, vector-for-each, vector-map!, vector-set!
 (define vector-map
-  (lambda (f . vs)
+  (lambda (f & vs)
     (list->vector (apply map (cons f (map vector->list vs))))))
 
 ;;; (vector-map! f v) -> void?
@@ -981,33 +981,33 @@
 ;;; @category constants, other
 (define ?? (js-var "prelude_qq"))
 
-;;; (compose . f1) -> procedure?
+;;; (compose & f1) -> procedure?
 ;;;  f1 : procedure?
 ;;; Returns a new procedure that is the composition of the given functions, _i.e._, `f(x) = f1(f2(...(fk(x))))`.
 ;;; @category function composition, all-of, any-of, =-eps, o, |>
 (define compose
-  (lambda (f . fs)
+  (lambda (f & fs)
     (lambda (x)
       (fold-right (lambda (g acc) (g acc)) x (cons f fs)))))
 
-;;; (o . f) -> procedure?
+;;; (o & f) -> procedure?
 ;;;  f : procedure?
 ;;; A synonym for `compose`.
 ;;; @category function composition, all-of, any-of, compose, =-eps, |>
 (define o
-  (lambda (f . fs)
+  (lambda (f & fs)
     (apply compose (cons f fs))))
 
-;;; (|> v . f1) -> any
+;;; (|> v & f1) -> any
 ;;;  v : any
 ;;;  f1 : procedure?
 ;;; Returns the result of applying the given function in sequence, starting with initial value `v`, _i.e._, `(fk (fk-1(...(f1 v)))`.
 ;;; @category function composition, all-of, any-of, compose, =-eps, o
 (define |>
-  (lambda (v . fs)
+  (lambda (v & fs)
     (fold (lambda (acc f) (f acc)) v fs)))
 
-;;; (range . args) -> list?
+;;; (range & args) -> list?
 ;;;  args : integer?
 ;;; Can be called with one, two, or three arguments, all of which are integers.
 ;;; (range end) returns a list containing the numbers from 0 to `end` (exclusive).
@@ -1287,61 +1287,61 @@
 ;;; @category list, list manipulation, association list
 (define cddddr (lambda (v) (cdr (cdr (cdr (cdr v))))))
 
-;;; (char=? . c1) -> boolean?
+;;; (char=? & c1) -> boolean?
 ;;;  c1 : char?
 ;;; Returns `#t` if and only `c1`, `c2`, ... are all equivalent characters.
 ;;; @category char, predicates, char>=?, char>?, char<=?, char<?
 (define char=? (js-var "prelude_char=?"))
 
-;;; (char<? . c1) -> boolean?
+;;; (char<? & c1) -> boolean?
 ;;;  c1 : char?
 ;;; Returns `#t` if and only `c1`, `c2`, ... have strictly increasing character values.
 ;;; @category char, predicates, char=?, char>=?, char>?, char<=?
 (define char<? (js-var "prelude_char<?"))
 
-;;; (char>? . c1) -> boolean?
+;;; (char>? & c1) -> boolean?
 ;;;  c1 : char?
 ;;; Returns `#t` if and only `c1`, `c2`, ... have strictly decreasing character values.
 ;;; @category char, predicates, char=?, char>=?, char<=?, char<?
 (define char>? (js-var "prelude_char>?"))
 
-;;; (char<=? . c1) -> boolean?
+;;; (char<=? & c1) -> boolean?
 ;;;  c1 : char?
 ;;; Returns `#t` if and only `c1`, `c2`, ... have non-decreasing character values.
 ;;; @category char, predicates, char=?, char>=?, char>?, char<?
 (define char<=? (js-var "prelude_char<=?"))
 
-;;; (char>=? . c1) -> boolean?
+;;; (char>=? & c1) -> boolean?
 ;;;  c1 : char?
 ;;; Returns `#t` if and only `c1`, `c2`, ... have non-increasing character values.
 ;;; @category char, predicates, char=?, char>?, char<=?, char<?
 (define char>=? (js-var "prelude_char>=?"))
 
-;;; (char-ci=? . c1) -> boolean?
+;;; (char-ci=? & c1) -> boolean?
 ;;;  c1 : char?
 ;;; Returns `#t` if and only `c1`, `c2`, ... are all equivalent characters, ignoring case.
 ;;; @category char, predicates, char-ci>=?, char-ci>?, char-ci<=?, char-ci<?
 (define char-ci=? (js-var "prelude_char-ci=?"))
 
-;;; (char-ci<? . c1) -> boolean?
+;;; (char-ci<? & c1) -> boolean?
 ;;;  c1 : char?
 ;;; Returns `#t` if and only `c1`, `c2`, ... have strictly increasing character values, ignoring case.
 ;;; @category char, predicates, char-ci=?, char-ci>=?, char-ci>?, char-ci<=?
 (define char-ci<? (js-var "prelude_char-ci<?"))
 
-;;; (char-ci>? . c1) -> boolean?
+;;; (char-ci>? & c1) -> boolean?
 ;;;  c1 : char?
 ;;; Returns `#t` if and only `c1`, `c2`, ... have strictly decreasing character values, ignoring case.
 ;;; @category char, predicates, char-ci=?, char-ci>=?, char-ci<=?, char-ci<?
 (define char-ci>? (js-var "prelude_char-ci>?"))
 
-;;; (char-ci<=? . c1) -> boolean?
+;;; (char-ci<=? & c1) -> boolean?
 ;;;  c1 : char?
 ;;; Returns `#t` if and only `c1`, `c2`, ... have non-decreasing character values, ignoring case.
 ;;; @category char, predicates, char-ci=?, char-ci>=?, char-ci>?, char-ci<?
 (define char-ci<=? (js-var "prelude_char-ci<=?"))
 
-;;; (char-ci>=? . c1) -> boolean?
+;;; (char-ci>=? & c1) -> boolean?
 ;;;  c1 : char?
 ;;; Returns `#t` if and only `c1`, `c2`, ... have non-increasing character values, ignoring case.
 ;;; @category char, predicates, char-ci=?, char-ci>?, char-ci<=?, char-ci<?
@@ -1377,61 +1377,61 @@
 ;;; @category char, predicates, char-alphabetic?, char-numeric?, char-upper-case?, char-whitespace?
 (define char-lower-case? (js-var "prelude_char-lower-case?"))
 
-;;; (string=? . s1) -> boolean?
+;;; (string=? & s1) -> boolean?
 ;;;  s1 : string?
 ;;; Returns `#t` if and only `s1`, `s2`, ... are equivalent strings.
 ;;; @category string, predicates, string>=?, string>?, string<=?, string<?, string-contains
 (define string=? (js-var "prelude_string=?"))
 
-;;; (string<? . s1) -> boolean?
+;;; (string<? & s1) -> boolean?
 ;;;  s1 : string?
 ;;; Returns `#t` if and only `s1`, `s2`, ... are in strictly lexicographically increasing order.
 ;;; @category string, predicates, string=?, string>=?, string>?, string<=?, string-contains
 (define string<? (js-var "prelude_string<?"))
 
-;;; (string>? . s1) -> boolean?
+;;; (string>? & s1) -> boolean?
 ;;;  s1 : string?
 ;;; Returns `#t` if and only `s1`, `s2`, ... are in strictly lexicographically decreasing order.
 ;;; @category string, predicates, string=?, string>=?, string<=?, string<?, string-contains
 (define string>? (js-var "prelude_string>?"))
 
-;;; (string<=? . s1) -> boolean?
+;;; (string<=? & s1) -> boolean?
 ;;;  s1 : string?
 ;;; Returns `#t` if and only `s1`, `s2`, ... are in lexicographical order.
 ;;; @category string, predicates, string=?, string>=?, string>?, string<?, string-contains
 (define string<=? (js-var "prelude_string<=?"))
 
-;;; (string>=? . s1) -> boolean?
+;;; (string>=? & s1) -> boolean?
 ;;;  s1 : string?
 ;;; Returns `#t` if and only `s1`, `s2`, ... are in reverse lexicographical order.
 ;;; @category string, predicates, string=?, string>?, string<=?, string<?, string-contains
 (define string>=? (js-var "prelude_string>=?"))
 
-;;; (string-ci=? . s1) -> boolean?
+;;; (string-ci=? & s1) -> boolean?
 ;;;  s1 : string?
 ;;; Returns `#t` if and only `s1`, `s2`, ... are equivalent strings, ignoring case.
 ;;; @category string, predicates, string-ci>=?, string-ci>?, string-ci<=?, string-ci<?, string-contains
 (define string-ci=? (js-var "prelude_string-ci=?"))
 
-;;; (string-ci<? . s1) -> boolean?
+;;; (string-ci<? & s1) -> boolean?
 ;;;  s1 : string?
 ;;; Returns `#t` if and only `s1`, `s2`, ... are in strictly lexicographically increasing order, ignoring case.
 ;;; @category string, predicates, string-ci=?, string-ci>=?, string-ci>?, string-ci<=?, string-contains
 (define string-ci<? (js-var "prelude_string-ci<?"))
 
-;;; (string-ci>? . s1) -> boolean?
+;;; (string-ci>? & s1) -> boolean?
 ;;;  s1 : string?
 ;;; Returns `#t` if and only `s1`, `s2`, ... are in strictly lexicographically decreasing order, ignoring case.
 ;;; @category string, predicates, string-ci=?, string-ci>=?, string-ci<=?, string-ci<?, string-contains
 (define string-ci>? (js-var "prelude_string-ci>?"))
 
-;;; (string-ci<=? . s1) -> boolean?
+;;; (string-ci<=? & s1) -> boolean?
 ;;;  s1 : string?
 ;;; Returns `#t` if and only `s1`, `s2`, ... are in lexicographical order, ignoring case.
 ;;; @category string, predicates, string-ci=?, string-ci>=?, string-ci>?, string-ci<?, string-contains
 (define string-ci<=? (js-var "prelude_string-ci<=?"))
 
-;;; (string-ci>=? . s1) -> boolean?
+;;; (string-ci>=? & s1) -> boolean?
 ;;;  s1 : string?
 ;;; Returns `#t` if and only `s1`, `s2`, ... are in reverse lexicographical order, ignoring case.
 ;;; @category string, predicates, string-ci=?, string-ci>?, string-ci<=?, string-ci<?, string-contains

--- a/src/lib/rex.scm
+++ b/src/lib/rex.scm
@@ -27,7 +27,7 @@
 ;;; @category regexes, rex-concat, rex-repeat
 (define rex-repeat-0 (js-var "rex_rexRepeat0"))
 
-;;; (rex-concat . xs) -> rex?
+;;; (rex-concat & xs) -> rex?
 ;;;  xs : rex?
 ;;; Returns a regex that matches the concatenation of the regexes `rs` in order.
 ;;; @category regexes, rex-repeat, rex-repeat-o
@@ -57,7 +57,7 @@
 ;;; @category regexes, rex-any-char, rex-char-antiset, rex-char-set
 (define rex-char-range (js-var "rex_rexCharRange"))
 
-;;; (rex-any-of . xs) -> rex?
+;;; (rex-any-of & xs) -> rex?
 ;;;  xs : rex?
 ;;; Returns a regex that matches any one of the regexes `rs`.
 ;;; @category regexes, rex-optional

--- a/src/lpm/renderers/vue/simple-renderers.ts
+++ b/src/lpm/renderers/vue/simple-renderers.ts
@@ -46,16 +46,13 @@ const symbolStrategy: Strategy = {
 }
 const closureStrategy: Strategy = {
   predicate: (v) => isClosure(v),
-  ...createSimpleVueRenderer<Closure>(
-    (v) =>
-      `(lambda (${
-        v.params.length > 0
-          ? v.params.reduce((acc, curr) => `${acc} ${curr}`)
-          : ''
-      }${
-        v.restParam ? ` . ${v.restParam}` : ''
-      }) ...)`,
-  ),
+  ...createSimpleVueRenderer<Closure>((v) => {
+    // Rest parameters use Clojure-style "&", e.g. (lambda (x & xs) ...) and the
+    // rest-only (lambda (& xs) ...).
+    const params = [...v.params]
+    if (v.restParam) params.push('&', v.restParam)
+    return `(lambda (${params.join(' ')}) ...)`
+  }),
 }
 const jsFunctionStrategy: Strategy = {
   predicate: (v) => isJsFunction(v),

--- a/src/prettier/scheme/printer.ts
+++ b/src/prettier/scheme/printer.ts
@@ -86,15 +86,19 @@ export const SchemePrinter: Printer = {
           ')',
         ])
 
-      case 'lam':
+      case 'lam': {
+        // Rest parameters use Clojure-style "&", e.g. (lambda (x & xs) ...) or
+        // the rest-only (lambda (& xs) ...).
+        const params = node.params.map((p) => p.name)
+        if (node.restParam) params.push('&', node.restParam.name)
         return group([
           '(lambda (',
-          join(' ', node.params.map((p) => p.name)),
-          node.restParam ? [' . ', node.restParam.name] : '',
+          join(' ', params),
           ')',
           indent([line, path.call(print, 'body')]),
           ')',
         ])
+      }
 
       case 'let': {
         const bindingDocs: Doc[] = path.map((bindingPath: AstPath) => {

--- a/src/scheme/ast-components/ExpRenderer.vue
+++ b/src/scheme/ast-components/ExpRenderer.vue
@@ -15,7 +15,7 @@ switch (e.tag) {
     break
   case 'lam':
     if (e.restParam) {
-      args = ['lambda', ...e.params.map((p) => p.name), '.', e.restParam.name, e.body]
+      args = ['lambda', ...e.params.map((p) => p.name), '&', e.restParam.name, e.body]
     } else {
       args = ['lambda', ...e.params.map((p) => p.name), e.body]
     }

--- a/src/scheme/ast.ts
+++ b/src/scheme/ast.ts
@@ -23,7 +23,7 @@ export interface Comment {
 //     -- Special forms
 //     | (lambda (x1 ... xk)
 //         e)
-//     | (lambda (x1 ... xk-1 . xk)
+//     | (lambda (x1 ... xk-1 & xk)
 //         e)
 //     | (let
 //         ([x1 e1]
@@ -520,8 +520,11 @@ export function expToString(e: Exp): string {
         return `(${expToString(e.head)} ${e.args.map(expToString).join(' ')})`
       }
     }
-    case 'lam':
-      return `(lambda (${e.params.map((p) => p.name).join(' ')}${e.restParam ? ` . ${e.restParam.name}` : ''}) ${expToString(e.body)})`
+    case 'lam': {
+      const params = e.params.map((p) => p.name)
+      if (e.restParam) params.push('&', e.restParam.name)
+      return `(lambda (${params.join(' ')}) ${expToString(e.body)})`
+    }
     case 'let':
       return `(let (${e.bindings.map(({ id, value }) => `[${id.name} ${expToString(value)}]`).join(' ')}) ${expToString(e.body)})`
     case 'begin':

--- a/src/scheme/contract.ts
+++ b/src/scheme/contract.ts
@@ -183,7 +183,7 @@ function mkCheckChain(
  *
  *   (define name
  *     (let ([##contract-target## expr])
- *       (lambda (x1 ... xk [. rest])
+ *       (lambda (x1 ... xk [& rest])
  *         <cascading predicate checks, then (##contract-target## x1 ... xk)>)))
  *
  * @returns the statement unchanged if it isn't a define, has no docstring,

--- a/src/scheme/docstring/render.ts
+++ b/src/scheme/docstring/render.ts
@@ -43,7 +43,7 @@ export function functionDocSignature(doc: FunctionDoc): string {
   }
   const argNames = [
     ...doc.params.map((p) => p.name),
-    ...(doc.restParam ? [`. ${doc.restParam.name}`] : []),
+    ...(doc.restParam ? [`& ${doc.restParam.name}`] : []),
   ].join(' ')
   const paramLine = (p: FunctionDoc['params'][number]) =>
     `  ${p.name}: ${predToString(p.predicate)}${p.description ? `\n    ${p.description}` : ''}`

--- a/src/scheme/docstring/signature.ts
+++ b/src/scheme/docstring/signature.ts
@@ -40,10 +40,10 @@ function validateIdentifierToken(token: string, range: Range): void {
 
 // N.B., deliberately not parsed via tokenizeAndParse/the real grammar, unlike
 // the rest of this file: the signature line's rest-parameter notation
-// (`(+ . xs)`, mirroring lambda's `(lambda (x1 . rest) ...)`) has no
-// equivalent in Application's grammar (paren<expression*> has no RestDot
+// (`(+ & xs)`, mirroring lambda's `(lambda (x1 & rest) ...)`) has no
+// equivalent in Application's grammar (paren<expression*> has no rest-marker
 // alternative -- that's Lambda's arglist-only), and adding one there would
-// make dotted-rest applications parse as ordinary (if meaningless) Scamper
+// make rest-marked applications parse as ordinary (if meaningless) Scamper
 // source everywhere, not just inside docstrings. Since every token here is
 // always a bare identifier (never a nested expression), hand-tokenizing on
 // whitespace and validating each token the same way param.ts already does
@@ -69,22 +69,22 @@ function parseFunctionSignature({ line, range }: DocComment): VarApp {
   const [nameTok, ...rest] = tokens
   validateIdentifierToken(nameTok, range)
 
-  const dotIdx = rest.indexOf('.')
+  const ampIdx = rest.indexOf('&')
   let argToks: string[]
   let restTok: string | undefined
-  if (dotIdx === -1) {
+  if (ampIdx === -1) {
     argToks = rest
   } else {
-    if (dotIdx !== rest.length - 2) {
-      throw mkDocError('Malformed rest parameter: expected a single "." immediately before the final (rest) parameter name',
+    if (ampIdx !== rest.length - 2) {
+      throw mkDocError('Malformed rest parameter: expected a single "&" immediately before the final (rest) parameter name',
         range,
       )
     }
-    argToks = rest.slice(0, dotIdx)
-    restTok = rest[dotIdx + 1]
+    argToks = rest.slice(0, ampIdx)
+    restTok = rest[ampIdx + 1]
   }
-  if (rest.filter((t) => t === '.').length > 1) {
-    throw mkDocError('Malformed function signature: more than one "." found',
+  if (rest.filter((t) => t === '&').length > 1) {
+    throw mkDocError('Malformed function signature: more than one "&" found',
       range,
     )
   }

--- a/src/scheme/lezer-bridge.ts
+++ b/src/scheme/lezer-bridge.ts
@@ -425,13 +425,13 @@ function expFromNode(ctx: Ctx, node: SyntaxNode): A.Exp {
       const rest = cs.slice(1)
       const body = expFromNode(ctx, rest[rest.length - 1])
       const argNodes = rest.slice(0, -1)
-      const dotIndex = argNodes.findIndex((c) => c.type.name === 'RestDot')
-      if (dotIndex === -1) {
+      const ampIndex = argNodes.findIndex((c) => c.type.name === 'Amp')
+      if (ampIndex === -1) {
         const params = argNodes.map((c) => identifier(ctx, c))
         return A.mkLam(params, body, range)
       }
-      const params = argNodes.slice(0, dotIndex).map((c) => identifier(ctx, c))
-      const restParam = identifier(ctx, argNodes[dotIndex + 1])
+      const params = argNodes.slice(0, ampIndex).map((c) => identifier(ctx, c))
+      const restParam = identifier(ctx, argNodes[ampIndex + 1])
       return A.mkLam(params, body, range, restParam)
     }
 

--- a/src/scheme/syntax.grammar
+++ b/src/scheme/syntax.grammar
@@ -14,7 +14,7 @@ simplearglist {
 
 arglist {
   simplearglist |
-  paren<Identifier+ RestDot Identifier>
+  paren<Identifier* Amp Identifier>
 }
 
 binding {
@@ -85,18 +85,19 @@ kw<term> { @specialize[@name={term}]<Identifier, term> }
     ) (("e" | "E") $[+\-]? $[0-9]+)?
   }
 
-  // N.B., mirrors reader.ts's tokenizer, which treats any run of characters
-  // not delimited by whitespace, brackets, a string quote, or an unescaped
-  // "'"/";" as an atom (disambiguated into number/boolean/char/identifier
-  // afterward). This is deliberately permissive so that identifiers like
-  // ">", "<=", "null?", and "set!" tokenize correctly.
-  Identifier { ![ \t\n\r()\[\]{}'";.]+ }
+  // N.B., treats any run of characters not delimited by whitespace, brackets, a
+  // string quote, an unescaped "'"/";", "." (number/rest disambiguation), or "&"
+  // (the rest-parameter marker below) as an atom (disambiguated into
+  // number/boolean/char/identifier afterward). This is deliberately permissive
+  // so that identifiers like ">", "<=", "null?", and "set!" tokenize correctly.
+  Identifier { ![ \t\n\r()\[\]{}'";.&]+ }
 
-  // The "." separating a lambda's fixed parameters from its rest parameter,
-  // e.g. (lambda (x y . z) ...). Named (rather than an inline anonymous
-  // literal) so it shows up in the parse tree and arglist can tell a rest
-  // parameter apart from an ordinary trailing identifier.
-  RestDot { "." }
+  // The "&" separating a lambda's fixed parameters from its rest parameter,
+  // e.g. (lambda (x y & z) ...), or introducing a rest-only list, e.g.
+  // (lambda (& z) ...). Clojure-style. Named (rather than an inline anonymous
+  // literal) so it shows up in the parse tree and arglist can tell the rest
+  // marker apart from an ordinary identifier.
+  Amp { "&" }
 
   String { '"' (!["\\] | "\\" _)* '"' }
 

--- a/test/prettier/printer.test.ts
+++ b/test/prettier/printer.test.ts
@@ -45,6 +45,17 @@ describe('roundtrip', () => {
   test('lambda with multiple params', () =>
     roundtrip('(define f (lambda (x y) (+ x y)))'))
 
+  test('lambda with a rest parameter (#272)', () =>
+    roundtrip('(define f (lambda (x & xs) xs))'))
+
+  test('lambda with a rest-only parameter list (#272)', () =>
+    roundtrip('(define g (lambda (& xs) xs))'))
+
+  test('rest parameters are printed with "&" (#272)', async () => {
+    expect(await format('(define f (lambda (x & xs) xs))')).toContain('(x & xs)')
+    expect(await format('(define g (lambda (& xs) xs))')).toContain('(& xs)')
+  })
+
   test('if expression', () =>
     roundtrip('(define abs (lambda (n) (if (>= n 0) n (- 0 n))))'))
 

--- a/test/scheme/ast.test.ts
+++ b/test/scheme/ast.test.ts
@@ -30,7 +30,11 @@ describe('expToString', () => {
     ).toBe('(lambda (x y) x)')
     expect(
       A.expToString(A.mkLam([A.mkId('x')], A.mkId('x', anyRange), anyRange, A.mkId('rest'))),
-    ).toBe('(lambda (x . rest) x)')
+    ).toBe('(lambda (x & rest) x)')
+    // Rest-only (no fixed parameters): (lambda (& rest) rest).
+    expect(
+      A.expToString(A.mkLam([], A.mkId('rest', anyRange), anyRange, A.mkId('rest'))),
+    ).toBe('(lambda (& rest) rest)')
   })
 
   test('let', () => {

--- a/test/scheme/codegen.test.ts
+++ b/test/scheme/codegen.test.ts
@@ -551,36 +551,36 @@ t1
 })
 
 describe('Rest parameters', () => {
-  // Coverage for rest parameters: (lambda (x y . z) ...) binds the trailing
+  // Coverage for rest parameters: (lambda (x y & z) ...) binds the trailing
   // arguments beyond the fixed parameters as a proper list bound to z.
 
   test('rest param collects extra arguments into a list', async () => {
     expect(await runProgram(`
-    (display ((lambda (x . y) y) 1 2 3))
+    (display ((lambda (x & y) y) 1 2 3))
     `)).toEqual(['(list 2 3)'])
   })
 
   test('rest param is an empty list when no extra arguments are given', async () => {
     expect(await runProgram(`
-    (display ((lambda (x . y) y) 1))
+    (display ((lambda (x & y) y) 1))
     `)).toEqual(['null'])
   })
 
   test('fixed parameter still binds correctly alongside a rest parameter', async () => {
     expect(await runProgram(`
-    (display ((lambda (x . y) x) 1 2 3))
+    (display ((lambda (x & y) x) 1 2 3))
     `)).toEqual(['1'])
   })
 
   test('multiple fixed parameters combine with one rest parameter', async () => {
     expect(await runProgram(`
-    (display ((lambda (a b . rest) (list a b rest)) 1 2 3 4 5))
+    (display ((lambda (a b & rest) (list a b rest)) 1 2 3 4 5))
     `)).toEqual(['(list 1 2 (list 3 4 5))'])
   })
 
   test('same rest-param lambda works across calls with varying argument counts', async () => {
     expect(await runProgram(`
-    (define f (lambda (x . y) y))
+    (define f (lambda (x & y) y))
     (display (f 1))
     (display (f 1 2))
     (display (f 1 2 3))
@@ -589,14 +589,14 @@ describe('Rest parameters', () => {
 
   test('rest parameter is a real list usable with car/length', async () => {
     expect(await runProgram(`
-    (define f (lambda (x . rest) (list (car rest) (length rest))))
+    (define f (lambda (x & rest) (list (car rest) (length rest))))
     (display (f 1 2 3 4))
     `)).toEqual(['(list 2 3)'])
   })
 
   test('empty rest parameter is recognized by null?/list?', async () => {
     expect(await runProgram(`
-    (define f (lambda (x . rest) (list (null? rest) (list? rest))))
+    (define f (lambda (x & rest) (list (null? rest) (list? rest))))
     (display (f 1))
     `)).toEqual(['(list #t #t)'])
   })
@@ -609,7 +609,7 @@ describe('Rest parameters', () => {
             0
             (+ (car lst) (sum-list (cdr lst))))))
     (define my-sum
-      (lambda (x . rest)
+      (lambda (x & rest)
         (+ x (sum-list rest))))
     (display (my-sum 1 2 3 4 5))
     `)).toEqual(['15'])
@@ -618,7 +618,7 @@ describe('Rest parameters', () => {
   test('rest parameter is captured correctly by a closure returned from a lambda', async () => {
     expect(await runProgram(`
     (define make-adder
-      (lambda (x . rest)
+      (lambda (x & rest)
         (lambda (y) (+ x y (length rest)))))
     (display ((make-adder 1 2 3) 10))
     `)).toEqual(['13'])
@@ -632,7 +632,7 @@ describe('Rest parameters', () => {
 
   test('arity mismatch: fewer than the required fixed args, even with a rest param present', async () => {
     expect(await runProgram(`
-    ((lambda (x y . z) z) 1)
+    ((lambda (x y & z) z) 1)
     `)).toEqual([
       'Runtime error [1:1-1:24]: Arity mismatch in function call: expected 2 arguments, got 1',
     ])
@@ -640,7 +640,7 @@ describe('Rest parameters', () => {
 
   test('arity mismatch: zero args against a lambda requiring one fixed arg plus a rest param', async () => {
     expect(await runProgram(`
-    ((lambda (x . y) y))
+    ((lambda (x & y) y))
     `)).toEqual([
       'Runtime error [1:1-1:20]: Arity mismatch in function call: expected 1 arguments, got 0',
     ])
@@ -656,25 +656,24 @@ describe('Rest parameters', () => {
 
   test('malformed: rest parameter missing its trailing identifier', async () => {
     expect(await runProgram(`
-    (lambda (x .) x)
+    (lambda (x &) x)
     `)).toEqual([
       'Parser error [1:1-1:16]: Malformed lambda expression (a list of parameters and a body).',
     ])
   })
 
-  test('malformed: more than one identifier following the rest dot', async () => {
+  test('malformed: more than one identifier following the rest marker', async () => {
     expect(await runProgram(`
-    (lambda (x . y z) x)
+    (lambda (x & y z) x)
     `)).toEqual([
       'Parser error [1:1-1:20]: Malformed lambda expression (a list of parameters and a body).',
     ])
   })
 
-  test('malformed: rest dot with no fixed parameters before it', async () => {
+  test('rest-only parameter list (no fixed parameters) collects all arguments (#272)', async () => {
     expect(await runProgram(`
-    (lambda (. y) y)
-    `)).toEqual([
-      'Parser error [1:1-1:16]: Malformed lambda expression (a list of parameters and a body).',
-    ])
+    (display ((lambda (& xs) xs) 1 2 3))
+    (display ((lambda (& xs) xs)))
+    `)).toEqual(['(list 1 2 3)', 'null'])
   })
 })

--- a/test/scheme/parse-ranges.test.ts
+++ b/test/scheme/parse-ranges.test.ts
@@ -203,7 +203,7 @@ describe('lambda', () => {
     assertSpan(asExp(lam.body, 'id').range, src, 'x', 1)
   })
   test('rest parameter', () => {
-    const src = '(lambda (x . rest) rest)'
+    const src = '(lambda (x & rest) rest)'
     const lam = asExp(parseExp(src), 'lam')
     expect(lam.params.map((p) => p.name)).toEqual(['x'])
     assertSpan(lam.params[0].range, src, 'x')

--- a/test/scheme/parsing/core.test.ts
+++ b/test/scheme/parsing/core.test.ts
@@ -16,6 +16,42 @@ describe('lezer-bridge parsing', () => {
     expectParses('(or 1 2 3)')
   })
 
+  test('rest parameters use Clojure-style "&", including zero fixed params (#272)', () => {
+    // A rest parameter after one or more fixed parameters.
+    const one = parse('(lambda (x & rest) rest)')
+    expect(one.errors).toEqual([])
+    const s1 = one.prog[0]
+    expect(s1.tag).toBe('stmtexp')
+    if (s1.tag !== 'stmtexp' || s1.expr.tag !== 'lam') return
+    expect(s1.expr.params.map((p) => p.name)).toEqual(['x'])
+    expect(s1.expr.restParam?.name).toBe('rest')
+
+    // A rest-only parameter list -- the case Scheme's dotted syntax couldn't
+    // express unambiguously.
+    const zero = parse('(lambda (& rest) rest)')
+    expect(zero.errors).toEqual([])
+    const s2 = zero.prog[0]
+    expect(s2.tag).toBe('stmtexp')
+    if (s2.tag !== 'stmtexp' || s2.expr.tag !== 'lam') return
+    expect(s2.expr.params).toEqual([])
+    expect(s2.expr.restParam?.name).toBe('rest')
+
+    expectParses('(lambda (a b c & rest) rest)')
+  })
+
+  test('the old Scheme dotted rest syntax is no longer accepted (#272)', () => {
+    // "." is not a valid identifier or rest marker anymore.
+    expect(parse('(lambda (x . y) y)').errors.length).toBeGreaterThan(0)
+    expect(parse('(lambda (. y) y)').errors.length).toBeGreaterThan(0)
+  })
+
+  test('a rest marker requires exactly one trailing identifier (#272)', () => {
+    // "&" with no rest name, or more than one name after it, is malformed.
+    expect(parse('(lambda (&) x)').errors.length).toBeGreaterThan(0)
+    expect(parse('(lambda (x &) x)').errors.length).toBeGreaterThan(0)
+    expect(parse('(lambda (x & y z) x)').errors.length).toBeGreaterThan(0)
+  })
+
   test('curly braces as an alternate to parens, mixed freely (each closed with its own kind)', () => {
     expectParses('{+ 1 2}')
     expectParses('(+ {* 3 4} (- 5 1))')

--- a/test/scheme/scope.test.ts
+++ b/test/scheme/scope.test.ts
@@ -129,7 +129,7 @@ describe('scope checking', () => {
       ['self-recursive define', '(define f (lambda (n) (f n)))'],
       ['lambda parameter', '(lambda (x) x)'],
       ['lambda with several parameters', '(lambda (x y z) (+ x (+ y z)))'],
-      ['lambda with a rest parameter', '(lambda (x . rest) rest)'],
+      ['lambda with a rest parameter', '(lambda (x & rest) rest)'],
       ['nullary lambda', '(lambda () 0)'],
       ['let binding', '(let ([x 1]) x)'],
       ['let with independent bindings', '(let ([x 1] [y 2]) (+ x y))'],
@@ -258,7 +258,7 @@ describe('scope checking', () => {
       )
     })
     test('a parameter colliding with the rest parameter', async () => {
-      expect(await scopeErrors('(lambda (x . x) x)')).toContain(
+      expect(await scopeErrors('(lambda (x & x) x)')).toContain(
         "Duplicate variable 'x' encountered in binding list",
       )
     })
@@ -487,7 +487,7 @@ describe('scope tree', () => {
     })
     test('a rest parameter is visible in the body', async () => {
       const names = await visibleAt(
-        '(define f (lambda (x . rest) rest))',
+        '(define f (lambda (x & rest) rest))',
         'rest',
         1,
       )


### PR DESCRIPTION
## Summary
Fixes #272. Replaces Scheme's dotted rest-parameter syntax `(lambda (x y . z) ...)` with Clojure's `&`: `(lambda (x y & z) ...)`. Crucially, this also allows a **rest-only** parameter list, `(lambda (& z) ...)` — the fully-variadic (zero fixed parameter) form that Scheme's dotted syntax couldn't express unambiguously, which is the core ask of the issue. The old `.` syntax is removed (not kept as an alias).

## Changes
- **`syntax.grammar`**: `&` is excluded from `Identifier` (so it tokenizes as its own marker); `RestDot { "." }` → `Amp { "&" }`; the rest production `paren<Identifier+ RestDot Identifier>` → `paren<Identifier* Amp Identifier>` — `Identifier*` (not `+`) is what enables zero fixed params.
- **`lezer-bridge.ts`**: consumes `Amp`. The existing rest-param AST/codegen already handled the zero-fixed case; only the grammar was blocking it.
- **Renderers/formatters** all emit `&` now: `ast.expToString`, `ExpRenderer.vue`, `docstring/render.ts`, the closure value renderer (`simple-renderers.ts`), LSP signature help (`signature.ts`), and the prettier printer (with clean zero-fixed output).
- **`docstring/signature.ts`**: the signature parser's rest marker is now `&`.
- **`codemirror/extensions/language.ts`**: `Amp` highlight mapping.
- **`src/lib/*.scm`**: all 71 dotted rest markers (lambda code + docstring signatures) converted to `&`.

## Compatibility
This is a deliberate breaking change (per the issue). `#\&` (the ampersand char literal) and `&` inside strings are unaffected. No stdlib identifier used `&`, so excluding it from identifiers is safe; no in-repo docs/examples used the dotted syntax.

## Testing
- New/updated tests in `core.test.ts` (parses `(x & rest)` and zero-fixed `(& rest)`; rejects old `.` and malformed `&` forms), `codegen.test.ts` (runs a rest-only lambda end-to-end), `printer.test.ts` (roundtrip + emits `&`), `ast.test.ts`, `scope.test.ts`, `parse-ranges.test.ts`.
- **Verified end-to-end in the IDE**: `(display ((lambda (& xs) xs) 1 2 3))` → `(list 1 2 3)`, with correct highlighting.

## Validation
- Typecheck: PASS · Tests: 85 files / 1325 tests (`npm test`) · Lint: 0 errors
- Independent code review performed; it caught two missed renderer sites (closure value renderer + LSP signature help) and stale doc comments — all fixed here, plus added negative-case tests.

_(Co-created with Claude Code)_