### PR TITLE
Assert TCO by frame depth, not by exhausting the frame limit

### DIFF
--- a/test/regressions/tco-frame-depth.test.ts
+++ b/test/regressions/tco-frame-depth.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'vitest'
+import * as S from '../../src/scheme/index.js'
+import { Fiber } from '../../src/lpm/fiber.js'
+import { diagnosticToError } from '../../src/scheme/diagnostic'
+import * as L from '../../src/lpm/index.js'
+
+// https://github.com/slag-plt/scamper/issues/316
+//
+// Tail-call optimization was asserted *indirectly*: run 12000 iterations and
+// rely on the fiber's 10000-frame limit to error if frames accumulated. That
+// cost ~9.2 million interpreter steps (~4s on an idle machine, 77% of vitest's
+// 5s default), so it went flaky under parallel load and needed a 30s timeout to
+// keep `validate` green -- and it only noticed a leak once 10000 frames had
+// piled up.
+//
+// The property is observable directly: a tail call replaces the current frame
+// (see the canTailCall branch in op-handlers.ts), so a tail-recursive loop runs
+// at a *constant* frame depth no matter how many iterations it makes. The
+// measured peak for the loop below is 6. Watching fiber.frames.length says
+// exactly that, catches a leak on the first iteration, and costs milliseconds.
+
+/** Runs `prog` to completion, returning its peak frame depth and last value. */
+function runTracked(prog: L.Prog): { maxFrames: number; result: L.Value } {
+  const fiber = new Fiber(prog, S.mkInitialEnv())
+  let maxFrames = 0
+  while (!fiber.isDone()) {
+    fiber.step()
+    maxFrames = Math.max(maxFrames, fiber.frames.length)
+  }
+  return { maxFrames, result: fiber.lastResult }
+}
+
+async function compileOrThrow(src: string): Promise<L.Prog> {
+  const { prog, diagnostics } = await S.compile(src.trim())
+  const errors = diagnostics.map((d) => diagnosticToError(d).toString())
+  expect(errors).toEqual([])
+  if (prog === undefined) throw new Error('compile produced no program')
+  return prog
+}
+
+/** A tail call in the else-branch of an `if`, inside a `let` body. */
+const countTo = (n: number) => `
+(define count
+  (lambda (n acc)
+    (if (= n 0)
+        acc
+        (let ([m (- n 1)])
+          (count m (+ acc 1))))))
+(count ${n.toString()} 0)
+`
+
+describe('tail calls run at a constant frame depth', () => {
+  test('frame depth does not grow with the number of iterations', async () => {
+    const shallow = runTracked(await compileOrThrow(countTo(10)))
+    const deeper = runTracked(await compileOrThrow(countTo(400)))
+
+    // The answer is still right...
+    expect(shallow.result).toBe(10)
+    expect(deeper.result).toBe(400)
+    // ...and 40x the iterations costs exactly zero extra frames. Without TCO
+    // this grows by one frame per iteration.
+    expect(deeper.maxFrames).toBe(shallow.maxFrames)
+  })
+
+  test('the peak frame depth is a small constant', async () => {
+    // Pinned so a regression that merely *slows* frame growth (rather than
+    // stopping it) still fails, instead of quietly passing under the 10000
+    // limit. The observed peak is 6; the bound leaves room for the evaluator
+    // to change shape without being meaninglessly loose.
+    const { maxFrames } = runTracked(await compileOrThrow(countTo(400)))
+    expect(maxFrames).toBeLessThanOrEqual(16)
+  })
+
+  test('a non-tail-recursive call still does grow the stack', async () => {
+    // The control: `(+ 1 (sum ...))` leaves work after the call, so it is not a
+    // tail call and frames must accumulate. This is what keeps the two tests
+    // above honest -- if frame depth were constant for *every* program, they
+    // would pass no matter what TCO did.
+    const src = `
+(define sum
+  (lambda (n)
+    (if (= n 0)
+        0
+        (+ n (sum (- n 1))))))
+(sum 100)
+`
+    const { maxFrames, result } = runTracked(await compileOrThrow(src))
+    expect(result).toBe(5050)
+    expect(maxFrames).toBeGreaterThan(100)
+  })
+})

--- a/test/scheme/codegen.test.ts
+++ b/test/scheme/codegen.test.ts
@@ -385,11 +385,18 @@ describe('End-to-end cases', () => {
 `, [10, 10])
   })
 
-  test('tail recursion through if and let does not grow the stack', async () => {
+  test('tail recursion through if and let returns the right answer', async () => {
     // The recursive call sits in tail position inside a let body inside an if
-    // else-branch, and 12000 > the 10000-frame default limit. A broken TCO
-    // (frames piling up behind the let's trailing pop-scope) would exceed the
-    // limit and error; tail calls must not accumulate frames.
+    // else-branch. This is the end-to-end check that such a loop computes the
+    // right value; that it runs at a *constant frame depth* -- the TCO property
+    // itself -- is asserted directly in test/regressions/tco-frame-depth.test.ts.
+    //
+    // N.B., this used to run 12000 iterations so that a frame leak would trip
+    // the fiber's 10000-frame limit. That proof cost ~9.2 million interpreter
+    // steps (~4s idle, 77% of vitest's 5s default) and went flaky under
+    // parallel load, so it needed a 30s timeout to be reliable (#316). The
+    // frame-depth assertion proves the same property on the first iteration,
+    // which leaves this free to be an ordinary, cheap output check.
     await checkMachineOutput(`
 (define count
   (lambda (n acc)
@@ -397,11 +404,9 @@ describe('End-to-end cases', () => {
         acc
         (let ([m (- n 1)])
           (count m (+ acc 1))))))
-(count 12000 0)
-`, [12000])
-    // 12000 interpreter iterations can exceed the 5s default under full parallel
-    // load, so give this heavy TCO check a realistic timeout.
-  }, 30000)
+(count 1000 0)
+`, [1000])
+  })
 
   test('list-length', async () => {
     await checkMachineOutput(`


### PR DESCRIPTION
Closes #316.

## Diagnosis

Reproduced by measuring rather than by waiting for a flake. The test takes **3.83s on a fully idle machine** — 77% of vitest's 5s default — so it has almost no margin before contention even enters the picture. Instrumenting it:

```
compile=0ms  run=3992ms  steps=9168041  maxFrames=6
```

Compilation is free; the entire cost is **9.2 million interpreter steps**. And the peak frame depth is **6** — the test runs 12000 iterations to prove the stack stays under 10000, when it never gets past single digits.

So the flakiness isn't really about the timeout. The proof strategy is the problem: it asserts TCO *indirectly*, by doing enough work to trip the fiber's 10000-frame limit if frames leak. That is both expensive and insensitive — a leak goes unnoticed until 10000 frames have piled up.

## Fix

A tail call replaces the current frame rather than pushing one (the `canTailCall` branch in `op-handlers.ts`), so a tail-recursive loop runs at a **constant frame depth** no matter how many iterations it makes. `fiber.frames` is already public, so a test can watch it directly — no API change.

`test/regressions/tco-frame-depth.test.ts` asserts exactly that:

- 40x the iterations (10 → 400) costs **zero** extra frames
- the peak stays a small constant (observed 6, bounded at 16)
- a **non-tail-recursive control** (`(+ n (sum ...))`) *does* still grow the stack, past 100 frames

That third one is what keeps the first two honest — without it they'd pass even if frame depth were trivially constant for every program.

This catches a leak on the *first* iteration instead of the 10000th, and runs in ~380ms.

The end-to-end case in `codegen.test.ts` then goes back to being an ordinary output check: 1000 iterations, default timeout, no special-casing. It's renamed to "returns the right answer", since it no longer claims to prove the stack property.

## Results

- `test/` now contains **no custom timeouts at all** — the 30s stopgap was the last one.
- Full suite test time: **25.3s → 21.8s**. That also eases the contention that was pushing `test/apps/cli/cli.test.ts` over its own timeout in the same runs — the issue named it as collateral. Its tests are ~840ms each idle (~6x headroom), versus the TCO test's 1.3x, so I left them alone.
- `npm run validate` passes; the full suite ran clean 3x consecutively.

## Verifying the guard actually catches the bug

Since a new test passes on `main` by construction, I checked sensitivity by breaking TCO deliberately — making `replaceFrame` skip its pop, i.e. the exact frame-leak-behind-the-`pop-scope` bug the original test was written for. All three assertions go red. Restored, all three pass.

Worth noting for anyone reading the VM: TCO can't be cleanly switched off there. Both sabotage attempts surfaced as `Attempted to pop operation off frame ... when none remain` rather than clean frame growth, because the leaked caller frame still holds trailing `pop-scope` ops. The guard goes red either way, but the failure mode is an ICE rather than the assertion message.

## Note on scope

The issue also floated investigating interpreter throughput. The measurement doesn't support a perf concern: ~9.2M steps in 4.0s is ~2.3M steps/sec, which is reasonable. The ~764 steps per iteration is the cost of three contract-wrapped prelude calls (`=`, `-`, `+`), not slow stepping. Nothing filed.

_(Co-created with Claude Code)_