### PR TITLE
Preserve comments through formatting by ornamenting the AST (#304)

### DIFF
--- a/src/prettier/scheme/parser.ts
+++ b/src/prettier/scheme/parser.ts
@@ -1,6 +1,7 @@
 import { Parser } from 'prettier'
 import { SchemeNode, progToNode } from '../../scheme/ast'
 import { tokenizeAndParse } from '../../scheme'
+import { attachComments, collectComments } from '../../scheme/comments'
 
 export const SchemeParserName = 'scamper-scheme'
 
@@ -13,10 +14,13 @@ export const SchemeParserASTFormat = `${SchemeParserName}-ast`
 export const SchemeParser: Parser<SchemeNode> = {
   parse: (text) => {
     const { program, diagnostics } = tokenizeAndParse(text)
-    return progToNode(
-      program ??
-        throwNull(diagnostics.map((d) => d.message).join('; ')),
+    const root = progToNode(
+      program ?? throwNull(diagnostics.map((d) => d.message).join('; ')),
     )
+    // Ornament the AST with its source comments so the printer can re-emit them
+    // (see comments.ts). Prettier's own comment machinery is not used.
+    attachComments(root, collectComments(text))
+    return root
   },
   astFormat: SchemeParserASTFormat,
   locStart: (node) => node.range.begin.idx,

--- a/src/prettier/scheme/printer.ts
+++ b/src/prettier/scheme/printer.ts
@@ -3,7 +3,7 @@ import * as A from '../../scheme/ast'
 import TextRenderer from '../../lpm/renderers/text'
 
 const {
-  builders: { group, indent, join, line, hardline },
+  builders: { group, indent, join, line, hardline, lineSuffix, breakParent },
 } = doc
 
 // ---- Type predicates -------------------------------------------------------
@@ -26,246 +26,276 @@ function isCondBranch(v: unknown): v is { test: A.Exp; body: A.Exp } {
   return typeof v === 'object' && v !== null && 'test' in v && 'body' in v
 }
 
-// ---- Printer ----------------------------------------------------------------
+// ---- Comments (issue #304) -------------------------------------------------
+// Comments are attached to AST nodes by the parser (see scheme/comments.ts);
+// the printer reads them off each node. Every node is wrapped by `print` below,
+// so a node only needs to be reachable via path.call/path.map for its comments
+// to be emitted -- that is why identifiers, params, fields, and binding names
+// are printed through the path rather than as bare strings.
+
+/** Comments printed on their own line(s) before the node; forces a line break. */
+function leadingDoc(node: A.Node): Doc {
+  if (!node.leading || node.leading.length === 0) return ''
+  return node.leading.flatMap((c) => [c.line, hardline])
+}
+
+/** A comment printed at the end of the node's line; forces the line to break. */
+function trailingDoc(node: A.Node): Doc {
+  if (!node.trailing || node.trailing.length === 0) return ''
+  return node.trailing.flatMap((c) => [lineSuffix([' ', c.line]), breakParent])
+}
+
+function renderNode(path: AstPath, print: (p: AstPath) => Doc): Doc {
+  const node: unknown = path.node
+  if (!isSchemeNode(node)) return ''
+
+  switch (node.tag) {
+    ///// Program ///////////////////////////////////////////////////////////////
+
+    case 'prog':
+      return join(hardline, path.map(print, 'body'))
+
+    ///// Statements ////////////////////////////////////////////////////////////
+
+    case 'import':
+      return `(import ${node.kind === 'file' ? JSON.stringify(node.module) : node.module})`
+
+    case 'define':
+      return group([
+        '(define ',
+        path.call(print, 'name'),
+        indent([line, path.call(print, 'value')]),
+        ')',
+      ])
+
+    case 'display':
+      return group(['(display', indent([line, path.call(print, 'value')]), ')'])
+
+    case 'stmtexp':
+      return path.call(print, 'expr')
+
+    case 'struct':
+      return group([
+        '(struct ',
+        path.call(print, 'name'),
+        ' (',
+        join(' ', path.map(print, 'fields')),
+        '))',
+      ])
+
+    ///// Expressions ///////////////////////////////////////////////////////////
+
+    case 'lit':
+      return TextRenderer.render(node.value)
+
+    // Identifiers double as variable references (Exp) and pattern
+    // variables (Pat) -- one case handles both.
+    case 'id':
+      return node.name
+
+    case 'app':
+      if (node.args.length === 0) {
+        return group(['(', path.call(print, 'head'), ')'])
+      }
+      return group([
+        '(',
+        path.call(print, 'head'),
+        indent([line, join(line, path.map(print, 'args'))]),
+        ')',
+      ])
+
+    case 'lam': {
+      // Rest parameters use Clojure-style "&", e.g. (lambda (x & xs) ...) or
+      // the rest-only (lambda (& xs) ...).
+      const paramDocs: Doc[] = path.map(print, 'params')
+      if (node.restParam) paramDocs.push('&', path.call(print, 'restParam'))
+      return group([
+        '(lambda (',
+        join(' ', paramDocs),
+        ')',
+        indent([line, path.call(print, 'body')]),
+        ')',
+      ])
+    }
+
+    case 'let': {
+      const bindingDocs: Doc[] = path.map((bindingPath: AstPath) => {
+        if (!isLetBinding(bindingPath.node)) return ''
+        return group([
+          '[',
+          bindingPath.call(print, 'id'),
+          ' ',
+          bindingPath.call(print, 'value'),
+          ']',
+        ])
+      }, 'bindings')
+      return group([
+        '(let',
+        indent([line, group(['(', join(line, bindingDocs), ')'])]),
+        indent([line, path.call(print, 'body')]),
+        ')',
+      ])
+    }
+
+    case 'begin':
+      return group([
+        '(begin',
+        indent([line, join(line, path.map(print, 'exps'))]),
+        ')',
+      ])
+
+    case 'if':
+      return group([
+        '(if ',
+        path.call(print, 'guard'),
+        indent([line, path.call(print, 'ifB'), line, path.call(print, 'elseB')]),
+        ')',
+      ])
+
+    case 'match': {
+      const branchDocs: Doc[] = path.map((branchPath: AstPath) => {
+        if (!isMatchBranch(branchPath.node)) return ''
+        return group([
+          '[',
+          branchPath.call(print, 'pat'),
+          ' ',
+          branchPath.call(print, 'body'),
+          ']',
+        ])
+      }, 'branches')
+      return group([
+        '(match ',
+        path.call(print, 'scrutinee'),
+        indent([line, join(line, branchDocs)]),
+        ')',
+      ])
+    }
+
+    case 'quote':
+      return `'${TextRenderer.render(node.value)}`
+
+    case 'jsvar':
+      return `(js-var ${JSON.stringify(node.name)})`
+
+    case 'error':
+      return group(['(error', indent([line, path.call(print, 'exp')]), ')'])
+
+    case 'apply':
+      return group([
+        '(apply ',
+        path.call(print, 'fn'),
+        indent([line, path.call(print, 'args')]),
+        ')',
+      ])
+
+    case 'with-handler':
+      return group([
+        '(with-handler ',
+        path.call(print, 'handler'),
+        indent([
+          line,
+          path.call(print, 'fn'),
+          ...path.map((argPath) => [line, print(argPath)], 'args'),
+        ]),
+        ')',
+      ])
+
+    case 'let*': {
+      const bindingDocs: Doc[] = path.map((bindingPath: AstPath) => {
+        if (!isLetBinding(bindingPath.node)) return ''
+        return group([
+          '[',
+          bindingPath.call(print, 'id'),
+          ' ',
+          bindingPath.call(print, 'value'),
+          ']',
+        ])
+      }, 'bindings')
+      return group([
+        '(let*',
+        indent([line, group(['(', join(line, bindingDocs), ')'])]),
+        indent([line, path.call(print, 'body')]),
+        ')',
+      ])
+    }
+
+    case 'and':
+      return group([
+        '(and',
+        indent([line, join(line, path.map(print, 'exps'))]),
+        ')',
+      ])
+
+    case 'or':
+      return group([
+        '(or',
+        indent([line, join(line, path.map(print, 'exps'))]),
+        ')',
+      ])
+
+    case 'cond': {
+      const branchDocs: Doc[] = path.map((branchPath: AstPath) => {
+        if (!isCondBranch(branchPath.node)) return ''
+        return group([
+          '[',
+          branchPath.call(print, 'test'),
+          ' ',
+          branchPath.call(print, 'body'),
+          ']',
+        ])
+      }, 'branches')
+      return group(['(cond', indent([line, join(line, branchDocs)]), ')'])
+    }
+
+    case 'section':
+      return group([
+        '(section',
+        indent([line, join(line, path.map(print, 'exps'))]),
+        ')',
+      ])
+
+    case 'report':
+      return group(['(report', indent([line, path.call(print, 'exp')]), ')'])
+
+    ///// Patterns //////////////////////////////////////////////////////////////
+
+    case 'pwild':
+      return '_'
+
+    case 'plit':
+      return TextRenderer.render(node.value)
+
+    case 'pctor':
+      if (node.args.length === 0) {
+        return group(['(', path.call(print, 'name'), ')'])
+      }
+      return group([
+        '(',
+        path.call(print, 'name'),
+        indent([line, join(line, path.map(print, 'args'))]),
+        ')',
+      ])
+  }
+  return ''
+}
 
 export const SchemePrinter: Printer = {
   print: (path, _options, print) => {
     const node: unknown = path.node
     if (!isSchemeNode(node)) return ''
-
-    switch (node.tag) {
-      ///// Program ///////////////////////////////////////////////////////////////
-
-      case 'prog':
-        return join(hardline, path.map(print, 'body'))
-
-      ///// Statements ////////////////////////////////////////////////////////////
-
-      case 'import':
-        return `(import ${node.kind === 'file' ? JSON.stringify(node.module) : node.module})`
-
-      case 'define':
-        return group([
-          '(define ',
-          node.name.name,
-          indent([line, path.call(print, 'value')]),
-          ')',
-        ])
-
-      case 'display':
-        return group([
-          '(display',
-          indent([line, path.call(print, 'value')]),
-          ')',
-        ])
-
-      case 'stmtexp':
-        return path.call(print, 'expr')
-
-      case 'struct':
-        return `(struct ${node.name.name} (${node.fields.map((f) => f.name).join(' ')}))`
-
-      ///// Expressions ///////////////////////////////////////////////////////////
-
-      case 'lit':
-        return TextRenderer.render(node.value)
-
-      // Identifiers double as variable references (Exp) and pattern
-      // variables (Pat) -- one case handles both.
-      case 'id':
-        return node.name
-
-      case 'app':
-        if (node.args.length === 0) {
-          return group(['(', path.call(print, 'head'), ')'])
-        }
-        return group([
-          '(',
-          path.call(print, 'head'),
-          indent([line, join(line, path.map(print, 'args'))]),
-          ')',
-        ])
-
-      case 'lam': {
-        // Rest parameters use Clojure-style "&", e.g. (lambda (x & xs) ...) or
-        // the rest-only (lambda (& xs) ...).
-        const params = node.params.map((p) => p.name)
-        if (node.restParam) params.push('&', node.restParam.name)
-        return group([
-          '(lambda (',
-          join(' ', params),
-          ')',
-          indent([line, path.call(print, 'body')]),
-          ')',
-        ])
-      }
-
-      case 'let': {
-        const bindingDocs: Doc[] = path.map((bindingPath: AstPath) => {
-          const raw: unknown = bindingPath.node
-          if (!isLetBinding(raw)) return ''
-          return group([
-            '[',
-            raw.id.name,
-            ' ',
-            bindingPath.call(print, 'value'),
-            ']',
-          ])
-        }, 'bindings')
-        return group([
-          '(let',
-          indent([line, group(['(', join(line, bindingDocs), ')'])]),
-          indent([line, path.call(print, 'body')]),
-          ')',
-        ])
-      }
-
-      case 'begin':
-        return group([
-          '(begin',
-          indent([line, join(line, path.map(print, 'exps'))]),
-          ')',
-        ])
-
-      case 'if':
-        return group([
-          '(if ',
-          path.call(print, 'guard'),
-          indent([
-            line,
-            path.call(print, 'ifB'),
-            line,
-            path.call(print, 'elseB'),
-          ]),
-          ')',
-        ])
-
-      case 'match': {
-        const branchDocs: Doc[] = path.map((branchPath: AstPath) => {
-          const raw: unknown = branchPath.node
-          if (!isMatchBranch(raw)) return ''
-          return group([
-            '[',
-            branchPath.call(print, 'pat'),
-            ' ',
-            branchPath.call(print, 'body'),
-            ']',
-          ])
-        }, 'branches')
-        return group([
-          '(match ',
-          path.call(print, 'scrutinee'),
-          indent([line, join(line, branchDocs)]),
-          ')',
-        ])
-      }
-
-      case 'quote':
-        return `'${TextRenderer.render(node.value)}`
-
-      case 'jsvar':
-        return `(js-var ${JSON.stringify(node.name)})`
-
-      case 'error':
-        return group(['(error', indent([line, path.call(print, 'exp')]), ')'])
-
-      case 'apply':
-        return group([
-          '(apply ',
-          path.call(print, 'fn'),
-          indent([line, path.call(print, 'args')]),
-          ')',
-        ])
-
-      case 'with-handler':
-        return group([
-          '(with-handler ',
-          path.call(print, 'handler'),
-          indent([
-            line,
-            path.call(print, 'fn'),
-            ...path.map((argPath) => [line, print(argPath)], 'args'),
-          ]),
-          ')',
-        ])
-
-      case 'let*': {
-        const bindingDocs: Doc[] = path.map((bindingPath: AstPath) => {
-          const raw: unknown = bindingPath.node
-          if (!isLetBinding(raw)) return ''
-          return group([
-            '[',
-            raw.id.name,
-            ' ',
-            bindingPath.call(print, 'value'),
-            ']',
-          ])
-        }, 'bindings')
-        return group([
-          '(let*',
-          indent([line, group(['(', join(line, bindingDocs), ')'])]),
-          indent([line, path.call(print, 'body')]),
-          ')',
-        ])
-      }
-
-      case 'and':
-        return group([
-          '(and',
-          indent([line, join(line, path.map(print, 'exps'))]),
-          ')',
-        ])
-
-      case 'or':
-        return group([
-          '(or',
-          indent([line, join(line, path.map(print, 'exps'))]),
-          ')',
-        ])
-
-      case 'cond': {
-        const branchDocs: Doc[] = path.map((branchPath: AstPath) => {
-          const raw: unknown = branchPath.node
-          if (!isCondBranch(raw)) return ''
-          return group([
-            '[',
-            branchPath.call(print, 'test'),
-            ' ',
-            branchPath.call(print, 'body'),
-            ']',
-          ])
-        }, 'branches')
-        return group(['(cond', indent([line, join(line, branchDocs)]), ')'])
-      }
-
-      case 'section':
-        return group([
-          '(section',
-          indent([line, join(line, path.map(print, 'exps'))]),
-          ')',
-        ])
-
-      case 'report':
-        return group(['(report', indent([line, path.call(print, 'exp')]), ')'])
-
-      ///// Patterns //////////////////////////////////////////////////////////////
-
-      case 'pwild':
-        return '_'
-
-      case 'plit':
-        return TextRenderer.render(node.value)
-
-      case 'pctor':
-        if (node.args.length === 0) {
-          return `(${node.name.name})`
-        }
-        return group([
-          '(',
-          node.name.name,
-          indent([line, join(line, path.map(print, 'args'))]),
-          ')',
-        ])
+    const rendered = renderNode(path, print)
+    const parts: Doc[] = [leadingDoc(node), rendered]
+    // Dangling comments (inside a form with no following child, or the whole of
+    // a comment-only program) print on their own line just after the node's doc.
+    // The trailing hardline keeps an enclosing closing paren off the comment's
+    // line so a line comment can never swallow it.
+    if (node.dangling && node.dangling.length > 0) {
+      const isEmpty =
+        rendered === '' || (Array.isArray(rendered) && rendered.length === 0)
+      const dcs = join(hardline, node.dangling.map((c) => c.line))
+      parts.push(isEmpty ? [dcs, hardline] : [hardline, dcs, hardline])
     }
+    parts.push(trailingDoc(node))
+    return parts
   },
 }

--- a/src/scheme/ast.ts
+++ b/src/scheme/ast.ts
@@ -6,6 +6,16 @@ export interface Tagged {
 }
 export interface Node {
   range: L.Range
+  // Source comments attached to this node (issue #304). Populated only on demand
+  // (see attachComments in comments.ts) -- normal compilation leaves them unset,
+  // so the compiler pays nothing. Structural equality ignores them.
+  //   leading:  comments on their own line(s) immediately before the node.
+  //   trailing: a comment on the same line, after the node.
+  //   dangling: comments inside a form with no following child (e.g. before its
+  //             closing paren, or the whole content of a comment-only program).
+  leading?: Comment[]
+  trailing?: Comment[]
+  dangling?: Comment[]
 }
 
 /** A single line comment, tracked so docstrings can be reassembled from it. */

--- a/src/scheme/comments.ts
+++ b/src/scheme/comments.ts
@@ -1,0 +1,176 @@
+// Comment recovery and attachment for the AST (issue #304).
+//
+// Scamper's compiler discards comments, but tools like the formatter need them.
+// Rather than carry comments in a side channel, we ornament the AST: each node
+// can hold leading/trailing/dangling comments (see ast.ts's Node). This module
+// recovers comments from the Lezer tree and attaches them to nodes by source
+// position, with our own placement rules -- no dependency on any particular
+// printer's comment model. It runs only when a caller asks for it (e.g. the
+// Prettier plugin), so normal compilation is unaffected.
+import * as L from '../lpm'
+import * as A from './ast.js'
+import { parser } from './generated/parser.js'
+
+function computeLineStarts(src: string): number[] {
+  const starts = [0]
+  for (let i = 0; i < src.length; i++) {
+    if (src[i] === '\n') starts.push(i + 1)
+  }
+  return starts
+}
+
+function locOf(offset: number, lineStarts: number[]): L.Loc {
+  let lo = 0
+  let hi = lineStarts.length - 1
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1
+    if (lineStarts[mid] <= offset) lo = mid
+    else hi = mid - 1
+  }
+  return new L.Loc(lo + 1, offset - lineStarts[lo] + 1, offset)
+}
+
+/**
+ * Recovers every line comment from `src`, in source order, by walking the Lezer
+ * tree (which reuses the real tokenizer, so `;` inside strings and `#\;` char
+ * literals are not mistaken for comments). Ranges use the same inclusive-end
+ * convention as AST nodes so the two order consistently.
+ */
+export function collectComments(src: string): A.Comment[] {
+  const lineStarts = computeLineStarts(src)
+  const comments: A.Comment[] = []
+  const cursor = parser.parse(src).cursor()
+  do {
+    if (cursor.name === 'LineComment') {
+      const { from, to } = cursor
+      comments.push({
+        line: src.slice(from, to).trimEnd(),
+        range: new L.Range(
+          locOf(from, lineStarts),
+          locOf(Math.max(from, to - 1), lineStarts),
+        ),
+      })
+    }
+  } while (cursor.next())
+  return comments
+}
+
+/** A node's child AST nodes, in source order. Identifiers, parameters, struct
+ * fields, and binding names are real nodes here (with ranges), so comments can
+ * attach to them even where a printer renders them as bare text. */
+export function astChildNodes(node: A.SchemeNode): A.SchemeNode[] {
+  switch (node.tag) {
+    case 'prog':
+      return node.body
+    case 'define':
+      return [node.name, node.value]
+    case 'display':
+      return [node.value]
+    case 'stmtexp':
+      return [node.expr]
+    case 'struct':
+      return [node.name, ...node.fields]
+    case 'app':
+      return [node.head, ...node.args]
+    case 'lam':
+      return [
+        ...node.params,
+        ...(node.restParam ? [node.restParam] : []),
+        node.body,
+      ]
+    case 'let':
+    case 'let*':
+      return [...node.bindings.flatMap((b) => [b.id, b.value]), node.body]
+    case 'begin':
+    case 'and':
+    case 'or':
+    case 'section':
+      return node.exps
+    case 'if':
+      return [node.guard, node.ifB, node.elseB]
+    case 'match':
+      return [node.scrutinee, ...node.branches.flatMap((b) => [b.pat, b.body])]
+    case 'cond':
+      return node.branches.flatMap((b) => [b.test, b.body])
+    case 'error':
+    case 'report':
+      return [node.exp]
+    case 'apply':
+      return [node.fn, node.args]
+    case 'with-handler':
+      return [node.handler, node.fn, ...node.args]
+    case 'pctor':
+      return [node.name, ...node.args]
+    case 'import':
+    case 'lit':
+    case 'id':
+    case 'quote':
+    case 'jsvar':
+    case 'pwild':
+    case 'plit':
+      return []
+  }
+}
+
+function append(
+  existing: A.Comment[] | undefined,
+  more: A.Comment[],
+): A.Comment[] {
+  return existing ? [...existing, ...more] : [...more]
+}
+
+// Distributes `comments` (sorted, each within `node`'s span) among node's
+// children and onto the node itself. Rule: a comment on the same line as the
+// preceding child is *trailing* on that child; otherwise it is *leading* on the
+// following child; a comment with no following child *dangles* on the node.
+function attachInto(node: A.SchemeNode, comments: A.Comment[]): void {
+  if (comments.length === 0) return
+  const kids = astChildNodes(node)
+  if (kids.length === 0) {
+    node.dangling = append(node.dangling, comments)
+    return
+  }
+  let i = 0
+  let pendingLeading: A.Comment[] = []
+  let lastKid: A.SchemeNode | null = null
+  const flush = (c: A.Comment) => {
+    if (lastKid !== null && lastKid.range.end.line === c.range.begin.line) {
+      lastKid.trailing = append(lastKid.trailing, [c])
+    } else {
+      pendingLeading.push(c)
+    }
+  }
+  for (const kid of kids) {
+    while (i < comments.length && comments[i].range.end.idx < kid.range.begin.idx) {
+      flush(comments[i++])
+    }
+    if (pendingLeading.length > 0) {
+      kid.leading = append(kid.leading, pendingLeading)
+      pendingLeading = []
+    }
+    const inside: A.Comment[] = []
+    while (i < comments.length && comments[i].range.end.idx <= kid.range.end.idx) {
+      inside.push(comments[i++])
+    }
+    if (inside.length > 0) attachInto(kid, inside)
+    lastKid = kid
+  }
+  while (i < comments.length) {
+    flush(comments[i++])
+  }
+  if (pendingLeading.length > 0) {
+    node.dangling = append(node.dangling, pendingLeading)
+  }
+}
+
+/**
+ * Attaches `comments` to `root` and its descendants in place, as
+ * leading/trailing/dangling on the nearest node by source position.
+ */
+export function attachComments(root: A.SchemeNode, comments: A.Comment[]): void {
+  if (comments.length === 0) return
+  const sorted = [...comments].sort(
+    (a, b) => a.range.begin.idx - b.range.begin.idx,
+  )
+  attachInto(root, sorted)
+}

--- a/test/prettier/printer.test.ts
+++ b/test/prettier/printer.test.ts
@@ -119,3 +119,165 @@ describe('idempotence', () => {
   test('multi-statement program', () =>
     idempotent('(define x 1)\n(define y 2)\n(display (+ x y))'))
 })
+
+// ---- comments are preserved (#304) -----------------------------------------
+
+describe('comment preservation', () => {
+  test('a docstring above a define survives formatting', async () => {
+    const src = [
+      ';;; (add1 n) -> number?',
+      ';;;   n: number?',
+      ';;; Adds one to n.',
+      '(define add1 (lambda (n) (+ n 1)))',
+    ].join('\n')
+    const out = await format(src)
+    expect(out).toContain(';;; (add1 n) -> number?')
+    expect(out).toContain(';;;   n: number?')
+    expect(out).toContain(';;; Adds one to n.')
+    // The comment stays immediately above the define it documents.
+    expect(out.indexOf(';;; Adds one to n.')).toBeLessThan(out.indexOf('(define add1'))
+  })
+
+  test('a standalone comment between statements is kept on its own line', async () => {
+    const out = await format('(define a 1)\n; a note\n(define b 2)')
+    expect(out).toBe('(define a 1)\n; a note\n(define b 2)')
+  })
+
+  test('a trailing comment stays on the same line as its code', async () => {
+    const out = await format('(define a 1) ; trailing')
+    expect(out).toBe('(define a 1) ; trailing')
+  })
+
+  test('a comment inside a form is preserved', async () => {
+    const out = await format('(let ([x 1] ; the x\n [y 2]) (+ x y))')
+    expect(out).toContain('; the x')
+    expect(out).toContain('[y 2]')
+    expect(out).toContain('(+ x y)')
+  })
+
+  test('the issue #304 example keeps its docstring', async () => {
+    const src = [
+      ';;; (factorial n) -> number?',
+      ';;;   n: number?',
+      ';;; Returns n!',
+      '(define factorial',
+      '  (lambda (n)',
+      '    (if (zero? n) 1 (* n (factorial (- n 1))))))',
+    ].join('\n')
+    const out = await format(src)
+    expect(out).toContain(';;; (factorial n) -> number?')
+    expect(out).toContain(';;; Returns n!')
+  })
+
+  test('formatting commented code is idempotent', async () => {
+    const src = [
+      ';;; a documented helper',
+      '(define f (lambda (x) (* x 2))) ; doubles',
+      '; and a note',
+      '(define g (lambda (y) (+ y 1)))',
+    ].join('\n')
+    const once = await format(src)
+    const twice = await format(once)
+    expect(twice).toBe(once)
+    // All three comments are still present after two passes.
+    expect(twice).toContain(';;; a documented helper')
+    expect(twice).toContain('; doubles')
+    expect(twice).toContain('; and a note')
+  })
+
+  test('a trailing comment on an inner element stays with that element', async () => {
+    // Comments attached to nodes (scheme/comments.ts) mean an inline comment no
+    // longer migrates to the end of the whole form.
+    const out = await format('(+ 1 ; one\n 2)')
+    expect(out).toContain('1 ; one')
+    expect(tokenizeAndParse(out).diagnostics).toEqual([])
+  })
+})
+
+// Comments in these positions are placed in situ and format idempotently.
+describe('comment placement is valid and idempotent (#304)', () => {
+  const cases: [string, string][] = [
+    ['a comment-only file', '; just a comment\n'],
+    ['a comment by a lambda body', '(lambda (x) ; body\n (+ x 1))'],
+    ['a comment by a define name', '(define ; name\n x 1)'],
+    ['a comment on a struct field', '(struct point (x ; ex\n y))'],
+    ['a comment on a let binding', '(let ([x ; the x\n 1]) x)'],
+    ['a comment before a closing paren', '(+ 1 2\n ; note\n)'],
+  ]
+  for (const [name, src] of cases) {
+    test(name, async () => {
+      const out = await format(src)
+      expect(tokenizeAndParse(out).diagnostics).toEqual([])
+      expect(out).toMatch(/;/) // preserved
+      expect(await format(out)).toBe(out) // idempotent
+    })
+  }
+})
+
+// Known limitations: these relocate the comment and stabilize after one further
+// reformat rather than being immediately idempotent. They never lose the comment
+// or produce invalid output.
+describe('comment placement relocates but stays valid (#304)', () => {
+  const cases: [string, string][] = [
+    ["a trailing comment on a form's last element", '(+ 1 2 ; sum\n)'],
+    ['a comment on a cond branch', '(cond [#t ; yes\n 1])'],
+  ]
+  for (const [name, src] of cases) {
+    test(name, async () => {
+      const out = await format(src)
+      expect(tokenizeAndParse(out).diagnostics).toEqual([])
+      expect(out).toMatch(/;/) // preserved
+      const stable = await format(out)
+      expect(await format(stable)).toBe(stable) // stable after one reformat
+    })
+  }
+
+  test('a comment inside quoted data is preserved (quote rendering is a separate bug)', async () => {
+    // N.B. quoted data itself does not round-trip today: (quote (1 2 3)) prints
+    // as '(list 1 2 3), which reparses differently -- a pre-existing quote
+    // printer bug independent of comments. So we only assert the comment
+    // survives in valid output, not idempotency.
+    const out = await format("(define xs '(1 ; one\n 2 3))")
+    expect(tokenizeAndParse(out).diagnostics).toEqual([])
+    expect(out).toContain('; one')
+  })
+})
+
+// Guards the core invariant: no comment is ever silently dropped, at any
+// position. Without Prettier's comment system there is no built-in "comment not
+// printed" error, so this injects a probe comment at every token boundary of
+// several realistic programs and asserts it survives in valid output.
+describe('no comment is ever lost (#304)', () => {
+  const programs = [
+    '(define x 1)',
+    '(define f (lambda (x y) (+ x y)))',
+    '(let ([a 1] [b 2]) (+ a b))',
+    '(let* ([a 1] [b (+ a 1)]) b)',
+    '(if (> x 0) 1 (- 0 x))',
+    '(struct point (x y))',
+    '(cond [(> n 0) 1] [else 0])',
+    '(match n [0 "z"] [_ "n"])',
+    '(and (> a 0) (< b 10))',
+    '(display (+ 1 2))',
+  ]
+  const PROBE = ';__probe__'
+
+  for (const prog of programs) {
+    // Every space is an inter-token gap; probe both an own-line comment there
+    // and a same-line (trailing) comment.
+    const gaps = Array.from(prog).flatMap((ch, i) => (ch === ' ' ? [i] : []))
+    for (const pos of gaps) {
+      for (const [kind, insert] of [
+        ['own-line', `\n${PROBE}\n`],
+        ['trailing', ` ${PROBE}\n`],
+      ] as const) {
+        const src = prog.slice(0, pos) + insert + prog.slice(pos + 1)
+        test(`${kind} probe at ${String(pos)} of ${prog}`, async () => {
+          const out = await format(src)
+          expect(tokenizeAndParse(out).diagnostics).toEqual([])
+          expect(out).toContain(PROBE)
+        })
+      }
+    }
+  }
+})

--- a/test/scheme/comments.test.ts
+++ b/test/scheme/comments.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest'
+import { tokenizeAndParse } from '../../src/scheme'
+import * as A from '../../src/scheme/ast'
+import { attachComments, collectComments } from '../../src/scheme/comments'
+
+function lines(cs: A.Comment[] | undefined): string[] {
+  return (cs ?? []).map((c) => c.line)
+}
+
+function attach(src: string): A.ProgNode {
+  const { program, diagnostics } = tokenizeAndParse(src)
+  if (!program) throw new Error(diagnostics.map((d) => d.message).join('; '))
+  const root = A.progToNode(program)
+  attachComments(root, collectComments(src))
+  return root
+}
+
+describe('collectComments', () => {
+  test('recovers line comments in source order with their text', () => {
+    expect(lines(collectComments('; hello\n(+ 1 2) ; world'))).toEqual([
+      '; hello',
+      '; world',
+    ])
+  })
+
+  test('ignores ";" inside strings and char literals', () => {
+    expect(collectComments('(define s "a;b")\n(define c #\\;)')).toEqual([])
+  })
+
+  test('trims trailing whitespace from a comment', () => {
+    expect(lines(collectComments('(+ 1 2)   ;  spaced   '))).toEqual([
+      ';  spaced',
+    ])
+  })
+})
+
+describe('attachComments — placement rules', () => {
+  test('a standalone comment leads the following statement', () => {
+    const define = attach('; note\n(define x 1)').body[0]
+    expect(lines(define.leading)).toEqual(['; note'])
+    expect(lines(define.trailing)).toEqual([])
+  })
+
+  test('a same-line comment trails the preceding statement', () => {
+    const define = attach('(define x 1) ; trailing').body[0]
+    expect(lines(define.trailing)).toEqual(['; trailing'])
+    expect(lines(define.leading)).toEqual([])
+  })
+
+  test('a mid-form comment trails the element on its line', () => {
+    const stmt = attach('(+ 1 ; one\n 2)').body[0]
+    if (stmt.tag !== 'stmtexp' || stmt.expr.tag !== 'app') throw new Error('shape')
+    expect(lines(stmt.expr.args[0].trailing)).toEqual(['; one'])
+    expect(lines(stmt.expr.args[1].leading)).toEqual([])
+  })
+
+  test('an own-line comment before an element leads that element', () => {
+    const stmt = attach('(+ 1\n ; note\n 2)').body[0]
+    if (stmt.tag !== 'stmtexp' || stmt.expr.tag !== 'app') throw new Error('shape')
+    expect(lines(stmt.expr.args[0].trailing)).toEqual([])
+    expect(lines(stmt.expr.args[1].leading)).toEqual(['; note'])
+  })
+
+  test('a comment before a closing paren dangles on the form', () => {
+    const stmt = attach('(+ 1 2\n ; note\n)').body[0]
+    if (stmt.tag !== 'stmtexp' || stmt.expr.tag !== 'app') throw new Error('shape')
+    expect(lines(stmt.expr.dangling)).toEqual(['; note'])
+  })
+
+  test('a comment-only program dangles on the root', () => {
+    expect(lines(attach('; only').dangling)).toEqual(['; only'])
+  })
+
+  test('a comment attaches to a nested identifier (lambda parameter)', () => {
+    const stmt = attach('(lambda (x ; the x\n y) x)').body[0]
+    if (stmt.tag !== 'stmtexp' || stmt.expr.tag !== 'lam') throw new Error('shape')
+    // The comment is on the same line as `x`, so it trails the `x` parameter.
+    expect(lines(stmt.expr.params[0].trailing)).toEqual(['; the x'])
+  })
+
+  test('trailing vs. leading is decided per line, never double-attached', () => {
+    // "; a" trails `1`; "; b" (own line) leads `2`.
+    const stmt = attach('(+ 1 ; a\n ; b\n 2)').body[0]
+    if (stmt.tag !== 'stmtexp' || stmt.expr.tag !== 'app') throw new Error('shape')
+    expect(lines(stmt.expr.args[0].trailing)).toEqual(['; a'])
+    expect(lines(stmt.expr.args[1].leading)).toEqual(['; b'])
+  })
+
+  test('a define docstring becomes the leading comments of its statement', () => {
+    const define = attach(';;; (f x) -> number?\n;;; doc\n(define f (lambda (x) x))').body[0]
+    expect(lines(define.leading)).toEqual([';;; (f x) -> number?', ';;; doc'])
+  })
+})


### PR DESCRIPTION
> **Draft for review.** This is the redesign you asked for: comments are ornamented onto the AST (our own attachment), not carried in Prettier's comment system. Prettier is now used only as a layout engine for comments — a step toward moving off it entirely.

## Problem
Auto-formatting stripped **every** comment, docstrings included. Scamper's AST discards comments (the compiler doesn't need them), and the formatter runs off that AST.

## Design — comments as first-class AST data
Each `Node` can carry `leading` / `trailing` / `dangling` comments (`ast.ts`), populated **on demand** by our own attachment pass — so normal compilation pays nothing and structural equality ignores them.

- **`src/scheme/comments.ts`** (new, reusable core, no Prettier dependency):
  - `collectComments(src)` recovers line comments from the Lezer tree (so `;` in strings and `#\;` are never mistaken for comments).
  - `attachComments(root, comments)` places each comment by source position: a comment on the **preceding child's line** is *trailing* on it; otherwise *leading* on the **following child**; otherwise *dangling* on the node.
  - `astChildNodes(node)` enumerates a node's child nodes in source order.
- **Prettier plugin**: the parser attaches comments in place; the printer reads `leading`/`trailing`/`dangling` off each node. Identifiers, params, struct fields, and binding names are now printed via the path (not bare strings) so their comments emit too. **Prettier's comment system is no longer used at all.**

## What works (in-place + idempotent)
Docstrings above defines (the issue's headline), standalone comments between statements, trailing end-of-line comments, and inline / between-sibling comments (e.g. `(+ 1 ; one\n 2)` keeps `; one` on `1`).

## Known limitations (never lossy, always valid output)
- A **trailing comment on a form's last element** (`(+ 1 2 ; sum)`) and comments in the **space-joined `struct`/`lambda` parameter lists** relocate slightly and stabilize after one further reformat rather than being immediately idempotent.
- Comments **inside quoted data** (`'(1 ; x\n 2)`) inherit a **pre-existing quote-rendering bug** — `'(1 2 3)` already prints as `'(list 1 2 3)` and reparses differently, with **no comment involved** (reproduced on `origin/main`). That quote bug is a separate correctness issue worth its own fix (it changes program meaning); flagged here, not addressed.

## Testing
- `test/scheme/comments.test.ts`: unit tests for the placement rules (leading/trailing/dangling, per-line trailing-vs-leading, nested identifiers) — attachment is now testable without Prettier.
- `test/prettier/printer.test.ts`: in-place + idempotent cases, the relocating cases, and a **fuzz loss-guard** that injects a probe comment at every token boundary of several programs and asserts it is never dropped (since removing Prettier's comment system also removed its "comment not printed" safety net).
- **Verified end-to-end in the IDE** via the real Format command.

## Validation
- Typecheck: PASS · Tests: 86 files / 1459 tests (`npm test`) · Lint: 0 errors
- Independent code review of this design: no comment loss found across a 68-point injection fuzz; recommended the loss-guard test, which is included.

## Design note
This supersedes the earlier Prettier-native-attachment version (per our discussion). The trade-off vs. that approach: we own the attachment logic (more control → in-place placement + idempotency, testable in isolation, comments live on the AST) at the cost of not reusing Prettier's comment heuristics. The secondary "tune up Prettier wrapping" ask, and the pre-existing quote-rendering bug, are left as separate follow-ups.

_(Co-created with Claude Code)_