### PR TITLE
Pin down contract errors' call-site ranges; drop stale test comments

### DIFF
--- a/test/libs/harness.ts
+++ b/test/libs/harness.ts
@@ -1,9 +1,8 @@
-// Library tests assert on error *messages*, not source locations. Contract
-// errors report the offending definition's range in the `.scm` library source,
-// so editing any library file would otherwise shift those ranges and break
-// unrelated tests. This wrapper runs programs with ranges stripped from error
-// output, keeping library tests decoupled from library line numbers. Range
-// *reporting* itself is covered directly by test/lpm/range.test.ts.
+// Library tests assert on error *messages*, not source locations. This wrapper
+// runs programs with ranges stripped from error output so a test's expectations
+// don't shift when its own source string is reflowed. Range *reporting* is
+// covered directly by test/lpm/range.test.ts, and the call-site attribution of
+// contract errors by test/regressions/contract-error-call-site.test.ts.
 import { runProgram as runProgramWithRanges } from '../harness.js'
 
 /** Like {@link runProgramWithRanges} but drops `[line:col]` ranges from error output. */

--- a/test/libs/prelude.test.ts
+++ b/test/libs/prelude.test.ts
@@ -1176,10 +1176,7 @@ test('not-boolean', async () => {
   // N.B., unlike standard Scheme (where any non-#f value is truthy), we are
   // stricter: `not`'s docstring declares its param `boolean?`, so a
   // non-boolean argument is a contract violation, enforced by the
-  // docstring-derived wrapper in contract.ts. The reported range points at
-  // `not`'s own definition in prelude.scm rather than the call site -- a
-  // known, unrelated limitation of contract-wrapped errors (#254; see
-  // cons-pair, range above).
+  // docstring-derived wrapper in contract.ts.
   expect(
     await runProgram(`
 (not #t)
@@ -2143,9 +2140,7 @@ test('string-to-number-negative', async () => {
 
 test('=-eps', async () => {
   // N.B., =-eps's docstring declares its param `n : number?`, so a
-  // non-number argument is a contract violation -- the reported range
-  // points at =-eps's own definition in prelude.scm rather than the call
-  // site (see cons-pair, not-boolean above).
+  // non-number argument is a contract violation.
   expect(
     await runProgram(`
 ((=-eps 0.5) 1 1.3)
@@ -2517,7 +2512,6 @@ test('vectorQ', async () => {
 })
 
 test('make-vector', async () => {
-  // N.B., contract error location points at the definition site, not the call site
   expect(
     await runProgram(`
 (make-vector 3 "a")
@@ -2534,7 +2528,6 @@ test('make-vector', async () => {
 })
 
 test('vector-length', async () => {
-  // N.B., contract error location points at the definition site, not the call site
   expect(
     await runProgram(`
 (vector-length (vector 1 2 3))
@@ -2549,9 +2542,6 @@ test('vector-length', async () => {
 })
 
 test('vector-ref', async () => {
-  // N.B., the contract (type) error points at the definition site, not the
-  // call site (#254); the #257 bounds errors, thrown from the function body,
-  // point at the call site.
   // #257: an out-of-range index (>= length or negative) now raises a clean bounds error
   expect(
     await runProgram(`
@@ -2571,7 +2561,6 @@ test('vector-ref', async () => {
 })
 
 test('vector-append', async () => {
-  // N.B., contract error location points at the definition site, not the call site
   expect(
     await runProgram(`
 (vector-append (vector 1 2) (vector 3 4 5))
@@ -2586,7 +2575,6 @@ test('vector-append', async () => {
 })
 
 test('vector-to-list', async () => {
-  // N.B., contract error location points at the definition site, not the call site
   expect(
     await runProgram(`
 (vector->list (vector 1 2 3))
@@ -2601,7 +2589,6 @@ test('vector-to-list', async () => {
 })
 
 test('list-to-vector', async () => {
-  // N.B., contract error location points at the definition site, not the call site
   expect(
     await runProgram(`
 (list->vector (list 1 2 3))

--- a/test/regressions/contract-error-call-site.test.ts
+++ b/test/regressions/contract-error-call-site.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+
+// https://github.com/slag-plt/scamper/issues/254
+// https://github.com/slag-plt/scamper/issues/239
+//
+// A docstring-derived contract check that failed at runtime reported the
+// *wrapped definition's* range -- the `(define ...)` in prelude.scm -- instead
+// of the call site the student actually wrote. `contract.ts` builds its
+// wrapper (including the `(error ...)` call) from `s.range`, since the real
+// call site isn't known until runtime, and the `error` special form's handler
+// threw with `op.range` unchanged, bypassing the call-site recovery `applyFn`
+// already performed for JS-thrown errors.
+//
+// Demoting `error` from a special form (#317) routed those generated calls
+// through `applyFn`, which recovers the range from the enclosing frame's
+// `callRange`. Nothing asserted the resulting ranges, so this pins them down:
+// the library suites all run with ranges stripped (see test/libs/harness.ts),
+// which is what let the original bug sit unnoticed.
+
+describe('a contract violation reports the call site, not the definition (#254)', () => {
+  test('the range covers the offending call', async () => {
+    expect(await runProgram('(not 1)')).toEqual([
+      'Runtime error [1:1-1:7]: (error) expected a boolean, received number',
+    ])
+  })
+
+  test('the range tracks the statement it occurs in', async () => {
+    expect(
+      await runProgram('(define f (lambda (x) x))\n(f 1)\n(not 1)'),
+    ).toEqual([
+      '1',
+      'Runtime error [3:1-3:7]: (error) expected a boolean, received number',
+    ])
+  })
+
+  test('a nested call reports the inner call, not the enclosing one', async () => {
+    expect(await runProgram('(+ 1\n   (not 1))')).toEqual([
+      'Runtime error [2:4-2:10]: (error) expected a boolean, received number',
+    ])
+  })
+
+  test("a call inside a user function reports that call, not the function's", async () => {
+    // The failing call sits at 1:23-1:39 inside g's body; g itself is invoked
+    // from 2:1. Reporting g's own call site would be the coarser answer -- the
+    // blind spot the first attempt at this fix had (see #239's history).
+    expect(
+      await runProgram('(define g (lambda (n) (string-length n)))\n(g 5)'),
+    ).toEqual([
+      'Runtime error [1:23-1:39]: (error) expected a string, received number',
+    ])
+  })
+
+  test('a call inside a lambda passed to a higher-order function', async () => {
+    expect(await runProgram('(map (lambda (x) (not x)) (list 1 2))')).toEqual([
+      'Runtime error [1:18-1:24]: (error) expected a boolean, received number',
+    ])
+  })
+
+  test('the other repros from the issue', async () => {
+    expect(await runProgram('(string-length (list 1 2 3))')).toEqual([
+      'Runtime error [1:1-1:28]: (error) expected a string, received list',
+    ])
+    expect(await runProgram('(+ 1 2 3 "bye")')).toEqual([
+      'Runtime error [1:1-1:15]: (error) expected every value of v1 to be a number, but at least one was not',
+    ])
+  })
+})
+
+describe('errors raised from a library body keep reporting the call site', () => {
+  // These never went through the contract wrapper -- they are the JS-thrown
+  // path `applyFn` already handled correctly -- so they guard against a fix
+  // that trades one misattribution for another.
+  test('a raw JsFunction argument check', async () => {
+    expect(await runProgram('(cons 1 2)')).toEqual([
+      'Runtime error [1:1-1:10]: (cons) The second argument to cons should be a list',
+    ])
+  })
+
+  test('a bounds error thrown from the function body', async () => {
+    expect(await runProgram('(vector-ref (vector 1 2 3) 5)')).toEqual([
+      'Runtime error [1:1-1:29]: (vector-ref) vector-ref: index 5 out of bounds of vector',
+    ])
+  })
+})

--- a/test/regressions/vector-bounds.test.ts
+++ b/test/regressions/vector-bounds.test.ts
@@ -11,9 +11,9 @@ import { runProgram } from '../harness.js'
 // Non-integer indices were, and remain, caught by the `integer?` docstring
 // contract.
 //
-// Ranges are stripped from error messages here: they point at vector-ref /
-// vector-set!'s definitions in prelude.scm and would shift with any edit to
-// that file.
+// Ranges are stripped from error messages here: this test is about the bounds
+// *message*, not the location. The ranges point at the call site, asserted in
+// contract-error-call-site.test.ts.
 
 const stripRange = (msgs: string[]): string[] =>
   msgs.map((m) => m.replace(/\[\d+:\d+-\d+:\d+\]/, '[..]'))

--- a/test/scheme/codegen.test.ts
+++ b/test/scheme/codegen.test.ts
@@ -186,11 +186,10 @@ describe('End-to-end cases', () => {
   })
 
   test('contract-check', async () => {
-    // N.B., the reported ranges point at string-length's/+'s own definitions
-    // in prelude.scm rather than the call site -- a known limitation of
-    // contract-wrapped errors (#254; see cons-pair, range, not-boolean in
-    // prelude.test.ts). We assert with ranges stripped so this test stays
-    // decoupled from prelude.scm's line numbers.
+    // N.B., ranges are stripped because this test is about the machine's
+    // output, not error locations. The ranges themselves point at the call
+    // site; that is asserted in
+    // test/regressions/contract-error-call-site.test.ts.
     await checkMachineOutput(`
 (string-length (list 1 2 3))
 


### PR DESCRIPTION
Follow-up to closing #254 / #239. No behavior change — tests and comments only.

## Why

Those two issues were fixed as a side effect of ba40417 (#317), which demoted `error` from a special form so `contract.ts`'s generated `(error ...)` calls flow through `applyFn` and inherit its `currFrame.callRange` recovery. But **nothing asserted the resulting ranges** — every library suite runs with ranges stripped (`test/libs/harness.ts`), which is precisely why the original bug went unnoticed for as long as it did. The fix could regress silently today.

Meanwhile a dozen comments across the test suite still claimed the broken behavior was current, several citing what is now a closed issue.

## Added

`test/regressions/contract-error-call-site.test.ts` asserts exact ranges for a contract violation:

| case | range |
| --- | --- |
| `(not 1)` | `[1:1-1:7]` |
| `(not 1)` as the third statement | `[3:1-3:7]` |
| `(+ 1\n   (not 1))` | `[2:4-2:10]` — the inner call |
| `(string-length n)` inside a user `g`, called as `(g 5)` | `[1:23-1:39]` |
| `(not x)` in a lambda passed to `map` | `[1:18-1:24]` |

plus the two remaining repros from #254 (`string-length`, `+`).

The fourth and fifth rows are the blind spot #239's "History" section describes — a raw JS function called at an arbitrary position inside an ordinary, non-wrapper named function. Two JS-thrown errors (`cons`'s argument check, `vector-ref`'s bounds error) are included as well, guarding the path that was always correct so a future fix can't trade one misattribution for another.

## Removed

The "N.B., contract error location points at the definition site, not the call site" notes in `test/libs/prelude.test.ts` (×8), `test/scheme/codegen.test.ts`, `test/regressions/vector-bounds.test.ts`, and `test/libs/harness.ts`. All are now false.

Where a comment also explained *why* ranges are stripped, I restated the rationale accurately rather than dropping it — the old reason ("editing a library file would shift these ranges") no longer applies, since every library error now reports a range in the test's own source, but stripping still makes sense for suites asserting on messages.

Left alone: the `callRange` comment in `src/lpm/frame.ts`, which accurately describes the mechanism doing the recovery.

`npm run validate` passes (typecheck, test, lint); lint warning count unchanged at 1086.

_(Co-created with Claude Code)_
