### PR TITLE
Fix let binding-list formatting in web traces (#318)

### DIFF
--- a/src/scheme/ast-components/ExpRenderer.vue
+++ b/src/scheme/ast-components/ExpRenderer.vue
@@ -47,6 +47,7 @@ switch (e.tag) {
       head: 'let',
       pairs: e.bindings.map(({ pat, value }) => ({ lhs: pat, rhs: value })),
       body: e.body,
+      parenthesizePairs: true,
     }
     break
   case 'match':

--- a/src/scheme/ast-components/HljsBindingForm.vue
+++ b/src/scheme/ast-components/HljsBindingForm.vue
@@ -5,23 +5,27 @@ import ValueRenderer from '../../lpm/renderers/vue/ValueRenderer.vue'
 
 defineProps<{ bindings: HljsBindings }>()
 </script>
-<!-- TODO: this looks weird, fix the formatting later-->
+<!-- Renders let/match/cond so the text matches expToString (#318): a single
+     space after the head, `let`'s binding list wrapped in its own parens
+     (match/cond clauses are not), and single spaces between clauses. -->
 <template>
   <div class="hljs">
-    <CodeElement>{{ `(${bindings.head} ` }}</CodeElement>
+    <CodeElement>{{ `(${bindings.head}` }}</CodeElement>
     <template v-if="bindings.scrutinee">
+      <CodeElement>{{ " " }}</CodeElement>
       <ValueRenderer :value="bindings.scrutinee" />
     </template>
+    <CodeElement>{{ bindings.parenthesizePairs ? " (" : " " }}</CodeElement>
     <template v-for="(pair, idx) in bindings.pairs" :key="idx">
-      <CodeElement>{{ " [" }}</CodeElement>
-      <template v-if="typeof pair.lhs === 'string'">
-        {{ pair.lhs }}
-      </template>
+      <CodeElement v-if="idx > 0">{{ " " }}</CodeElement>
+      <CodeElement>{{ "[" }}</CodeElement>
+      <template v-if="typeof pair.lhs === 'string'">{{ pair.lhs }}</template>
       <ValueRenderer v-else :value="pair.lhs" />
       <CodeElement>{{ " " }}</CodeElement>
       <ValueRenderer :value="pair.rhs" />
       <CodeElement>{{ "]" }}</CodeElement>
     </template>
+    <CodeElement v-if="bindings.parenthesizePairs">{{ ")" }}</CodeElement>
     <template v-if="bindings.body">
       <CodeElement>{{ " " }}</CodeElement>
       <ValueRenderer :value="bindings.body" />

--- a/src/scheme/ast.ts
+++ b/src/scheme/ast.ts
@@ -538,6 +538,10 @@ export interface HljsBindings {
   pairs: { lhs: string | Pat | Exp; rhs: Exp }[]
   body?: Exp
   scrutinee?: Exp
+  // Whether the pair list is wrapped in its own parentheses, as `let`'s
+  // binding list is -- `(let ([x 1] [y 2]) body)` -- but `match`/`cond`
+  // clauses are not. Keeps the web rendering in step with expToString (#318).
+  parenthesizePairs?: boolean
 }
 
 ///// Equality /////////////////////////////////////////////////////////////////

--- a/test/regressions/let-trace-formatting.test.ts
+++ b/test/regressions/let-trace-formatting.test.ts
@@ -1,0 +1,69 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+import {
+  Exp,
+  expToString,
+  mkApp,
+  mkCond,
+  mkId,
+  mkLet,
+  mkLit,
+  mkMatch,
+  mkPLit,
+} from '../../src/scheme/ast.js'
+import ExpRenderer from '../../src/scheme/ast-components/ExpRenderer.vue'
+// Side-effect import: registers the Exp/Pat Vue renderers that ValueRenderer
+// dispatches to (mirrors what src/app/web/renderers.ts wires up in the IDE).
+import '../../src/scheme/renderers/vue.js'
+
+// Regression for #318: in the interactive (web) trace, a `let` rendered via the
+// shared HljsBindingForm component dropped the parentheses around its binding
+// list and doubled the space after `let`, e.g. `(let  [next (- 5 1)] body)`
+// instead of the correct `(let ([next (- 5 1)]) body)`. The canonical text form
+// (expToString) was always correct; only the Vue rendering diverged. Assert the
+// Vue rendering's text matches expToString for the binding forms.
+
+/** The exact text the web renderer paints for expression `e`. */
+function renderedText(e: Exp): string {
+  return mount(ExpRenderer, { props: { value: e } }).element.textContent ?? ''
+}
+
+describe('binding forms render (web) identically to their text form (#318)', () => {
+  test('let wraps its binding list in parens with no doubled space', () => {
+    // (let ([next (- 5 1)]) (* 5 (factorial next)))
+    const e = mkLet(
+      [{ pat: mkId('next'), value: mkApp(mkId('-'), [mkLit(5), mkLit(1)]) }],
+      mkApp(mkId('*'), [mkLit(5), mkApp(mkId('factorial'), [mkId('next')])]),
+    )
+    expect(renderedText(e)).toBe(expToString(e))
+    expect(renderedText(e)).toBe('(let ([next (- 5 1)]) (* 5 (factorial next)))')
+  })
+
+  test('let with multiple bindings keeps them inside one paren group', () => {
+    const e = mkLet(
+      [
+        { pat: mkId('x'), value: mkLit(2) },
+        { pat: mkId('y'), value: mkLit(3) },
+      ],
+      mkApp(mkId('+'), [mkId('x'), mkId('y')]),
+    )
+    expect(renderedText(e)).toBe(expToString(e))
+    expect(renderedText(e)).toBe('(let ([x 2] [y 3]) (+ x y))')
+  })
+
+  test('match still renders identically to its text form', () => {
+    const e = mkMatch(mkId('n'), [
+      { pat: mkPLit(0), body: mkLit(1) },
+      { pat: mkId('k'), body: mkApp(mkId('*'), [mkId('k'), mkId('k')]) },
+    ])
+    expect(renderedText(e)).toBe(expToString(e))
+  })
+
+  test('cond still renders identically to its text form', () => {
+    const e = mkCond([
+      { test: mkApp(mkId('<'), [mkId('x'), mkLit(0)]), body: mkLit(-1) },
+      { test: mkLit(true), body: mkLit(1) },
+    ])
+    expect(renderedText(e)).toBe(expToString(e))
+  })
+})


### PR DESCRIPTION
Fixes #318.

## Problem
In the interactive (web) trace, a `let` rendered as `(let  [next (- 5 1)] body)` — a doubled space after `let` and no parentheses around the binding list — instead of the correct `(let ([next (- 5 1)]) body)`.

The web trace renders `let`/`match`/`cond` through the shared `HljsBindingForm.vue` component, which:
- emitted `(let ` (trailing space) then ` [` (leading space) → doubled space, and
- never wrapped `let`'s binding list in its own `(…)`.

The canonical text form (`expToString`) was always correct, so the CLI `--trace` was unaffected; only the Vue rendering diverged.

## Fix
- Add a `parenthesizePairs` flag to `HljsBindings` (set only for `let`).
- Rewrite the `HljsBindingForm` template to emit a single space after the head keyword, wrap `let`'s binding list in its own parens, and single-space between clauses.

This brings the web rendering back in step with `expToString` for all three forms — and along the way fixes the same doubled-space that `cond` had.

## Testing
- New regression test `test/regressions/let-trace-formatting.test.ts` mounts `ExpRenderer` and asserts the rendered text equals `expToString` for `let` (single + multiple bindings), `match`, and `cond`. It fails on `main` (`(let  [x 2] [y 3] (+ x y))`) and passes with this change.
- `npm run validate` passes (typecheck, test, lint).

_(Co-created with Claude Code)_