### PR TITLE
Read app version from package.json in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 // vite.config.ts
+import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import { defineConfig } from 'vitest/config'
 
@@ -8,7 +9,14 @@ import { libSourcesPlugin } from './scripts/vite-plugin-lib-sources.mjs'
 import { flattenHtmlPlugin } from './scripts/vite-plugin-flatten-html.mjs'
 import { devFlatHtmlPlugin } from './scripts/vite-plugin-dev-flat-html.mjs'
 
-const AppVersion = process.env.npm_package_version ?? 'unknown'
+// Read the version from package.json directly so it's correct regardless of
+// how the build/test runner was launched. `npm_package_version` is only set by
+// the npm lifecycle (`npm run ...`), not by IDE test runners or a bare
+// `vitest`, so relying on it alone leaves APP_VERSION as 'unknown' there.
+const pkg = JSON.parse(
+  readFileSync(resolve(__dirname, 'package.json'), 'utf-8'),
+)
+const AppVersion = process.env.npm_package_version ?? pkg.version ?? 'unknown'
 
 // The single source of truth for the HTML entry points, so the build input,
 // the production flattening (flattenHtmlPlugin), and the dev server's flat


### PR DESCRIPTION
## Problem

`APP_VERSION` was derived solely from `process.env.npm_package_version`, which npm only sets for its own lifecycle scripts (`npm run ...`). IDE test runners (VS Code / JetBrains Vitest extensions) and a bare `vitest` leave it unset, so `AppVersion` fell back to the literal string `'unknown'`.

That tripped the intentional version guard in `test/apps/web/ide-patch-notes.test.ts`:

```
AssertionError: expected 'unknown' to match /^\d+(\.\d+)*$/
```

The failure was launcher-dependent — `npm run test` passed, but running the same file from an IDE/watcher did not.

## Fix

Read the version from `package.json` directly as a fallback in `vite.config.ts`, so `APP_VERSION` is correct regardless of how the build/test runner was launched. `npm_package_version` still takes precedence when present, so nothing changes for the npm lifecycle.

## Verification

- Previously-failing mode (`vitest` with `npm_package_version` unset) → 4/4 pass (`APP_VERSION` = `3.5.0`).
- Normal npm path (`npm_package_version` set) → 4/4 pass (no regression).
- `vue-tsc --noEmit` on the config → clean.

_(Co-created with Claude Code)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)