### PR TITLE
Qualified names for imported modules

### DIFF
--- a/src/app/web/codemirror/lsp/completion.ts
+++ b/src/app/web/codemirror/lsp/completion.ts
@@ -1,5 +1,4 @@
 import type { CompletionItem } from 'vscode-languageserver-protocol'
-import { tokenizeAndParse } from '../../../../scheme'
 import { docRegistry } from '../../../../lib'
 import {
   FunctionDoc,
@@ -7,13 +6,24 @@ import {
 } from '../../../../scheme/docstring/docstring'
 import { functionDocSignature } from '../../../../scheme/docstring/render'
 import { makeScopeTreeFromProgram } from '../../../../scheme/scope-tree'
+import * as A from '../../../../scheme/ast'
 import type { Prog } from '../../../../scheme/ast'
+import * as SymbolDB from '../../../../scheme/symbol-db'
+import { parseProgramFromSource } from '../../../../scheme/lezer-bridge'
+import { ScamperDiagnostic } from '../../../../scheme/diagnostic'
 import { findBuiltinDoc, functionDocMarkdown } from './docs'
 import { rangeAtOffset } from './scope'
+import { computeLineStarts, rangeFromOffsets } from './positions'
 
 // CompletionItemKind values (vscode-languageserver-protocol).
 const KIND_FUNCTION = 3
 const KIND_VARIABLE = 6
+const KIND_MODULE = 9
+
+// The run of identifier characters ending at the cursor (its delimiters mirror
+// syntax.grammar's Identifier token). Used to detect a qualified `alias.member`
+// context mid-word, since a half-typed `alias.` doesn't parse into a program.
+const TRAILING_TOKEN = /[^\s()[\]{}'";&]*$/
 
 /**
  * Completion candidates in scope at [offset]: everything visible per the scope
@@ -27,10 +37,29 @@ export async function completionsFor(
   src: string,
   offset: number,
 ): Promise<CompletionItem[]> {
-  const { program } = tokenizeAndParse(src)
-  if (program === undefined) {
+  // Parse tolerantly (not tokenizeAndParse, which yields no program on any
+  // error): a half-typed qualified name like `img.` doesn't parse, but the
+  // earlier import statements do, and the qualified branch below needs them to
+  // resolve the alias mid-edit.
+  const diagnostics: ScamperDiagnostic[] = []
+  const program = parseProgramFromSource(diagnostics, src)
+  // Make sure imported file modules are in the symbol DB before we resolve
+  // either qualified members or the flat scope tree (both read from it).
+  await SymbolDB.loadTransitiveImports(program)
+
+  // Typing `alias.` (a qualified name) offers that module's members instead of
+  // the flat scope -- nothing else is in scope after the dot.
+  const qualified = qualifiedMemberCompletions(src, offset, program)
+  if (qualified !== undefined) {
+    return qualified
+  }
+
+  // Outside a qualified context, a buffer that doesn't parse cleanly falls back
+  // to prelude so completion still works mid-edit.
+  if (diagnostics.length > 0) {
     return preludeFallback()
   }
+
   const userDocs = topLevelUserDocs(program)
   const tree = await makeScopeTreeFromProgram(program)
   const scope = tree.getInnermostScope(rangeAtOffset(offset)) ?? tree
@@ -45,6 +74,62 @@ export async function completionsFor(
     }
     seen.add(id.name)
     items.push(itemFor(id.name, userDocs))
+  }
+  // Surface qualified-import aliases so the user can discover `alias.member`.
+  for (const alias of A.qualifiedImportMap(program).keys()) {
+    if (!seen.has(alias)) {
+      seen.add(alias)
+      items.push({ label: alias, kind: KIND_MODULE })
+    }
+  }
+  return items
+}
+
+/**
+ * When the cursor sits in a qualified name `alias.partial` for a known
+ * qualified-import alias, the completion candidates are that module's exported
+ * members (as `alias.member`), each with a textEdit spanning the whole dotted
+ * token so insertion is correct regardless of the editor's word boundaries
+ * (`.` isn't a word character). Returns undefined when not in a qualified
+ * context, so the caller falls back to ordinary scope completion.
+ */
+function qualifiedMemberCompletions(
+  src: string,
+  offset: number,
+  program: Prog,
+): CompletionItem[] | undefined {
+  const token = TRAILING_TOKEN.exec(src.slice(0, offset))?.[0] ?? ''
+  if (!A.isQualifiedName(token)) {
+    return undefined
+  }
+  const { qualifier } = A.splitQualifiedName(token)
+  const imp = A.qualifiedImportMap(program).get(qualifier)
+  if (imp === undefined) {
+    return undefined
+  }
+  const range = rangeFromOffsets(offset - token.length, offset, computeLineStarts(src))
+  const docs = docRegistry.get(imp.module)
+  const items: CompletionItem[] = []
+  const seen = new Set<string>()
+  for (const { name: member } of SymbolDB.get(imp.module) ?? []) {
+    if (member.includes('##') || seen.has(member)) {
+      continue
+    }
+    seen.add(member)
+    const label = `${qualifier}.${member}`
+    const doc = docs?.get(member)
+    items.push({
+      label,
+      kind: doc !== undefined ? KIND_FUNCTION : KIND_VARIABLE,
+      filterText: label,
+      textEdit: { range, newText: label },
+      ...(doc !== undefined
+        ? {
+            detail: functionDocSignature(doc).split('\n')[0],
+            documentation: functionDocMarkdown(doc, imp.module),
+          }
+        : {}),
+    })
   }
   return items
 }

--- a/src/app/web/codemirror/lsp/docs.ts
+++ b/src/app/web/codemirror/lsp/docs.ts
@@ -1,6 +1,7 @@
 import type { MarkupContent } from 'vscode-languageserver-protocol'
 import { tokenizeAndParse } from '../../../../scheme'
 import { docRegistry } from '../../../../lib'
+import * as A from '../../../../scheme/ast'
 import {
   FunctionDoc,
   parseFunctionDocFromComments,
@@ -35,6 +36,11 @@ export function lookupFunctionDoc(
   src: string,
   name: string,
 ): DocLookup | undefined {
+  // A qualified name (`alias.member`) resolves through the module its alias
+  // imports, not the flat doc registry.
+  if (A.isQualifiedName(name)) {
+    return lookupQualifiedDoc(src, name)
+  }
   const builtin = findBuiltinDoc(name)
   if (builtin !== undefined) {
     return builtin
@@ -56,6 +62,26 @@ export function lookupFunctionDoc(
     }
   }
   return undefined
+}
+
+/**
+ * Resolves a qualified name `alias.member` to its documentation: find the
+ * import that introduced `alias`, then look up `member` in that module's doc
+ * registry. Only built-in modules carry registered docs; a file module has
+ * none, so its members resolve to undefined (no hover).
+ */
+function lookupQualifiedDoc(src: string, name: string): DocLookup | undefined {
+  const { qualifier, member } = A.splitQualifiedName(name)
+  const { program } = tokenizeAndParse(src)
+  if (program === undefined) {
+    return undefined
+  }
+  const imp = A.qualifiedImportMap(program).get(qualifier)
+  if (imp === undefined) {
+    return undefined
+  }
+  const doc = docRegistry.get(imp.module)?.get(member)
+  return doc !== undefined ? { doc, module: imp.module } : undefined
 }
 
 /** Renders a doc entry as Markdown: a signature code block, the description, then the source module. */

--- a/src/app/web/codemirror/lsp/docs.ts
+++ b/src/app/web/codemirror/lsp/docs.ts
@@ -1,5 +1,6 @@
 import type { MarkupContent } from 'vscode-languageserver-protocol'
 import { tokenizeAndParse } from '../../../../scheme'
+import { parseProgramFromSource } from '../../../../scheme/lezer-bridge'
 import { docRegistry } from '../../../../lib'
 import * as A from '../../../../scheme/ast'
 import {
@@ -72,10 +73,10 @@ export function lookupFunctionDoc(
  */
 function lookupQualifiedDoc(src: string, name: string): DocLookup | undefined {
   const { qualifier, member } = A.splitQualifiedName(name)
-  const { program } = tokenizeAndParse(src)
-  if (program === undefined) {
-    return undefined
-  }
+  // Parse tolerantly (not tokenizeAndParse, which yields no program on any
+  // error) so hover keeps working while the rest of the buffer is mid-edit --
+  // the import statements survive an error elsewhere.
+  const program = parseProgramFromSource([], src)
   const imp = A.qualifiedImportMap(program).get(qualifier)
   if (imp === undefined) {
     return undefined

--- a/src/lpm/fiber.ts
+++ b/src/lpm/fiber.ts
@@ -46,6 +46,9 @@ export interface YieldStep { tag: 'yield' }
 export interface ImportFileStep {
   tag: 'import-file'
   filename: string
+  // When set, import the file under this qualified name (alias) rather than
+  // injecting its bindings unqualified. Mirrors Import.alias.
+  alias?: string
 }
 // A fiber suspended mid-expression by a blocking primitive (see SuspendSignal).
 // The scheduler runs `action`, then resumes the fiber with the resolved value
@@ -67,8 +70,11 @@ export const displayStep: DisplayStep = { tag: 'display' }
 export const traceStep: TraceStep = { tag: 'trace' }
 export const minorStep: MinorStep = { tag: 'minor' }
 export const yieldStep: YieldStep = { tag: 'yield' }
-export function importFileStep(filename: string): ImportFileStep {
-  return { tag: 'import-file', filename }
+export function importFileStep(
+  filename: string,
+  alias?: string,
+): ImportFileStep {
+  return { tag: 'import-file', filename, ...(alias !== undefined ? { alias } : {}) }
 }
 export function blockOnStep(action: () => Promise<Value>): BlockOnStep {
   return { tag: 'block-on', action }
@@ -357,7 +363,11 @@ export class Fiber {
   }
 
   /* Module importing helper functions */
-  loadModule(name: string, kind: 'builtin' | 'file'): StepResult {
+  loadModule(
+    name: string,
+    kind: 'builtin' | 'file',
+    alias?: string,
+  ): StepResult {
     if (kind === 'builtin') {
       const builtin = builtinLibs.get(name)
       if (!builtin) {
@@ -368,14 +378,19 @@ export class Fiber {
       // with an initializer at this point is the music lib, so we might
       // want to remove initializers altogether and do something for
       // the music lib instead.
-      this.topLevelEnv = this.topLevelEnv.extendWithImport(name, builtin)
+      // A qualified import (alias set) binds the module under its alias so it
+      // is reachable only as `alias.member`; otherwise it injects unqualified.
+      this.topLevelEnv =
+        alias !== undefined
+          ? this.topLevelEnv.extendWithQualifiedImport(alias, builtin)
+          : this.topLevelEnv.extendWithImport(name, builtin)
       return traceStep
     } else {
       // ...otherwise, we're loading a user file as a lib. The libname
       // should correspond to the exact name of the source file. This will
       // be handled by the scheduler who will, ultimately, pause the current
       // fiber and execute an asynchronous load of that file.
-      return importFileStep(name)
+      return importFileStep(name, alias)
     }
   }
 }

--- a/src/lpm/frame.ts
+++ b/src/lpm/frame.ts
@@ -23,6 +23,11 @@ export class Frame {
   // the tracer can keep the whole call atomic. False for the synthetic
   // per-statement frame and for the user's own closures.
   stepOver: boolean
+  // The applied closure's `home` env, if any (see Closure.home). Propagated so
+  // that a lambda created while this frame runs inherits the same home -- a
+  // closure returned by a qualified-module function must still resolve the
+  // module's siblings. Undefined for ordinary frames (dynamic fiber resolution).
+  home?: L.Env
 
   constructor(
     name: string,
@@ -30,6 +35,7 @@ export class Frame {
     blk: L.Blk,
     callRange: Range = Range.none,
     stepOver = false,
+    home?: L.Env,
   ) {
     this.name = name
     this.env = env
@@ -37,6 +43,7 @@ export class Frame {
     this.ops = blk.toReversed()
     this.callRange = callRange
     this.stepOver = stepOver
+    this.home = home
   }
 
   isFinished(): boolean {

--- a/src/lpm/handlers/op-handlers.ts
+++ b/src/lpm/handlers/op-handlers.ts
@@ -43,6 +43,9 @@ export const ClsHandler: OpHandler<'cls'> = (op, currFrame, fiber) => {
       // Closures born while a library/import fiber runs are stepped over in
       // traces (see Fiber.stepOverClosures / Closure.stepOver).
       fiber.stepOverClosures,
+      // Inherit the enclosing frame's home so a lambda returned by a
+      // qualified-module function still resolves the module's siblings.
+      currFrame.home,
     ),
   )
   return minorStep
@@ -123,14 +126,18 @@ export function applyFn(
       [p, namedArgs[i]]).concat(
         fn.restParam ? [[fn.restParam, vectorToList(args.slice(fn.params.length))]] : [])
     // The callee sees the closure's captured scopes (shared, so letrec fills
-    // are visible) with the parameters as a fresh innermost scope on top.
+    // are visible) with the parameters as a fresh innermost scope on top. Its
+    // free top-level names resolve against the closure's `home` env when set (a
+    // qualified-module closure -- see Closure.home), else the running fiber's
+    // env (so top-level forward references / letrec keep working).
     const paramScope: Scope = new Map(bindings)
     const newFrame = new Frame(
       fn.name ?? '##anonymous##',
-      fiber.topLevelEnv.withLocalScopes([...fn.locals, paramScope]),
+      (fn.home ?? fiber.topLevelEnv).withLocalScopes([...fn.locals, paramScope]),
       fn.code,
       range,
       fn.stepOver ?? false,
+      fn.home,
     )
     if (currFrame.canTailCall()) {
       // tail-call optimize by replacing the current frame (any leftover

--- a/src/lpm/handlers/stmt-handlers.ts
+++ b/src/lpm/handlers/stmt-handlers.ts
@@ -8,7 +8,7 @@ type StatementHandler<T extends Stmt['tag']> = (
 ) => StepResult
 
 export const ImportHandler: StatementHandler<'import'> = (stmt, fiber) => {
-  const result = fiber.loadModule(stmt.name, stmt.kind)
+  const result = fiber.loadModule(stmt.name, stmt.kind, stmt.alias)
   if (result.tag === 'trace') {
     fiber.advanceStmt()
   }

--- a/src/lpm/lang.ts
+++ b/src/lpm/lang.ts
@@ -239,9 +239,22 @@ export class Env {
    */
   extendWithQualifiedImport(alias: string, lib: Module): Env {
     const rehomed = new Module()
-    // `home` imports the (about-to-be-filled) re-homed module, so a sibling
-    // lookup lands on a re-homed closure too -- keeping the chain within `lib`.
-    const home = this.extendWithImport(alias, rehomed)
+    // `home` resolves a re-homed closure's free names against, in order: the
+    // module's own bindings, then this base env's imports (the standard library
+    // and the importer's other imports). It deliberately drops the importer's
+    // *top-level* bindings: the module's internals -- siblings and the contract
+    // predicates they reference -- must not be shadowed by a user define that
+    // happens to share a name (an alias is a separate namespace, so such a
+    // define is not even flagged as a collision). `rehomed` is added to imports
+    // last so it wins over the standard library; the map holds it by reference,
+    // so the closures filled into it below are visible through `home` too,
+    // keeping the resolution chain within `lib`.
+    const home = new Env(
+      this.extendImports(alias, rehomed),
+      new Map(),
+      this.locals,
+      this.qualified,
+    )
     for (const [name, value] of lib.bindings) {
       rehomed.registerValue(
         name,

--- a/src/lpm/lang.ts
+++ b/src/lpm/lang.ts
@@ -40,9 +40,25 @@ export const HOLE: unique symbol = Symbol('hole')
 /** A local binding scope: names to values (or HOLE while still unassigned). */
 export type Scope = Map<string, Value | typeof HOLE>
 
+// A closure test local to this module (util.ts's isClosure would be circular).
+// Used by extendWithQualifiedImport to pick out the closures to re-home.
+function isClosureValue(v: Value): v is Closure {
+  return (
+    v !== null &&
+    typeof v === 'object' &&
+    (v as Partial<TaggedObject>)[scamperTag] === 'closure'
+  )
+}
+
 export class Env {
-  /** A mapping of imported modules to their bound libraries */
+  /** A mapping of unqualified imported modules to their bound libraries */
   private imports: Map<string, Module>
+  /**
+   * A mapping of qualified imports: each module's alias to its library. Kept
+   * separate from `imports` because these are reachable *only* through a
+   * qualified name (`alias.member`, see lookup), never flattened into scope.
+   */
+  private qualified: Map<string, Module>
   /** A mapping of top-level (module-level) bindings */
   private topLevel: Map<string, Value>
   /** A stack of local binding scopes; the last element is the innermost. */
@@ -53,10 +69,12 @@ export class Env {
     imports: Map<string, Module>,
     topLevel: Map<string, Value>,
     locals: Scope[],
+    qualified: Map<string, Module> = new Map(),
   ) {
     this.imports = imports
     this.topLevel = topLevel
     this.locals = locals
+    this.qualified = qualified
   }
 
   /** The empty environment */
@@ -75,6 +93,19 @@ export class Env {
   lookup(
     name: string,
   ): { found: true; slot: Value | typeof HOLE } | { found: false } {
+    // 0. A qualified name (`alias.member`) resolves *only* through a qualified
+    // import's alias -- it is never a local, a top-level binding, or an
+    // unqualified import (binders can't be qualified). The scheme grammar admits
+    // exactly one separator, so split on the first one.
+    const dot = name.indexOf('.')
+    if (dot >= 0) {
+      const module = this.qualified.get(name.slice(0, dot))
+      const member = name.slice(dot + 1)
+      if (module !== undefined && module.bindings.has(member)) {
+        return { found: true, slot: module.bindings.get(member) }
+      }
+      return { found: false }
+    }
     // 1. Local scopes, innermost (most recently pushed) first
     for (let i = this.locals.length - 1; i >= 0; i--) {
       const scope = this.locals[i]
@@ -154,7 +185,7 @@ export class Env {
    */
   declareScope(names: string[]): Env {
     const scope: Scope = new Map(names.map((n) => [n, HOLE]))
-    return new Env(this.imports, this.topLevel, [...this.locals, scope])
+    return new Env(this.imports, this.topLevel, [...this.locals, scope], this.qualified)
   }
 
   /**
@@ -174,7 +205,7 @@ export class Env {
 
   /** Replace the local scope stack wholesale (used to build a callee frame). */
   withLocalScopes(scopes: Scope[]): Env {
-    return new Env(this.imports, this.topLevel, scopes)
+    return new Env(this.imports, this.topLevel, scopes, this.qualified)
   }
 
   /**
@@ -182,15 +213,47 @@ export class Env {
    * @return true iff the variable is bound in this environment
    */
   has(name: string): boolean {
-    return (
-      this.locals.some((scope) => scope.has(name)) ||
-      this.topLevel.has(name) ||
-      [...this.imports.values()].some((lib) => lib.bindings.has(name))
-    )
+    return this.lookup(name).found
   }
 
   extendWithImport(name: string, lib: Module): Env {
-    return new Env(this.extendImports(name, lib), this.topLevel, this.locals)
+    return new Env(
+      this.extendImports(name, lib),
+      this.topLevel,
+      this.locals,
+      this.qualified,
+    )
+  }
+
+  /**
+   * Import `lib` under the qualified name `alias`: its bindings become reachable
+   * only as `alias.member` (see lookup), never injected unqualified into scope.
+   *
+   * Because `lib`'s names are not in the importing scope, its own functions
+   * could not otherwise resolve their siblings (or the contract predicates they
+   * reference) at call time -- those are bare names, and applyFn resolves a
+   * closure's free names against the running fiber's env. So each of `lib`'s
+   * closures is re-homed: given a `home` env in which `lib`'s bindings resolve,
+   * layered over this base env (which carries the standard library). applyFn
+   * uses that `home` instead of the fiber env. Non-closure values need none.
+   */
+  extendWithQualifiedImport(alias: string, lib: Module): Env {
+    const rehomed = new Module()
+    // `home` imports the (about-to-be-filled) re-homed module, so a sibling
+    // lookup lands on a re-homed closure too -- keeping the chain within `lib`.
+    const home = this.extendWithImport(alias, rehomed)
+    for (const [name, value] of lib.bindings) {
+      rehomed.registerValue(
+        name,
+        isClosureValue(value) ? { ...value, home } : value,
+      )
+    }
+    return new Env(
+      this.imports,
+      this.topLevel,
+      this.locals,
+      new Map([...this.qualified, [alias, rehomed]]),
+    )
   }
 
   extendWithTopLevel(...bindings: [string, Value][]): Env {
@@ -198,6 +261,7 @@ export class Env {
       this.imports,
       this.extendBindings(this.topLevel, bindings),
       this.locals,
+      this.qualified,
     )
   }
 
@@ -208,15 +272,17 @@ export class Env {
 
   /** Push a new innermost local scope with the given bindings. */
   pushScope(bindings: [string, Value][]): Env {
-    return new Env(this.imports, this.topLevel, [
-      ...this.locals,
-      new Map(bindings),
-    ])
+    return new Env(
+      this.imports,
+      this.topLevel,
+      [...this.locals, new Map(bindings)],
+      this.qualified,
+    )
   }
 
   /** Drop the innermost local scope (inverse of {@link pushScope}). */
   popScope(): Env {
-    return new Env(this.imports, this.topLevel, this.locals.slice(0, -1))
+    return new Env(this.imports, this.topLevel, this.locals.slice(0, -1), this.qualified)
   }
 
   extendImports(name: string, lib: Module) {
@@ -229,13 +295,13 @@ export class Env {
 
   /** Replace all local scopes with a single scope holding `locals`. */
   extendReplacingLocals(...locals: [string, Value][]): Env {
-    return new Env(this.imports, this.topLevel, [new Map(locals)])
+    return new Env(this.imports, this.topLevel, [new Map(locals)], this.qualified)
   }
 
   /** Collapse the local scopes into one, dropping the named bindings. */
   withoutLocals(...names: string[]): Env {
     const kept = [...this.getLocals()].filter(([x]) => !names.includes(x))
-    return new Env(this.imports, this.topLevel, [new Map(kept)])
+    return new Env(this.imports, this.topLevel, [new Map(kept)], this.qualified)
   }
 }
 
@@ -291,6 +357,15 @@ export interface Closure extends TaggedObject {
   // steps through the user's own module/local definitions but not library
   // code. See src/scheme/trace.ts.
   stepOver?: boolean
+  // The environment this closure resolves its free top-level names against,
+  // instead of the running fiber's env (applyFn). Set only for closures of a
+  // module imported under a qualified name (see extendWithQualifiedImport): that
+  // module's bindings are NOT injected into the importing scope, so its own
+  // functions -- and the contract predicates they reference -- must resolve
+  // their siblings here. Undefined for ordinary closures, which resolve
+  // dynamically against the fiber's top-level env so that top-level forward
+  // references / letrec keep working.
+  home?: Env
 }
 
 /** A char is a tagged object that captures a single character (a one-character string). */
@@ -501,6 +576,10 @@ export interface Import {
   name: string
   kind: 'builtin' | 'file'
   range: Range
+  // When set, the module is imported under this qualified name (alias): its
+  // bindings are reachable only as `alias.<name>` (via Env's qualified map),
+  // not injected unqualified. Absent for the plain (import m) form.
+  alias?: string
 }
 export interface Define {
   tag: 'define'

--- a/src/lpm/scheduler.ts
+++ b/src/lpm/scheduler.ts
@@ -223,10 +223,18 @@ export class Scheduler {
                 err: task.err,
                 onComplete: () => {
                   const mod = moduleFiber.topLevelEnv.getTopLevelAsModule()
-                  fiber.topLevelEnv = fiber.topLevelEnv.extendWithImport(
-                    stepResult.filename,
-                    mod,
-                  )
+                  // A qualified file import (alias set) is reachable only as
+                  // `alias.member`; an unqualified one injects into scope.
+                  fiber.topLevelEnv =
+                    stepResult.alias !== undefined
+                      ? fiber.topLevelEnv.extendWithQualifiedImport(
+                          stepResult.alias,
+                          mod,
+                        )
+                      : fiber.topLevelEnv.extendWithImport(
+                          stepResult.filename,
+                          mod,
+                        )
                   fiber.advanceStmt()
                   this.schedule(task)
                 },

--- a/src/lpm/util.ts
+++ b/src/lpm/util.ts
@@ -46,8 +46,9 @@ export const mkClosure = (
   call: (...args: any) => any,
   name?: L.Id,
   restParam?: string,
-  stepOver = false
-): L.Closure => ({ [L.scamperTag]: 'closure', params, code, locals: env, call, name, restParam, stepOver })
+  stepOver = false,
+  home?: L.Env
+): L.Closure => ({ [L.scamperTag]: 'closure', params, code, locals: env, call, name, restParam, stepOver, home })
 export const mkChar = (v: string): L.Char => ({
   [L.scamperTag]: 'char',
   value: v,
@@ -172,7 +173,14 @@ export const mkImport = (
   name: string,
   kind: 'builtin' | 'file',
   range: Range = Range.none,
-): L.Import => ({ tag: 'import', name, kind, range })
+  alias?: string,
+): L.Import => ({
+  tag: 'import',
+  name,
+  kind,
+  range,
+  ...(alias !== undefined ? { alias } : {}),
+})
 export const mkStmtExp = (
   expr: L.Blk,
   range: Range = Range.none,

--- a/src/prettier/scheme/printer.ts
+++ b/src/prettier/scheme/printer.ts
@@ -57,8 +57,10 @@ function renderNode(path: AstPath, print: (p: AstPath) => Doc): Doc {
 
     ///// Statements ////////////////////////////////////////////////////////////
 
-    case 'import':
-      return `(import ${node.kind === 'file' ? JSON.stringify(node.module) : node.module})`
+    case 'import': {
+      const mod = node.kind === 'file' ? JSON.stringify(node.module) : node.module
+      return `(import ${mod}${node.alias !== undefined ? ` ${node.alias}` : ''})`
+    }
 
     case 'define':
       return group([

--- a/src/scheme/ast.ts
+++ b/src/scheme/ast.ts
@@ -481,6 +481,21 @@ export function isStmt(v: unknown): v is Stmt {
 export const isStmtExp = (s: Stmt): s is StmtExp =>
   isTagged(s) && s.tag === 'stmtexp'
 
+/**
+ * Maps each qualified import's alias to its Import statement, so a qualified
+ * reference `alias.member` can be resolved back to the module it names. The last
+ * import wins if an alias is (erroneously) reused.
+ */
+export function qualifiedImportMap(prog: Prog): Map<string, Import> {
+  const m = new Map<string, Import>()
+  for (const s of prog) {
+    if (s.tag === 'import' && s.alias !== undefined) {
+      m.set(s.alias, s)
+    }
+  }
+  return m
+}
+
 export const isVar = (e: Exp): e is Identifier => isTagged(e) && e.tag === 'id'
 
 export const isApp = (e: Exp): e is App =>

--- a/src/scheme/ast.ts
+++ b/src/scheme/ast.ts
@@ -65,6 +65,7 @@ export interface Comment {
 //
 // s ::= e
 //     | (import m)
+//     | (import m x)     -- m imported under the qualified name (alias) x
 //     | (define x e)
 //     | <docstring>
 //       (define x e)
@@ -91,9 +92,35 @@ export interface Comment {
 // Identifier node itself plays both roles -- it is a member of both the Exp
 // and Pat unions (tag 'id'), and is also used directly in binder positions
 // (lambda params, let bindings, define/struct names).
+//
+// `name` may be a one-level *qualified* name (`mod.member`) -- but only when the
+// identifier is a variable *reference*. Binder positions reject qualified names
+// (see lezer-bridge.ts), so a name in any binding/pattern/top-level slot is
+// always simple. Use isQualifiedName/splitQualifiedName to inspect one.
 export interface Identifier extends Tagged, Node {
   tag: 'id'
   name: string
+}
+
+/** The separator joining the two halves of a qualified name (`mod.member`). */
+export const QUALIFIER_SEP = '.'
+
+/** @returns whether `name` is a qualified reference of the form `mod.member` */
+export function isQualifiedName(name: string): boolean {
+  return name.includes(QUALIFIER_SEP)
+}
+
+/**
+ * Splits a qualified `mod.member` name into its `qualifier` (the module alias)
+ * and `member` halves. The grammar admits exactly one separator, so this splits
+ * on the first (and only) one.
+ */
+export function splitQualifiedName(name: string): {
+  qualifier: string
+  member: string
+} {
+  const i = name.indexOf(QUALIFIER_SEP)
+  return { qualifier: name.slice(0, i), member: name.slice(i + 1) }
 }
 
 ///// Patterns /////
@@ -200,11 +227,14 @@ export interface Import extends Tagged, Node {
   // "builtin" for a bare identifier (e.g. (import prelude)), resolved
   // against the standard library; "file" for a quoted string (e.g.
   // (import "my-file.scm")), resolved against the user's file system. A
-  // bare identifier can never contain "." (see syntax.grammar's Identifier
-  // token), so file names -- which routinely do -- must be quoted; this
-  // also means the two import kinds no longer need to be disambiguated by
-  // probing existence at runtime.
+  // module name is a simple identifier or a quoted string, so the two import
+  // kinds need not be disambiguated by probing existence at runtime.
   kind: 'builtin' | 'file'
+  // An optional qualified name (alias): (import image img) binds the module
+  // under `img`, and its exports are reachable only as `img.<name>` (never
+  // injected unqualified into the top level). Absent for the one-argument
+  // form (import image), which injects the module's names into global scope.
+  alias?: string
 }
 export interface Define extends Tagged, Node {
   tag: 'define'
@@ -387,7 +417,8 @@ export const mkImport = (
   module: string,
   kind: 'builtin' | 'file',
   range: L.Range = L.Range.none,
-): Import => ({ tag: 'import', module, kind, range })
+  alias?: string,
+): Import => ({ tag: 'import', module, kind, range, ...(alias !== undefined ? { alias } : {}) })
 export const mkDefine = (
   name: Identifier,
   value: Exp,
@@ -583,6 +614,7 @@ export function stmtToLayout(s: Stmt): Layout {
       return parens([
         kw('import'),
         tok(s.kind === 'file' ? JSON.stringify(s.module) : s.module),
+        ...(s.alias !== undefined ? [tok(s.alias)] : []),
       ])
     case 'define':
       return parens([kw('define'), tok(s.name.name), expToLayout(s.value)])
@@ -725,7 +757,9 @@ export function expEquals(e1: Exp, e2: Exp): boolean {
 
 export function stmtEquals(s1: Stmt, s2: Stmt): boolean {
   if (s1.tag === 'import' && s2.tag === 'import') {
-    return s1.module === s2.module && s1.kind === s2.kind
+    return (
+      s1.module === s2.module && s1.kind === s2.kind && s1.alias === s2.alias
+    )
   } else if (s1.tag === 'define' && s2.tag === 'define') {
     return s1.name.name === s2.name.name && expEquals(s1.value, s2.value)
   } else if (s1.tag === 'display' && s2.tag === 'display') {

--- a/src/scheme/codegen.ts
+++ b/src/scheme/codegen.ts
@@ -84,7 +84,7 @@ function lowerExpr(e: A.Exp): L.Blk {
 function lowerStmt(s: A.Stmt, displayStmtExpr = true): L.Stmt {
   switch (s.tag) {
     case 'import':
-      return L.mkImport(s.module, s.kind, s.range)
+      return L.mkImport(s.module, s.kind, s.range, s.alias)
     case 'define':
       // N.B., docComments is documentation metadata, not executable code --
       // it deliberately doesn't carry forward into the lowered bytecode.

--- a/src/scheme/lezer-bridge.ts
+++ b/src/scheme/lezer-bridge.ts
@@ -626,7 +626,9 @@ function stmtFromNode(ctx: Ctx, node: SyntaxNode): A.Stmt {
     case 'Import': {
       const target = cs[1]
       // The optional third child is the qualified name (alias): a simple
-      // identifier, so identifierName rejects a qualified or reserved alias.
+      // identifier, so identifierName rejects a *qualified* alias. A reserved
+      // word or non-identifier in that slot isn't an Identifier node at all, so
+      // it's already caught above by errorOr as a malformed import.
       const alias =
         cs.length > 2
           ? identifierName(ctx, cs[2], 'Expected a module alias')

--- a/src/scheme/lezer-bridge.ts
+++ b/src/scheme/lezer-bridge.ts
@@ -274,14 +274,39 @@ function isPercentId(name: string): boolean {
   return name === '%' || name === '%&' || /^%[1-9][0-9]*$/.test(name)
 }
 
+// Validates a qualified reference `mod.member` (only reached when allowQualified
+// is set -- see identifierName). Each half must be a legal simple name: neither
+// a reserved word nor a `%` identifier (those name a `#(...)` parameter, which
+// can't be qualified). Returns the name unchanged, or '<error>' after reporting.
+function qualifiedName(ctx: Ctx, node: SyntaxNode, name: string): string {
+  const { qualifier, member } = A.splitQualifiedName(name)
+  for (const half of [qualifier, member]) {
+    if (reservedWords.includes(half) || half.startsWith('%')) {
+      ctx.diagnostics.push(
+        mkDiagnostic(
+          'Parse',
+          'error',
+          `The qualified name "${name}" is invalid: "${half}" is not a valid name`,
+          ctx.range(node),
+        ),
+      )
+      return '<error>'
+    }
+  }
+  return name
+}
+
 // `allowPercent` is set only for a variable *reference* (see the Identifier
 // case in expFromNode); a `%` identifier is legal there (inside a `#(...)`) but
-// never as a binder, so every binder call leaves it false.
+// never as a binder, so every binder call leaves it false. `allowQualified` is
+// likewise set only for a reference: a qualified name (`mod.member`) resolves a
+// binding through an imported module and is meaningless in a binder position.
 function identifierName(
   ctx: Ctx,
   node: SyntaxNode,
   errorMsg = 'Expected an identifier',
   allowPercent = false,
+  allowQualified = false,
 ): string {
   const name = ctx.text(node)
   if (reservedWords.includes(name)) {
@@ -298,6 +323,20 @@ function identifierName(
   if (node.type.name !== 'Identifier') {
     ctx.diagnostics.push(mkDiagnostic('Parse', 'error', errorMsg, ctx.range(node)))
     return '<error>'
+  }
+  if (A.isQualifiedName(name)) {
+    if (!allowQualified) {
+      ctx.diagnostics.push(
+        mkDiagnostic(
+          'Parse',
+          'error',
+          `Qualified names (like "${name}") may only be used as variable references, not as a binding name`,
+          ctx.range(node),
+        ),
+      )
+      return '<error>'
+    }
+    return qualifiedName(ctx, node, name)
   }
   if (name.startsWith('%')) {
     if (!isPercentId(name)) {
@@ -349,9 +388,10 @@ function identifier(
   node: SyntaxNode,
   errorMsg = 'Expected an identifier',
   allowPercent = false,
+  allowQualified = false,
 ): A.Identifier {
   return A.mkId(
-    identifierName(ctx, node, errorMsg, allowPercent),
+    identifierName(ctx, node, errorMsg, allowPercent, allowQualified),
     ctx.range(node),
   )
 }
@@ -447,8 +487,8 @@ function expFromNode(ctx: Ctx, node: SyntaxNode): A.Exp {
         return A.mkLit(v, range)
       }
       // A variable reference: the only position where a `%` identifier (a
-      // #(...) parameter) is permitted.
-      return identifier(ctx, node, 'Expected an identifier', true)
+      // #(...) parameter) or a qualified name (`mod.member`) is permitted.
+      return identifier(ctx, node, 'Expected an identifier', true, true)
     }
 
     case 'Quote': {
@@ -585,12 +625,34 @@ function stmtFromNode(ctx: Ctx, node: SyntaxNode): A.Stmt {
   switch (node.type.name) {
     case 'Import': {
       const target = cs[1]
+      // The optional third child is the qualified name (alias): a simple
+      // identifier, so identifierName rejects a qualified or reserved alias.
+      const alias =
+        cs.length > 2
+          ? identifierName(ctx, cs[2], 'Expected a module alias')
+          : undefined
       if (target.type.name === 'String') {
         const filename = leafValue(ctx, target) as string
-        return A.mkImport(filename, 'file', range)
+        return A.mkImport(filename, 'file', range, alias)
       }
-      const name = identifierName(ctx, target)
-      return A.mkImport(name, 'builtin', range)
+      const name = ctx.text(target)
+      if (target.type.name === 'Identifier' && A.isQualifiedName(name)) {
+        // A dotted, unquoted module name -- a builtin library name is always a
+        // simple identifier, so this is almost certainly a file name missing
+        // its quotes. Point the user at the fix rather than the generic
+        // qualified-name-in-a-binder message.
+        ctx.diagnostics.push(
+          mkDiagnostic(
+            'Parse',
+            'error',
+            `Malformed import statement: a file name like "${name}" must be quoted, e.g. (import "${name}")`,
+            ctx.range(target),
+          ),
+        )
+        return A.mkStmtExp(A.mkLit(undefined, range), range)
+      }
+      const modName = identifierName(ctx, target)
+      return A.mkImport(modName, 'builtin', range, alias)
     }
 
     case 'Define': {

--- a/src/scheme/scope-tree.ts
+++ b/src/scheme/scope-tree.ts
@@ -185,7 +185,12 @@ export async function makeScopeTreeFromProgram(
         break
       case 'import':
         // TODO: do we need to scope imports? Are later imports visible in earlier code?
-        SymbolDB.get(stmt.module)?.forEach((id) => identifiers.push(id))
+        // A qualified import (with an alias) binds only `alias.member` names,
+        // which live outside the flat scope, so its exports are not surfaced
+        // here. An unqualified import injects the module's names into scope.
+        if (stmt.alias === undefined) {
+          SymbolDB.get(stmt.module)?.forEach((id) => identifiers.push(id))
+        }
         break
       case 'display':
         children.push(...scopesInExp(stmt.value))

--- a/src/scheme/scope.ts
+++ b/src/scheme/scope.ts
@@ -77,17 +77,54 @@ function scopeCheckPat(
 }
 
 /**
+ * A qualified-import table: each imported module's alias (the qualified name it
+ * was given, e.g. `img` from `(import image img)`) mapped to the source module
+ * it names and the set of binding names it exports. Aliases live in their own
+ * namespace, distinct from value bindings -- `img` names the module for
+ * `img.member` references and never collides with a `(define img ...)`.
+ */
+type QualifiedModules = Map<string, { module: string; exports: Set<string> }>
+
+/**
  * Scope-checks an expression, reporting references to names bound in neither
- * `locals` (lexical scope) nor `globals` (top level), plus duplicate binders.
+ * `locals` (lexical scope) nor `globals` (top level), plus duplicate binders. A
+ * qualified reference (`mod.member`) is resolved against `qualified` instead.
  */
 function scopeCheckExp(
   diagnostics: ScamperDiagnostic[],
   globals: string[],
+  qualified: QualifiedModules,
   locals: string[],
   e: A.Exp,
 ) {
   switch (e.tag) {
     case 'id': {
+      if (A.isQualifiedName(e.name)) {
+        // A qualified reference resolves only through its module's alias -- never
+        // against locals/globals (a binder can never be qualified).
+        const { qualifier, member } = A.splitQualifiedName(e.name)
+        const mod = qualified.get(qualifier)
+        if (mod === undefined) {
+          diagnostics.push(
+            mkDiagnostic(
+              'Scope',
+              'warning',
+              `No imported module is qualified as '${qualifier}'`,
+              e.range,
+            ),
+          )
+        } else if (!mod.exports.has(member)) {
+          diagnostics.push(
+            mkDiagnostic(
+              'Scope',
+              'warning',
+              `Module '${qualifier}' (${mod.module}) has no exported binding '${member}'`,
+              e.range,
+            ),
+          )
+        }
+        return
+      }
       if (!locals.includes(e.name) && !globals.includes(e.name)) {
         diagnostics.push(
           mkDiagnostic(
@@ -105,9 +142,9 @@ function scopeCheckExp(
       return
 
     case 'app': {
-      scopeCheckExp(diagnostics, globals, locals, e.head)
+      scopeCheckExp(diagnostics, globals, qualified, locals, e.head)
       e.args.forEach((e) => {
-        scopeCheckExp(diagnostics, globals, locals, e)
+        scopeCheckExp(diagnostics, globals, qualified, locals, e)
       })
       return
     }
@@ -118,7 +155,7 @@ function scopeCheckExp(
         e.restParam ? [...e.params, e.restParam] : e.params
       ).map((p) => p.name)
       checkDuplicateVars(diagnostics, allParams, e.range)
-      scopeCheckExp(diagnostics, globals, [...locals, ...allParams], e.body)
+      scopeCheckExp(diagnostics, globals, qualified, [...locals, ...allParams], e.body)
       return
     }
     case 'let': {
@@ -142,23 +179,23 @@ function scopeCheckExp(
       })
       const scope = [...locals, ...bindingVars]
       e.bindings.forEach((b) => {
-        scopeCheckExp(diagnostics, globals, scope, b.value)
+        scopeCheckExp(diagnostics, globals, qualified, scope, b.value)
       })
-      scopeCheckExp(diagnostics, globals, scope, e.body)
+      scopeCheckExp(diagnostics, globals, qualified, scope, e.body)
       return
     }
     case 'if': {
-      scopeCheckExp(diagnostics, globals, locals, e.guard)
-      scopeCheckExp(diagnostics, globals, locals, e.ifB)
-      scopeCheckExp(diagnostics, globals, locals, e.elseB)
+      scopeCheckExp(diagnostics, globals, qualified, locals, e.guard)
+      scopeCheckExp(diagnostics, globals, qualified, locals, e.ifB)
+      scopeCheckExp(diagnostics, globals, qualified, locals, e.elseB)
       return
     }
     case 'match': {
-      scopeCheckExp(diagnostics, globals, locals, e.scrutinee)
+      scopeCheckExp(diagnostics, globals, qualified, locals, e.scrutinee)
       e.branches.forEach((b) => {
         const bindingVars = new Set<string>()
         scopeCheckPat(diagnostics, bindingVars, b.pat)
-        scopeCheckExp(diagnostics, globals, [...locals, ...bindingVars], b.body)
+        scopeCheckExp(diagnostics, globals, qualified, [...locals, ...bindingVars], b.body)
       })
       return
     }
@@ -400,6 +437,7 @@ async function resolveImport(
 async function collectTopLevelBindings(
   diagnostics: ScamperDiagnostic[],
   globals: string[],
+  qualified: QualifiedModules,
   sources: Map<string, string | null>,
   s: A.Stmt,
 ): Promise<void> {
@@ -407,6 +445,31 @@ async function collectTopLevelBindings(
     case 'import': {
       const ids = await resolveImport(diagnostics, s)
       if (ids === undefined) {
+        return
+      }
+      if (s.alias !== undefined) {
+        // Qualified import: the module's names are reachable only as
+        // `alias.member`, never injected unqualified into `globals`. Register
+        // the alias -> exports mapping (in its own namespace, so it never
+        // collides with a define/value name). Re-importing the same module
+        // under the same alias is idempotent; a different module under an
+        // in-use alias is a collision.
+        const prev = qualified.get(s.alias)
+        if (prev !== undefined && prev.module !== s.module) {
+          diagnostics.push(
+            mkDiagnostic(
+              'Scope',
+              'warning',
+              `Qualified name '${s.alias}' is already bound to module '${prev.module}'`,
+              s.range,
+            ),
+          )
+        } else if (prev === undefined) {
+          qualified.set(s.alias, {
+            module: s.module,
+            exports: new Set(ids.map((id) => id.name)),
+          })
+        }
         return
       }
       for (const { name } of ids) {
@@ -471,6 +534,7 @@ async function collectTopLevelBindings(
 function scopeCheckStmtBodies(
   diagnostics: ScamperDiagnostic[],
   globals: string[],
+  qualified: QualifiedModules,
   s: A.Stmt,
 ): void {
   switch (s.tag) {
@@ -478,7 +542,7 @@ function scopeCheckStmtBodies(
       return
 
     case 'define': {
-      scopeCheckExp(diagnostics, globals, [], s.value)
+      scopeCheckExp(diagnostics, globals, qualified, [], s.value)
       if (s.docComments) {
         // A malformed docstring is collected as a "Docstring" warning, the
         // same treatment as a semantic mismatch -- not a real scope error.
@@ -493,11 +557,11 @@ function scopeCheckStmtBodies(
     }
 
     case 'display':
-      scopeCheckExp(diagnostics, globals, [], s.value)
+      scopeCheckExp(diagnostics, globals, qualified, [], s.value)
       return
 
     case 'stmtexp':
-      scopeCheckExp(diagnostics, globals, [], s.expr)
+      scopeCheckExp(diagnostics, globals, qualified, [], s.expr)
       return
 
     default:
@@ -541,13 +605,15 @@ export async function scopeCheckProgram(
     globals.push(id.name)
   }
   // Two passes so that top-level definitions are mutually recursive: collect
-  // every top-level binding first (also resolving imports and flagging name
-  // collisions), then check each statement's bodies against the full set.
+  // every top-level binding first (also resolving imports, registering qualified
+  // module aliases, and flagging name collisions), then check each statement's
+  // bodies against the full set.
   const sources = new Map<string, string | null>()
+  const qualified: QualifiedModules = new Map()
   for (const s of prog) {
-    await collectTopLevelBindings(diagnostics, globals, sources, s)
+    await collectTopLevelBindings(diagnostics, globals, qualified, sources, s)
   }
   for (const s of prog) {
-    scopeCheckStmtBodies(diagnostics, globals, s)
+    scopeCheckStmtBodies(diagnostics, globals, qualified, s)
   }
 }

--- a/src/scheme/symbol-db.ts
+++ b/src/scheme/symbol-db.ts
@@ -61,13 +61,21 @@ async function parseFile(filename: string): Promise<A.Prog> {
 
 /** @returns the identifiers a module exports: its top-level definitions */
 function moduleIdentifiers(prog: A.Prog): A.Identifier[] {
-  // TODO: a struct also exports its `${name}?` predicate and `${name}-${field}`
-  // accessors (only synthesized during expansion); re-exported imports aren't
-  // surfaced either.
+  // TODO: re-exported imports aren't surfaced.
   const ids: A.Identifier[] = []
   for (const stmt of prog) {
-    if (stmt.tag === 'define' || stmt.tag === 'struct') {
+    if (stmt.tag === 'define') {
       ids.push(stmt.name)
+    } else if (stmt.tag === 'struct') {
+      // A struct also exports the `${name}?` predicate and `${name}-${field}`
+      // accessors that expansion synthesizes (see expansion.ts) and that the
+      // module actually binds at runtime -- so a qualified import can reach
+      // them as `alias.point?` / `alias.point-x`.
+      ids.push(stmt.name)
+      ids.push(A.mkId(`${stmt.name.name}?`, stmt.name.range))
+      for (const field of stmt.fields) {
+        ids.push(A.mkId(`${stmt.name.name}-${field.name}`, stmt.name.range))
+      }
     }
   }
   return ids

--- a/src/scheme/syntax.grammar
+++ b/src/scheme/syntax.grammar
@@ -64,7 +64,10 @@ expression {
 }
 
 statement {
-  Import { paren<kw<"import"> (Identifier | String)> } |
+  // The optional trailing Identifier is the module's qualified name (alias) in
+  // the importing file, e.g. (import image img) -- see lezer-bridge.ts. It must
+  // be a simple (unqualified) name; that is enforced there, not in the grammar.
+  Import { paren<kw<"import"> (Identifier | String) Identifier?> } |
   Define { paren<kw<"define"> Identifier expression> } |
   Display { paren<kw<"display"> expression> } |
   Struct { paren<kw<"struct"> Identifier simplearglist> } |
@@ -98,7 +101,16 @@ kw<term> { @specialize[@name={term}]<Identifier, term> }
   // tokenize as a single identifier even though "&" is otherwise a delimiter.
   // It greedily consumes any trailing atom characters so that e.g. "%&x" is one
   // (invalid) identifier rather than "%&" followed by "x".
-  Identifier { "%&" ![ \t\n\r()\[\]{}'";.&]* | ![ \t\n\r()\[\]{}'";.&]+ }
+  //
+  // An identifier may also be a one-level *qualified* name -- two base names
+  // joined by a single "." (e.g. img.outlined-square) -- used to reference a
+  // binding through an imported module's alias. Exactly one "." is allowed, so
+  // there is no nested qualification (a.b.c does not tokenize as one name), and
+  // a bare/trailing "." never joins the token. Whether a qualified name is legal
+  // in a given position (a reference, never a binder) is decided in
+  // lezer-bridge.ts, not here.
+  baseIdentifier { "%&" ![ \t\n\r()\[\]{}'";.&]* | ![ \t\n\r()\[\]{}'";.&]+ }
+  Identifier { baseIdentifier ("." baseIdentifier)? }
 
   // The "&" separating a lambda's fixed parameters from its rest parameter,
   // e.g. (lambda (x y & z) ...), or introducing a rest-only list, e.g.

--- a/test/apps/web/lsp-features.test.ts
+++ b/test/apps/web/lsp-features.test.ts
@@ -42,6 +42,51 @@ describe('completionsFor', () => {
   })
 })
 
+describe('completionsFor: qualified imports', () => {
+  const prelude = '(import image img)\n'
+  const labelsOf = async (src: string, offset: number) =>
+    (await completionsFor(src, offset)).map((i) => i.label)
+
+  test('typing `alias.` offers the module members as alias.member', async () => {
+    const src = `${prelude}img.`
+    const labels = await labelsOf(src, src.length)
+    expect(labels).toContain('img.rgb')
+    expect(labels).toContain('img.rgb-red')
+  })
+
+  test('member completions are qualified, never bare', async () => {
+    const src = `${prelude}img.`
+    const labels = await labelsOf(src, src.length)
+    expect(labels).not.toContain('rgb')
+  })
+
+  test('member completions carry a textEdit and filterText for the dotted token', async () => {
+    const src = `${prelude}img.rg`
+    const item = (await completionsFor(src, src.length)).find(
+      (i) => i.label === 'img.rgb',
+    )
+    expect(item?.filterText).toBe('img.rgb')
+    expect(item?.textEdit).toBeDefined()
+  })
+
+  test('a qualified import does not inject member names into the flat scope', async () => {
+    // At a non-qualified position, `rgb` is only reachable as `img.rgb`.
+    const labels = await labelsOf(prelude, prelude.length)
+    expect(labels).not.toContain('rgb')
+    expect(labels).not.toContain('rgb-red')
+  })
+
+  test('the alias itself is surfaced as a completion', async () => {
+    expect(await labelsOf(prelude, prelude.length)).toContain('img')
+  })
+
+  test('an unqualified import does not create a qualified alias', async () => {
+    // `image.` is not a known alias, so no members are offered under it.
+    const src = '(import image)\nimage.'
+    expect(await labelsOf(src, src.length)).not.toContain('image.rgb')
+  })
+})
+
 describe('signatureHelpAt', () => {
   test('describes a one-argument call with the active parameter', () => {
     const sig = signatureHelpAt('(car )', 5)

--- a/test/apps/web/lsp-hover.test.ts
+++ b/test/apps/web/lsp-hover.test.ts
@@ -30,6 +30,22 @@ describe('hoverAt', () => {
     const offset = src.lastIndexOf('double') // the call site
     expect(hoverAt(src, offset)?.contents.value).toContain('Doubles')
   })
+
+  test('documents a qualified reference through its module', () => {
+    const src = '(import image img)\n(img.rgb 1 2 3)'
+    const offset = src.indexOf('img.rgb') + 5 // on the `rgb` half
+    const result = hoverAt(src, offset)
+    expect(result).not.toBeNull()
+    expect(result?.contents.value).toContain('rgb')
+    expect(result?.contents.value).toContain('image') // source-module footer
+    // The hover span covers the whole dotted identifier.
+    expect(src.slice(result?.from, result?.to)).toBe('img.rgb')
+  })
+
+  test('a qualified reference through an unknown alias has no hover', () => {
+    const src = '(nope.rgb 1 2 3)'
+    expect(hoverAt(src, src.indexOf('nope.rgb') + 1)).toBeNull()
+  })
 })
 
 describe('ScamperLanguageServer', () => {

--- a/test/lpm/lang.test.ts
+++ b/test/lpm/lang.test.ts
@@ -188,6 +188,49 @@ describe('Env.get resolution order', () => {
   })
 })
 
+describe('Env qualified imports (extendWithQualifiedImport)', () => {
+  test('a qualified name resolves to the aliased module member', () => {
+    const env = Env.empty.extendWithQualifiedImport(
+      'img',
+      mkModule({ 'rgb-red': 'red-fn' }),
+    )
+    expect(env.get('img.rgb-red')).toBe('red-fn')
+  })
+
+  test("a qualified import's members are NOT reachable unqualified", () => {
+    const env = Env.empty.extendWithQualifiedImport('img', mkModule({ x: 1 }))
+    expect(env.has('x')).toBe(false)
+    expect(() => env.get('x')).toThrow(ScamperError)
+  })
+
+  test('a qualified name against an unknown alias is unbound', () => {
+    const env = Env.empty.extendWithQualifiedImport('img', mkModule({ x: 1 }))
+    expect(env.has('other.x')).toBe(false)
+    expect(() => env.get('other.x')).toThrow(ScamperError)
+  })
+
+  test('a qualified name for a member the module lacks is unbound', () => {
+    const env = Env.empty.extendWithQualifiedImport('img', mkModule({ x: 1 }))
+    expect(env.has('img.nope')).toBe(false)
+  })
+
+  test('an unqualified import is not reachable through a qualified name', () => {
+    // Alias-only qualified handles: (import image) injects flat but does not
+    // create an `image.` qualifier.
+    const env = Env.empty.extendWithImport('image', mkModule({ x: 1 }))
+    expect(env.has('image.x')).toBe(false)
+    expect(env.get('x')).toBe(1)
+  })
+
+  test('an alias and a same-named value binding coexist (separate namespaces)', () => {
+    const env = Env.empty
+      .extendWithQualifiedImport('img', mkModule({ x: 'from-module' }))
+      .extendWithTopLevel(['img', 'a-value'])
+    expect(env.get('img')).toBe('a-value')
+    expect(env.get('img.x')).toBe('from-module')
+  })
+})
+
 describe('Env.has', () => {
   test('true for a local, top-level, or imported binding; false otherwise', () => {
     const env = Env.empty

--- a/test/prettier/printer.test.ts
+++ b/test/prettier/printer.test.ts
@@ -101,6 +101,11 @@ describe('roundtrip', () => {
 
   test('import statement', () => roundtrip('(import image)'))
 
+  test('qualified import statement', () => roundtrip('(import image img)'))
+
+  test('qualified file import statement', () =>
+    roundtrip('(import "utils.scm" u)'))
+
   test('struct definition', () => roundtrip('(struct point (x y))'))
 
   test('multi-statement program', () =>

--- a/test/regressions/import-file-vs-builtin.test.ts
+++ b/test/regressions/import-file-vs-builtin.test.ts
@@ -4,13 +4,12 @@ import { tokenizeAndParse } from '../../src/scheme'
 // A bare-identifier import, e.g. `(import lists)`, denotes a built-in
 // library. A quoted-string import, e.g. `(import "my-file.scm")`, denotes a
 // user file. These two forms are distinguished at parse time -- not, as
-// before, by probing for the name's existence at runtime -- because a file
-// name routinely contains a "." (its extension), and "." can never appear in
-// a bare identifier (see syntax.grammar's Identifier token, which carves "."
-// out to make room for the lambda rest-parameter dot). Before this was
-// fixed, `(import example-defns.scm)` failed to parse at all: "." isn't part
-// of Identifier, so the module name split into three tokens and Import's
-// grammar production (which only ever accepted one Identifier) rejected it.
+// before, by probing for the name's existence at runtime -- because a built-in
+// library name is always a simple identifier, whereas a file name routinely
+// contains a "." (its extension). A dotted, unquoted name now tokenizes as a
+// *qualified* identifier (see syntax.grammar), which is illegal as a module
+// name, so `(import example-defns.scm)` is still a parse error -- but with a
+// message that points at the fix (quote it).
 
 describe('import: built-in library vs. file', () => {
   test('a bare identifier import is parsed as a built-in library', () => {
@@ -37,9 +36,9 @@ describe('import: built-in library vs. file', () => {
     expect(stmt.kind).toBe('file')
   })
 
-  // A file import must be quoted -- a bare identifier can never contain ".",
-  // so this remains a parse error, just with a message that now points at
-  // the fix (quote it) instead of the old generic "malformed" message.
+  // A file import must be quoted -- an unquoted dotted name is a qualified
+  // identifier, illegal as a module name -- so this remains a parse error,
+  // with a message that points at the fix (quote it).
   test('an unquoted, dotted import is still a parse error', () => {
     const { program: prog, diagnostics } = tokenizeAndParse(
       '(import example-defns.scm)',
@@ -47,5 +46,6 @@ describe('import: built-in library vs. file', () => {
     expect(prog).toBeUndefined()
     expect(diagnostics.length).toBe(1)
     expect(diagnostics[0].message).toMatch(/malformed import statement/i)
+    expect(diagnostics[0].message).toMatch(/must be quoted/i)
   })
 })

--- a/test/scheme/parsing/qualified-names.test.ts
+++ b/test/scheme/parsing/qualified-names.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'vitest'
+import { parse } from './test-utils'
+import * as A from '../../../src/scheme/ast'
+
+// Qualified names (`mod.member`) and the qualified import form `(import m alias)`.
+// The grammar tokenizes a one-level dotted name as a single Identifier; whether
+// it's legal in a given position (a reference, never a binder) is decided in
+// lezer-bridge.ts. See src/scheme/syntax.grammar and lezer-bridge.ts.
+
+// The single expression of a one-statement program.
+function soleExp(src: string): A.Exp {
+  const { prog, errors } = parse(src)
+  expect(errors, `unexpected parse errors for ${JSON.stringify(src)}`).toEqual([])
+  expect(prog.length).toBe(1)
+  expect(prog[0].tag).toBe('stmtexp')
+  return (prog[0] as A.StmtExp).expr
+}
+
+describe('qualified identifiers', () => {
+  test('a bare qualified reference is one identifier carrying the dotted name', () => {
+    const e = soleExp('img.outlined-square')
+    expect(e.tag).toBe('id')
+    expect((e as A.Identifier).name).toBe('img.outlined-square')
+  })
+
+  test('a qualified name works as the head of an application', () => {
+    const e = soleExp('(img.square 5)')
+    expect(e.tag).toBe('app')
+    const head = (e as A.App).head
+    expect(head.tag).toBe('id')
+    expect((head as A.Identifier).name).toBe('img.square')
+  })
+
+  test('a qualified name works as an argument', () => {
+    const e = soleExp('(+ img.a m.b)')
+    const args = (e as A.App).args.map((a) => (a as A.Identifier).name)
+    expect(args).toEqual(['img.a', 'm.b'])
+  })
+
+  test('splitQualifiedName round-trips the two halves', () => {
+    expect(A.isQualifiedName('img.square')).toBe(true)
+    expect(A.isQualifiedName('square')).toBe(false)
+    expect(A.splitQualifiedName('img.square')).toEqual({
+      qualifier: 'img',
+      member: 'square',
+    })
+  })
+})
+
+describe('qualified identifiers are rejected outside reference position', () => {
+  // A dotted name in any binder/pattern slot is a parse error.
+  test.each([
+    ['a define name', '(define a.b 5)'],
+    ['a lambda parameter', '(lambda (a.b) a.b)'],
+    ['a let binder', '(let ([a.b 1]) a.b)'],
+    ['a struct name', '(struct a.b (x))'],
+    ['a struct field', '(struct s (a.b))'],
+  ])('%s', (_name, src) => {
+    const { errors } = parse(src)
+    expect(errors.length).toBeGreaterThan(0)
+  })
+})
+
+describe('malformed qualified names', () => {
+  test('two levels of qualification (a.b.c) does not tokenize as one name', () => {
+    const { errors } = parse('a.b.c')
+    expect(errors.length).toBeGreaterThan(0)
+  })
+
+  test('a trailing dot is a parse error', () => {
+    const { errors } = parse('foo.')
+    expect(errors.length).toBeGreaterThan(0)
+  })
+
+  test('a reserved word as a half is rejected', () => {
+    const { errors } = parse('if.x')
+    expect(errors.length).toBeGreaterThan(0)
+  })
+})
+
+describe('qualified imports', () => {
+  test('(import m alias) records the alias on a builtin import', () => {
+    const { prog, errors } = parse('(import image img)')
+    expect(errors).toEqual([])
+    const s = prog[0] as A.Import
+    expect(s.tag).toBe('import')
+    expect(s.module).toBe('image')
+    expect(s.kind).toBe('builtin')
+    expect(s.alias).toBe('img')
+  })
+
+  test('(import "f.scm" alias) records the alias on a file import', () => {
+    const { prog, errors } = parse('(import "utils.scm" u)')
+    expect(errors).toEqual([])
+    const s = prog[0] as A.Import
+    expect(s.kind).toBe('file')
+    expect(s.module).toBe('utils.scm')
+    expect(s.alias).toBe('u')
+  })
+
+  test('the one-argument import form leaves the alias unset', () => {
+    const { prog } = parse('(import image)')
+    expect((prog[0] as A.Import).alias).toBeUndefined()
+  })
+
+  test('a qualified (dotted) alias is rejected', () => {
+    const { errors } = parse('(import image a.b)')
+    expect(errors.length).toBeGreaterThan(0)
+  })
+
+  test('a reserved word as an alias is rejected', () => {
+    const { errors } = parse('(import image if)')
+    expect(errors.length).toBeGreaterThan(0)
+  })
+})

--- a/test/scheme/qualified-imports.test.ts
+++ b/test/scheme/qualified-imports.test.ts
@@ -92,6 +92,17 @@ describe('qualified imports: scope checking', () => {
     ).toEqual(["Qualified name 'm' is already bound to module 'a.scm'"])
   })
 
+  test('a qualified file import surfaces struct-derived export names', async () => {
+    // A struct's synthesized `${name}?` / `${name}-${field}` bindings exist at
+    // runtime, so a qualified reference to them must scope-check cleanly.
+    mockFS({ 'shapes.scm': '(struct point (x y))' })
+    expect(
+      await scopeErrors(
+        '(import "shapes.scm" s)\n(s.point 1 2)\ns.point?\ns.point-x\ns.point-y',
+      ),
+    ).toEqual([])
+  })
+
   test('a qualified file import exposes its exports only as alias.member', async () => {
     mockFS({ 'utils.scm': '(define helper 1)\n(define other 2)' })
     expect(await scopeErrors('(import "utils.scm" u)\nu.helper\nu.other')).toEqual(
@@ -126,6 +137,18 @@ describe('qualified imports: runtime', () => {
     expect(out.length).toBe(1)
     expect(out[0]).toContain('rgb-red')
     expect(out[0]).toContain('not found')
+  })
+
+  test('a user define does not shadow a qualified module internal name', async () => {
+    // `rgb-component?` is an internal predicate of the image module. Defining a
+    // same-named value (allowed -- aliases are a separate namespace) must not
+    // capture the module's own internal reference to it: img.rgb's contract
+    // check still resolves the module's predicate, not the user's.
+    expect(
+      await runProgram(
+        '(define rgb-component? (lambda (x) #f))\n(import image img)\n(img.rgb-red (img.rgb 10 20 30))',
+      ),
+    ).toEqual(['10'])
   })
 
   test('the one-argument import form still injects names at runtime', async () => {

--- a/test/scheme/qualified-imports.test.ts
+++ b/test/scheme/qualified-imports.test.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect, vi, afterEach } from 'vitest'
+import * as fs from '../../src/fs'
+import { scopeCheckProgram } from '../../src/scheme/scope'
+import { expandProgram } from '../../src/scheme/expansion'
+import { parseProgramFromSource } from '../../src/scheme/lezer-bridge'
+import { ScamperDiagnostic } from '../../src/scheme/diagnostic'
+import { runProgram } from '../harness.js'
+
+// End-to-end coverage of qualified imports: `(import m alias)` makes m's exports
+// reachable only as `alias.member`, never injected unqualified. Scope checking
+// validates the alias/member pair; the runtime resolves it through Env's
+// qualified map. The symbol DB + builtin libs are initialized by test/setup.ts.
+
+function parse(src: string) {
+  const errs: ScamperDiagnostic[] = []
+  const prog = parseProgramFromSource(errs, src)
+  expect(
+    errs.map((e) => e.message),
+    'test source should itself parse cleanly',
+  ).toEqual([])
+  return prog
+}
+
+async function scopeErrors(src: string): Promise<string[]> {
+  const errors: ScamperDiagnostic[] = []
+  await scopeCheckProgram(errors, expandProgram(parse(src)))
+  return errors.map((e) => e.message)
+}
+
+function mockFS(files: Record<string, string>): void {
+  vi.spyOn(fs, 'getFS').mockReturnValue({
+    fileExists: (f: string) => Promise.resolve(f in files),
+    loadFile: (f: string) =>
+      f in files
+        ? Promise.resolve(files[f])
+        : Promise.reject(new Error(`no such file: ${f}`)),
+  } as unknown as ReturnType<typeof fs.getFS>)
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('qualified imports: scope checking', () => {
+  test('a qualified reference to an existing export is well-scoped', async () => {
+    expect(await scopeErrors('(import image img)\nimg.rgb-red')).toEqual([])
+  })
+
+  test("a qualified import does NOT inject the module's names unqualified", async () => {
+    expect(await scopeErrors('(import image img)\nrgb-red')).toEqual([
+      "Undefined variable 'rgb-red'",
+    ])
+  })
+
+  test('a reference through an unknown alias is reported', async () => {
+    expect(await scopeErrors('img.rgb-red')).toEqual([
+      "No imported module is qualified as 'img'",
+    ])
+  })
+
+  test('a reference to a name the module does not export is reported', async () => {
+    expect(await scopeErrors('(import image img)\nimg.not-a-thing')).toEqual([
+      "Module 'img' (image) has no exported binding 'not-a-thing'",
+    ])
+  })
+
+  test('the one-argument import form still injects names into global scope', async () => {
+    expect(await scopeErrors('(import image)\nrgb-red')).toEqual([])
+  })
+
+  test('an alias and a same-named define coexist (separate namespaces)', async () => {
+    // `img` names the module for `img.rgb-red`; the bare `img` is the define.
+    // Neither is a collision.
+    expect(
+      await scopeErrors('(import image img)\n(define img 5)\nimg\nimg.rgb-red'),
+    ).toEqual([])
+  })
+
+  test('re-importing the same module under the same alias is idempotent', async () => {
+    mockFS({ 'utils.scm': '(define helper 1)' })
+    expect(
+      await scopeErrors(
+        '(import "utils.scm" u)\n(import "utils.scm" u)\nu.helper',
+      ),
+    ).toEqual([])
+  })
+
+  test('binding one alias to two different modules is a collision', async () => {
+    mockFS({ 'a.scm': '(define fromA 1)', 'b.scm': '(define fromB 2)' })
+    expect(
+      await scopeErrors('(import "a.scm" m)\n(import "b.scm" m)'),
+    ).toEqual(["Qualified name 'm' is already bound to module 'a.scm'"])
+  })
+
+  test('a qualified file import exposes its exports only as alias.member', async () => {
+    mockFS({ 'utils.scm': '(define helper 1)\n(define other 2)' })
+    expect(await scopeErrors('(import "utils.scm" u)\nu.helper\nu.other')).toEqual(
+      [],
+    )
+    expect(await scopeErrors('(import "utils.scm" u)\nhelper')).toEqual([
+      "Undefined variable 'helper'",
+    ])
+    expect(await scopeErrors('(import "utils.scm" u)\nu.missing')).toEqual([
+      "Module 'u' (utils.scm) has no exported binding 'missing'",
+    ])
+  })
+
+  test('a qualified import of an unknown builtin is still reported', async () => {
+    expect(await scopeErrors('(import not-a-lib nl)')).toEqual([
+      "No such built-in library: 'not-a-lib'",
+    ])
+  })
+})
+
+describe('qualified imports: runtime', () => {
+  test('a qualified reference resolves to the aliased module member', async () => {
+    expect(
+      await runProgram('(import image img)\n(img.rgb-red (img.rgb 10 20 30))'),
+    ).toEqual(['10'])
+  })
+
+  test('an unqualified reference after a qualified import fails at runtime', async () => {
+    const out = await runProgram('(import image img)\nrgb-red', {
+      stripRanges: true,
+    })
+    expect(out.length).toBe(1)
+    expect(out[0]).toContain('rgb-red')
+    expect(out[0]).toContain('not found')
+  })
+
+  test('the one-argument import form still injects names at runtime', async () => {
+    expect(
+      await runProgram('(import image)\n(rgb-red (rgb 10 20 30))'),
+    ).toEqual(['10'])
+  })
+
+  test('an alias and a same-named define resolve independently at runtime', async () => {
+    expect(
+      await runProgram(
+        '(import image img)\n(define img 5)\nimg\n(img.rgb-red (img.rgb 10 20 30))',
+      ),
+    ).toEqual(['5', '10'])
+  })
+})

--- a/test/scheme/scope.test.ts
+++ b/test/scheme/scope.test.ts
@@ -581,6 +581,20 @@ describe('scope tree', () => {
         .map((i) => i.name)
       expect(names).toContain('local')
     })
+    test('a qualified import does not surface its names in the flat scope', async () => {
+      // Names of a module imported under an alias are reachable only as
+      // `alias.member`, so they must not appear in the flat visible set.
+      const qualified = (await treeOf('(import image img)'))
+        .getVisibleIdentifiers()
+        .map((i) => i.name)
+      expect(qualified).not.toContain('rgb')
+      expect(qualified).not.toContain('rgb-red')
+      // Sanity: the unqualified form still surfaces them.
+      const flat = (await treeOf('(import image)'))
+        .getVisibleIdentifiers()
+        .map((i) => i.name)
+      expect(flat).toContain('rgb')
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

Adds Clojure-style **qualified names** for imported modules.

- `(import image img)` imports the `image` module under the alias `img`. Its exports are reachable **only** as `img.<name>` (e.g. `img.rgb`, `img.outlined-square`) and are **not** injected into global scope.
- `(import image)` (one argument) is unchanged: it injects the module's names into scope, flat, as before. File imports may be aliased too: `(import "utils.scm" u)` → `u.helper`.
- An identifier may now be a one-level qualified name `base.base`; only one level is allowed (`a.b.c` and a trailing `foo.` are errors), and a qualified name is legal only as a variable *reference*, never as a binder.

### Design decisions (confirmed up front)
- **Alias-only qualified handles.** A one-argument import does not create an implicit `module.` qualifier; the alias form is the only way to get a qualified handle.
- **Separate namespace for aliases.** `(import image img)` alongside `(define img 5)` is not a collision: bare `img` is the value, `img.x` is the module. Re-importing the same module under the same alias is idempotent; a different module under an in-use alias is flagged.

## How it works

- **Grammar / front-end:** the `Identifier` token gains an optional `"." baseIdentifier`; `import` takes an optional alias. The reader rejects qualified names in every binder position. Scope checking resolves `alias.member` against a per-file qualified-module table instead of the flat globals.
- **Runtime:** `Env` gains a `qualified` map consulted only for dotted names. Because a qualified import deliberately doesn't flatten the module into scope, the module's own functions couldn't otherwise resolve their siblings (or the contract predicates they reference). So each qualified-imported module's closures are re-homed (`Closure.home`) to resolve their internal names against the module itself (over the standard library), never against the importer's scope — this is isolated entirely to the new qualified path, so unqualified imports and all existing behavior are untouched.
- **LSP:** hover on `alias.member` resolves through the aliased module; completion after `alias.` offers that module's exports (as `alias.member`, with a `textEdit` spanning the dotted token); the scope tree no longer surfaces a qualified import's names in the flat set. Diagnostics flow through the existing scope check, which now understands qualified references.

## Testing

- New suites: qualified-name parsing (incl. malformed/binder-rejection cases), scope + runtime integration, `Env` qualified resolution unit tests, and LSP hover/completion coverage; existing import regression test updated for the new grammar.
- `npm run validate` (test + typecheck + lint) is green.

## Review

An independent two-part code review of the branch surfaced (and this PR fixes) a home-env precedence bug where an importer's `define` could shadow a qualified module's internal names, and a gap where a qualified file import didn't expose a struct's derived `?`/accessor names. Both are covered by regression tests.

_(Co-created with Claude Code)_