### PR TITLE
Add a `file` library: whole-file reads and writes

### DIFF
--- a/src/app/cli/index.ts
+++ b/src/app/cli/index.ts
@@ -8,7 +8,7 @@ import { ConsoleOutput } from '../../lpm/output'
 import { compile, mkInitialEnv } from '../../scheme'
 import { traceReductions } from '../../scheme/trace'
 import { Fiber } from '../../lpm/fiber'
-import { ScamperError } from '../../lpm/error'
+import { ScamperError, SuspendSignal } from '../../lpm/error'
 import { setFS } from '../../fs'
 import NodeFileSystem from '../../fs/node'
 import Scamper, { initialize } from '../../scamper'
@@ -101,6 +101,17 @@ if (values.trace) {
   } catch (e) {
     if (e instanceof ScamperError) {
       traceOut.report(e)
+    } else if (e instanceof SuspendSignal) {
+      // A blocking primitive (the `file` library, with-file, images from a URL)
+      // suspended the fiber. Only the scheduler can resume it, and this path
+      // steps the fiber directly -- so report that rather than letting a raw
+      // SuspendSignal abort the process. See issue #339.
+      traceOut.report(
+        new ScamperError(
+          'Runtime',
+          'Blocking operations (reading a file, loading an image) cannot be traced; run the program without --trace',
+        ),
+      )
     } else {
       throw e
     }

--- a/src/app/docs/DocsApp.vue
+++ b/src/app/docs/DocsApp.vue
@@ -13,7 +13,7 @@ import type { FunctionDoc } from '../../scheme/docstring/docstring'
 // plumbing, not user-facing, so it's deliberately excluded here.
 const moduleOrder = [
   'prelude', 'image', 'lab', 'music', 'test',
-  'audio', 'canvas', 'html', 'reactive', 'data', 'rex',
+  'audio', 'canvas', 'html', 'reactive', 'data', 'rex', 'file',
 ]
 const libs: [string, Map<string, FunctionDoc>][] = moduleOrder.map(
   (name) => [name, docRegistry.get(name) ?? new Map<string, FunctionDoc>()],

--- a/src/app/search/ApiEntries.vue
+++ b/src/app/search/ApiEntries.vue
@@ -17,7 +17,7 @@ const props = defineProps<{
 // LPM-internal plumbing, not user-facing, so it's deliberately excluded.
 const moduleOrder = [
   'prelude', 'image', 'lab', 'music', 'test',
-  'audio', 'canvas', 'html', 'reactive', 'data', 'rex',
+  'audio', 'canvas', 'html', 'reactive', 'data', 'rex', 'file',
 ]
 
 function allDocs(): FunctionDoc[] {

--- a/src/app/search/ApiEntries.vue
+++ b/src/app/search/ApiEntries.vue
@@ -167,7 +167,9 @@ const tagListStr = ref([
     'create',
     'plot',
     'parse',
-    
+
+  'file',
+
   'typecheck',
 
   'regexes',

--- a/src/js/file/index.ts
+++ b/src/js/file/index.ts
@@ -44,6 +44,13 @@ function splitLines(contents: string): string[] {
   return lines
 }
 
+export function file_fileExistsQ(filename: string): L.Value {
+  throw new L.SuspendSignal(async () => {
+    const { getFS } = await import('../../fs')
+    return getFS().fileExists(filename)
+  })
+}
+
 export function file_fileToString(filename: string): L.Value {
   throw new L.SuspendSignal(async () => readFile(filename))
 }

--- a/src/js/file/index.ts
+++ b/src/js/file/index.ts
@@ -1,0 +1,85 @@
+import * as L from '../../lpm'
+
+// The `file` library's blocking primitives (issue #315). Each suspends the
+// current fiber, hands the scheduler an async filesystem action, and resumes
+// with its result as the call's return value (see SuspendSignal / Scheduler
+// `block-on`). A rejected action surfaces as a runtime error at the call site,
+// catchable by with-handler.
+//
+// N.B., the filesystem is imported lazily *inside* each action, never at module
+// load: this module is pulled in during test setup (library registration), and
+// eagerly importing src/fs there would grab the real OPFS out from under tests
+// that mock it. Same reasoning as src/js/prelude/files.ts.
+
+/** Loads `filename`, or rejects if it does not exist. */
+async function readFile(filename: string): Promise<string> {
+  const { getFS } = await import('../../fs')
+  const fs = getFS()
+  if (!(await fs.fileExists(filename))) {
+    throw new L.ScamperError('Runtime', `File "${filename}" does not exist`)
+  }
+  return fs.loadFile(filename)
+}
+
+/** Writes `contents` to `filename`, creating or overwriting it. */
+async function writeFile(filename: string, contents: string): Promise<void> {
+  const { getFS } = await import('../../fs')
+  await getFS().saveFile(filename, contents)
+}
+
+/**
+ * Splits file contents into lines, dropping the single empty element a trailing
+ * newline would otherwise produce -- a file ending in "\n" has no final empty
+ * line. This is what makes lines->file and file->lines round-trip.
+ *
+ * N.B., deliberately not data_stringToLines: that one keeps the trailing empty
+ * element (its callers want the raw split), and reusing it would make the
+ * `file` library depend on `data`.
+ */
+function splitLines(contents: string): string[] {
+  const lines = contents.split(/\r?\n/g)
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop()
+  }
+  return lines
+}
+
+export function file_fileToString(filename: string): L.Value {
+  throw new L.SuspendSignal(async () => readFile(filename))
+}
+
+export function file_fileToLines(filename: string): L.Value {
+  throw new L.SuspendSignal(async () =>
+    L.vectorToList(splitLines(await readFile(filename))),
+  )
+}
+
+export function file_stringToFile(contents: string, filename: string): L.Value {
+  throw new L.SuspendSignal(async () => {
+    await writeFile(filename, contents)
+    return undefined
+  })
+}
+
+export function file_linesToFile(lines: L.List, filename: string): L.Value {
+  throw new L.SuspendSignal(async () => {
+    // Checked here rather than by a docstring contract: `list?` cannot say
+    // "list *of strings*", and a non-string element would otherwise be
+    // stringified into the file by join(). Collecting into a string[] (rather
+    // than checking in place) is what lets the join below be type-safe.
+    const strs: string[] = L.listToVector(lines).map((v) => {
+      if (typeof v !== 'string') {
+        throw new L.ScamperError(
+          'Runtime',
+          `lines->file: expected a list of strings, but the list contains ${L.typeOf(v)}`,
+        )
+      }
+      return v
+    })
+    // Joined with "\n" plus a trailing newline, so the file ends in a newline
+    // and file->lines recovers exactly `lines`. An empty list writes an empty
+    // file rather than a lone newline.
+    await writeFile(filename, strs.length === 0 ? '' : `${strs.join('\n')}\n`)
+    return undefined
+  })
+}

--- a/src/js/file/index.ts
+++ b/src/js/file/index.ts
@@ -11,20 +11,35 @@ import * as L from '../../lpm'
 // eagerly importing src/fs there would grab the real OPFS out from under tests
 // that mock it. Same reasoning as src/js/prelude/files.ts.
 
-/** Loads `filename`, or rejects if it does not exist. */
+/**
+ * Loads `filename`, or rejects if it does not exist.
+ *
+ * N.B., the host's own failures (a directory rather than a file, a permission
+ * error, ...) are rewritten into a Scamper error: a raw "EISDIR: illegal
+ * operation on a directory" is not something to put in front of a student, and
+ * the wording would differ between Node and OPFS besides.
+ */
 async function readFile(filename: string): Promise<string> {
   const { getFS } = await import('../../fs')
   const fs = getFS()
   if (!(await fs.fileExists(filename))) {
     throw new L.ScamperError('Runtime', `File "${filename}" does not exist`)
   }
-  return fs.loadFile(filename)
+  try {
+    return await fs.loadFile(filename)
+  } catch {
+    throw new L.ScamperError('Runtime', `Could not read the file "${filename}"`)
+  }
 }
 
 /** Writes `contents` to `filename`, creating or overwriting it. */
 async function writeFile(filename: string, contents: string): Promise<void> {
   const { getFS } = await import('../../fs')
-  await getFS().saveFile(filename, contents)
+  try {
+    await getFS().saveFile(filename, contents)
+  } catch {
+    throw new L.ScamperError('Runtime', `Could not write to the file "${filename}"`)
+  }
 }
 
 /**
@@ -37,8 +52,9 @@ async function writeFile(filename: string, contents: string): Promise<void> {
  * `file` library depend on `data`.
  */
 function splitLines(contents: string): string[] {
+  // split always yields at least one element, so no length guard is needed.
   const lines = contents.split(/\r?\n/g)
-  if (lines.length > 0 && lines[lines.length - 1] === '') {
+  if (lines[lines.length - 1] === '') {
     lines.pop()
   }
   return lines

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -2,6 +2,8 @@ import * as L from '../lpm'
 import * as Audio from './audio/index.js'
 import * as Canvas from './canvas/index.js'
 import * as Data from './data/index.js'
+// N.B., `FileLib`, not `File`: `File` is a DOM global.
+import * as FileLib from './file/index.js'
 import * as Html from './html/index.js'
 import * as Image from './image/index.js'
 import * as Lab from './lab/index.js'
@@ -38,6 +40,7 @@ const internals = new Map<string, L.Value>([
   ...Object.entries(Audio),
   ...Object.entries(Canvas),
   ...Object.entries(Data),
+  ...Object.entries(FileLib),
   ...Object.entries(Html),
   ...Object.entries(Image),
   ...Object.entries(Lab),

--- a/src/lib/file.scm
+++ b/src/lib/file.scm
@@ -1,25 +1,31 @@
+;;; (file-exists? fname) -> boolean?
+;;;  fname : string?
+;;; Returns `#t` if a file named `fname` exists and `#f` otherwise.
+;;; @category file, file->string, file->lines, string->file, lines->file
+(define-export file-exists? (js-var "file_fileExistsQ"))
+
 ;;; (file->string fname) -> string?
 ;;;  fname : string?
-;;; Reads the contents of the file named `fname` and returns it as a string. Raises an error if the file does not exist.
-;;; @category file, file->lines, string->file, lines->file, with-file
+;;; Reads the contents of the file named `fname` and returns it as a string. Raises an error if the file does not exist, so use `file-exists?` first if that is a possibility.
+;;; @category file, file-exists?, file->lines, string->file, lines->file, with-file
 (define-export file->string (js-var "file_fileToString"))
 
 ;;; (file->lines fname) -> list?
 ;;;  fname : string?
-;;; Reads the contents of the file named `fname` and returns it as a list of strings, one per line. A trailing newline at the end of the file does not produce a final empty line. Raises an error if the file does not exist.
-;;; @category file, file->string, lines->file, string->file, with-file
+;;; Reads the contents of the file named `fname` and returns it as a list of strings, one per line. A trailing newline at the end of the file does not produce a final empty line. Raises an error if the file does not exist, so use `file-exists?` first if that is a possibility.
+;;; @category file, file-exists?, file->string, lines->file, string->file, with-file
 (define-export file->lines (js-var "file_fileToLines"))
 
 ;;; (string->file str fname) -> void?
 ;;;  str : string?
 ;;;  fname : string?
 ;;; Writes the string `str` to the file named `fname`, creating the file if it does not exist and replacing its contents if it does.
-;;; @category file, lines->file, file->string, file->lines
+;;; @category file, lines->file, file->string, file->lines, file-exists?
 (define-export string->file (js-var "file_stringToFile"))
 
 ;;; (lines->file lines fname) -> void?
 ;;;  lines : list?
 ;;;  fname : string?
 ;;; Writes `lines`, a list of strings, to the file named `fname`, one line each, creating the file if it does not exist and replacing its contents if it does. The file ends with a trailing newline, so that `file->lines` reads back exactly `lines`.
-;;; @category file, string->file, file->lines, file->string
+;;; @category file, string->file, file->lines, file->string, file-exists?
 (define-export lines->file (js-var "file_linesToFile"))

--- a/src/lib/file.scm
+++ b/src/lib/file.scm
@@ -1,6 +1,6 @@
 ;;; (file-exists? fname) -> boolean?
 ;;;  fname : string?
-;;; Returns `#t` if a file named `fname` exists and `#f` otherwise.
+;;; Returns `#t` if `fname` names something in storage and `#f` otherwise. Note that a directory counts as existing, so a `#t` here does not guarantee that `file->string` will succeed.
 ;;; @category file, file->string, file->lines, string->file, lines->file
 (define-export file-exists? (js-var "file_fileExistsQ"))
 
@@ -26,6 +26,6 @@
 ;;; (lines->file lines fname) -> void?
 ;;;  lines : list?
 ;;;  fname : string?
-;;; Writes `lines`, a list of strings, to the file named `fname`, one line each, creating the file if it does not exist and replacing its contents if it does. The file ends with a trailing newline, so that `file->lines` reads back exactly `lines`.
+;;; Writes `lines`, a list of strings, to the file named `fname`, one line each, creating the file if it does not exist and replacing its contents if it does. A non-empty list is written with a trailing newline, so that `file->lines` reads it back unchanged; the empty list writes an empty file. A string that itself contains a newline is written as-is, so it reads back as more than one line.
 ;;; @category file, string->file, file->lines, file->string, file-exists?
 (define-export lines->file (js-var "file_linesToFile"))

--- a/src/lib/file.scm
+++ b/src/lib/file.scm
@@ -1,0 +1,25 @@
+;;; (file->string fname) -> string?
+;;;  fname : string?
+;;; Reads the contents of the file named `fname` and returns it as a string. Raises an error if the file does not exist.
+;;; @category file, file->lines, string->file, lines->file, with-file
+(define-export file->string (js-var "file_fileToString"))
+
+;;; (file->lines fname) -> list?
+;;;  fname : string?
+;;; Reads the contents of the file named `fname` and returns it as a list of strings, one per line. A trailing newline at the end of the file does not produce a final empty line. Raises an error if the file does not exist.
+;;; @category file, file->string, lines->file, string->file, with-file
+(define-export file->lines (js-var "file_fileToLines"))
+
+;;; (string->file str fname) -> void?
+;;;  str : string?
+;;;  fname : string?
+;;; Writes the string `str` to the file named `fname`, creating the file if it does not exist and replacing its contents if it does.
+;;; @category file, lines->file, file->string, file->lines
+(define-export string->file (js-var "file_stringToFile"))
+
+;;; (lines->file lines fname) -> void?
+;;;  lines : list?
+;;;  fname : string?
+;;; Writes `lines`, a list of strings, to the file named `fname`, one line each, creating the file if it does not exist and replacing its contents if it does. The file ends with a trailing newline, so that `file->lines` reads back exactly `lines`.
+;;; @category file, string->file, file->lines, file->string
+(define-export lines->file (js-var "file_linesToFile"))

--- a/src/lpm/scheduler.ts
+++ b/src/lpm/scheduler.ts
@@ -180,6 +180,12 @@ export class Scheduler {
    * its completion) itself, asynchronously. The caller must then NOT also
    * advance/remove it: doing so removes a *second* task, or trips
    * removeTaskFromQueue's atomicity check when the queue is now empty.
+   *
+   * N.B., stepTask's isReportTask error branch also dequeues (via endCurrFiber)
+   * and then yields `undefined` here, which reports false -- the one place that
+   * does not follow this rule. It is harmless today only because that fiber is
+   * never done at that point, so the caller's moveNextTask just mis-advances
+   * currTaskIdx rather than removing a second task.
    */
   async processStepResult(
     stepResult: StepResult | undefined,

--- a/src/lpm/scheduler.ts
+++ b/src/lpm/scheduler.ts
@@ -174,13 +174,20 @@ export class Scheduler {
     }
   }
 
+  /**
+   * @returns true when this step took over managing the task's place in the run
+   * queue -- it has already dequeued the task and will re-schedule it (or signal
+   * its completion) itself, asynchronously. The caller must then NOT also
+   * advance/remove it: doing so removes a *second* task, or trips
+   * removeTaskFromQueue's atomicity check when the queue is now empty.
+   */
   async processStepResult(
     stepResult: StepResult | undefined,
     task: SchedulerTask,
-  ) {
+  ): Promise<boolean> {
     const fiber = task.fiber
     if (!stepResult) {
-      return
+      return false
     }
     if (stepResult.tag === 'import-file') {
       // TODO: this branch (and the getFS()/fileExists() call in particular)
@@ -260,7 +267,7 @@ export class Scheduler {
       }
       // This step is fully handled asynchronously; do not fall through to the
       // display-task branch (which would treat it as a reduction and park).
-      return
+      return true
     }
 
     if (stepResult.tag === 'block-on') {
@@ -301,11 +308,11 @@ export class Scheduler {
       // Handled asynchronously; don't fall through to the display-task branch
       // (which would re-process this suspended fiber as a reduction and re-park,
       // double-removing it from the queue).
-      return
+      return true
     }
 
     if (!isDisplayTask(task)) {
-      return
+      return false
     }
 
     const { out } = task
@@ -352,14 +359,18 @@ export class Scheduler {
             ? advanced
             : false)
       if (park) {
+        // parkInGate dequeued the task, so the caller must leave currTaskIdx
+        // alone -- removeTaskFromQueue swapped a different task into this slot,
+        // and advancing past it would skip that task for a round.
         this.parkInGate(task)
-        return
+        return true
       }
     }
 
     if (isMinor) {
       this.currTaskIdx++
     }
+    return false
   }
 
   /**
@@ -471,8 +482,14 @@ export class Scheduler {
           )
         }
         const stepResult = this.stepTask(task)
-        await this.processStepResult(stepResult, task)
-        this.moveNextTask(task.fiber)
+        // A step that suspended the fiber (block-on, import-file) or parked it
+        // has already taken the task out of the run queue and owns re-scheduling
+        // it. Advancing here as well would remove a second task -- or, if the
+        // async action already finished the program during the await above,
+        // trip removeTaskFromQueue's atomicity check on an empty queue.
+        if (!(await this.processStepResult(stepResult, task))) {
+          this.moveNextTask(task.fiber)
+        }
       }
     }
   }

--- a/test/apps/cli/cli.test.ts
+++ b/test/apps/cli/cli.test.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 
@@ -110,5 +112,37 @@ describe('scamper CLI', () => {
     expect(result.stdout).toBe('(hsv 0 100 100 255)\n(rgba 255 0 0 255)\n')
     expect(result.stderr).toBe('')
     expect(result.status).toBe(0)
+  })
+
+  // The `file` library (#315) suspends the fiber on every read/write, so it only
+  // works under the real scheduler. This runs the actual binary against a real
+  // Node filesystem end-to-end. Written to a temp directory rather than
+  // fixtures/, since the program creates files as it runs.
+  test('the file library round-trips through the real filesystem (#315)', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'scamper-cli-file-'))
+    try {
+      writeFileSync(
+        path.join(dir, 'prog.scm'),
+        [
+          '(import file)',
+          '(string->file "alpha" "a.txt")',
+          '(file->string "a.txt")',
+          '(lines->file (list "x" "y") "b.txt")',
+          '(file->lines "b.txt")',
+        ].join('\n'),
+        'utf-8',
+      )
+
+      const result = runCli([path.join(dir, 'prog.scm')])
+
+      expect(result.stderr).toBe('')
+      expect(result.status).toBe(0)
+      expect(result.stdout).toBe('void\n"alpha"\nvoid\n(list "x" "y")\n')
+      // The writes really landed on disk, next to the program.
+      expect(readFileSync(path.join(dir, 'a.txt'), 'utf-8')).toBe('alpha')
+      expect(readFileSync(path.join(dir, 'b.txt'), 'utf-8')).toBe('x\ny\n')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2,6 +2,7 @@ import * as Scheme from '../src/scheme'
 import * as LPM from '../src/lpm'
 import { diagnosticToError } from '../src/scheme/diagnostic'
 import { Fiber } from '../src/lpm/fiber'
+import { Scheduler } from '../src/lpm/scheduler'
 import HTMLDisplay from '../src/lpm/output/html'
 
 /** Options controlling how {@link runProgram} reports errors. */
@@ -69,6 +70,52 @@ export async function runProgram (src: string, opts: RunOptions = {}): Promise<s
     const fiber = new Fiber(prog, env)
     runFiber(fiber, out, opts.stripRanges)
     return out.log as string[]
+}
+
+/** A LoggingChannel that drops each reported error's range. See RunOptions. */
+class StrippingChannel extends LPM.LoggingChannel {
+  report (e: LPM.ScamperError): void {
+    super.report(e.stripRange())
+  }
+}
+
+/**
+ * As {@link runProgram}, but drives a real {@link Scheduler} rather than
+ * stepping the fiber directly.
+ *
+ * This is what any program using a *blocking* primitive needs: those suspend
+ * the fiber mid-expression (SuspendSignal) and are resumed by the scheduler's
+ * `block-on` handling, which the synchronous loop in runProgram has no way to
+ * service -- it would see the SuspendSignal escape as an uncaught throw. The
+ * `file` library, `with-file`, and `with-image-from-url` are all in this class.
+ *
+ * Prefer runProgram for everything else: it is synchronous and cheaper.
+ */
+export async function runProgramAsync (
+  src: string,
+  opts: RunOptions = {},
+): Promise<string[]> {
+  src = src.trim()
+  const out = opts.stripRanges ? new StrippingChannel() : new LPM.LoggingChannel()
+  const { prog, diagnostics } = await Scheme.compile(src)
+  diagnostics.forEach((d) => { out.report(diagnosticToError(d)) })
+  if (out.log.length !== 0) { return out.log as string[] }
+  if (prog === undefined) {
+    throw new Error('compile produced no program and no logged errors')
+  }
+  const fiber = new Fiber(prog, Scheme.mkInitialEnv())
+  const sched = new Scheduler()
+  await new Promise<void>((resolve) => {
+    sched.schedule({
+      id: crypto.randomUUID(),
+      fiber,
+      out,
+      err: out,
+      isTracing: false,
+      onComplete: resolve,
+    })
+  })
+  return out.log as string[]
 }
 
 export async function runProgramWithHTML (src: string, out: HTMLDisplay): Promise<HTMLElement[]> {

--- a/test/libs/file.test.ts
+++ b/test/libs/file.test.ts
@@ -74,6 +74,46 @@ const read = (name: string) => readFile(path.join(dir, name), 'utf-8')
 const write = (name: string, contents: string) =>
   writeFile(path.join(dir, name), contents, 'utf-8')
 
+describe('file-exists?', () => {
+  test('is #t for a file that exists and #f otherwise', async () => {
+    await write('here.txt', 'contents')
+    expect(
+      await runFileProgram(`
+(import file)
+(file-exists? "here.txt")
+(file-exists? "nope.txt")
+`),
+    ).toEqual(['#t', '#f'])
+  })
+
+  test('sees a file created earlier in the same program', async () => {
+    expect(
+      await runFileProgram(`
+(import file)
+(file-exists? "made.txt")
+(string->file "x" "made.txt")
+(file-exists? "made.txt")
+`),
+    ).toEqual(['#f', 'void', '#t'])
+  })
+
+  test('an empty file still exists', async () => {
+    await write('empty.txt', '')
+    expect(await runFileProgram('(import file)\n(file-exists? "empty.txt")')).toEqual(['#t'])
+  })
+
+  test('guards a read that would otherwise raise', async () => {
+    // The idiom file-exists? is for: check before reading, rather than wrapping
+    // the read in with-handler.
+    expect(
+      await runFileProgram(`
+(import file)
+(if (file-exists? "nope.txt") (file->string "nope.txt") "no such file")
+`),
+    ).toEqual(['"no such file"'])
+  })
+})
+
 describe('file->string', () => {
   test('reads a file back as a string', async () => {
     await write('greet.txt', 'hello\nworld\n')
@@ -204,6 +244,7 @@ describe('argument contracts', () => {
       await runProgram(
         `
 (import file)
+(file-exists? 5)
 (file->string 5)
 (file->lines 5)
 (string->file "s" 5)
@@ -212,6 +253,7 @@ describe('argument contracts', () => {
         { stripRanges: true },
       ),
     ).toEqual([
+      'Runtime error: (error) expected a string, received number',
       'Runtime error: (error) expected a string, received number',
       'Runtime error: (error) expected a string, received number',
       'Runtime error: (error) expected a string, received number',

--- a/test/libs/file.test.ts
+++ b/test/libs/file.test.ts
@@ -1,84 +1,35 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import path from 'node:path'
-import * as Scheme from '../../src/scheme'
-import * as LPM from '../../src/lpm'
-import { Fiber } from '../../src/lpm/fiber'
-import { Scheduler } from '../../src/lpm/scheduler'
-import { diagnosticToError } from '../../src/scheme/diagnostic'
+import { beforeEach, describe, expect, test } from 'vitest'
 import { setFS } from '../../src/fs'
-import NodeFileSystem from '../../src/fs/node'
-import { runProgram } from '../harness.js'
+import { MockFileSystem } from '../stubs/mock-file-system'
+import { runProgram, runProgramAsync } from './harness.js'
 
 // The `file` library (issue #315): whole-file reads and writes, each of which
 // suspends the fiber on an async filesystem action (SuspendSignal / Scheduler
-// `block-on`). Because those only resolve under the scheduler, the happy path
-// cannot run on test/harness.ts's synchronous runProgram -- runFileProgram
-// below drives a real Scheduler instead. Argument contracts still fail eagerly,
-// so those cases use the ordinary harness.
+// `block-on`). Those only resolve under the scheduler, so the happy path runs
+// on runProgramAsync rather than the synchronous runProgram. Argument contracts
+// still fail eagerly, so those cases use the plain harness.
+//
+// Backed by the in-memory MockFileSystem: these tests are about the library's
+// semantics, not Node I/O, and an in-memory FS keeps them fast and leaves no
+// temp directories to clean up. The real filesystem is covered a tier up, by
+// the CLI end-to-end test in test/apps/cli/cli.test.ts.
 
-let dir: string
+let fs: MockFileSystem
 
-beforeAll(async () => {
-  dir = await mkdtemp(path.join(tmpdir(), 'scamper-file-'))
-  // Mirror the CLI: a Node-backed FS rooted at a scratch directory.
-  setFS(await NodeFileSystem.create(dir))
+beforeEach(async () => {
+  // A fresh FS per test, so writes can't leak between them.
+  fs = await MockFileSystem.create()
+  setFS(fs)
 })
 
-afterAll(async () => {
-  await rm(dir, { recursive: true, force: true })
-})
-
-afterEach(async () => {
-  // Each test starts from an empty directory so writes can't leak between them.
-  for (const f of await (await import('node:fs/promises')).readdir(dir)) {
-    await rm(path.join(dir, f), { force: true })
-  }
-})
-
-/** Strips the `[line:col-line:col]` span from an error line. Library contract
- *  errors point into the .scm source, so their ranges shift on any library
- *  edit; the messages are what these tests are about. */
-const stripRanges = (s: string): string => s.replace(/ \[\d+:\d+-\d+:\d+\]/g, '')
-
-/** Compiles and runs `src` under a real Scheduler, returning its output lines. */
-async function runFileProgram(src: string): Promise<string[]> {
-  const out = new LPM.LoggingChannel()
-  const { prog, diagnostics } = await Scheme.compile(src.trim())
-  diagnostics.forEach((d) => {
-    out.report(diagnosticToError(d))
-  })
-  if (out.log.length !== 0) {
-    return (out.log as string[]).map(stripRanges)
-  }
-  if (prog === undefined) {
-    throw new Error('compile produced no program and no logged errors')
-  }
-  const fiber = new Fiber(prog, Scheme.mkInitialEnv())
-  const sched = new Scheduler()
-  await new Promise<void>((resolve) => {
-    sched.schedule({
-      id: crypto.randomUUID(),
-      fiber,
-      out,
-      err: out,
-      isTracing: false,
-      onComplete: resolve,
-    })
-  })
-  return (out.log as string[]).map(stripRanges)
-}
-
-const read = (name: string) => readFile(path.join(dir, name), 'utf-8')
-const write = (name: string, contents: string) =>
-  writeFile(path.join(dir, name), contents, 'utf-8')
+const read = (name: string) => fs.loadFile(name)
+const write = (name: string, contents: string) => fs.saveFile(name, contents)
 
 describe('file-exists?', () => {
   test('is #t for a file that exists and #f otherwise', async () => {
     await write('here.txt', 'contents')
     expect(
-      await runFileProgram(`
+      await runProgramAsync(`
 (import file)
 (file-exists? "here.txt")
 (file-exists? "nope.txt")
@@ -88,7 +39,7 @@ describe('file-exists?', () => {
 
   test('sees a file created earlier in the same program', async () => {
     expect(
-      await runFileProgram(`
+      await runProgramAsync(`
 (import file)
 (file-exists? "made.txt")
 (string->file "x" "made.txt")
@@ -99,14 +50,14 @@ describe('file-exists?', () => {
 
   test('an empty file still exists', async () => {
     await write('empty.txt', '')
-    expect(await runFileProgram('(import file)\n(file-exists? "empty.txt")')).toEqual(['#t'])
+    expect(await runProgramAsync('(import file)\n(file-exists? "empty.txt")')).toEqual(['#t'])
   })
 
   test('guards a read that would otherwise raise', async () => {
     // The idiom file-exists? is for: check before reading, rather than wrapping
     // the read in with-handler.
     expect(
-      await runFileProgram(`
+      await runProgramAsync(`
 (import file)
 (if (file-exists? "nope.txt") (file->string "nope.txt") "no such file")
 `),
@@ -117,25 +68,25 @@ describe('file-exists?', () => {
 describe('file->string', () => {
   test('reads a file back as a string', async () => {
     await write('greet.txt', 'hello\nworld\n')
-    expect(await runFileProgram('(import file)\n(file->string "greet.txt")')).toEqual([
+    expect(await runProgramAsync('(import file)\n(file->string "greet.txt")')).toEqual([
       '"hello\nworld\n"',
     ])
   })
 
   test('reads an empty file as the empty string', async () => {
     await write('empty.txt', '')
-    expect(await runFileProgram('(import file)\n(file->string "empty.txt")')).toEqual(['""'])
+    expect(await runProgramAsync('(import file)\n(file->string "empty.txt")')).toEqual(['""'])
   })
 
   test('a missing file raises a runtime error', async () => {
-    expect(await runFileProgram('(import file)\n(file->string "nope.txt")')).toEqual([
+    expect(await runProgramAsync('(import file)\n(file->string "nope.txt")')).toEqual([
       'Runtime error: File "nope.txt" does not exist',
     ])
   })
 
   test('a missing file is catchable by with-handler', async () => {
     expect(
-      await runFileProgram(`
+      await runProgramAsync(`
 (import file)
 (with-handler (lambda (e) "caught") (lambda () (file->string "nope.txt")))
 `),
@@ -146,14 +97,14 @@ describe('file->string', () => {
 describe('file->lines', () => {
   test('splits on newlines', async () => {
     await write('lines.txt', 'a\nb\nc')
-    expect(await runFileProgram('(import file)\n(file->lines "lines.txt")')).toEqual([
+    expect(await runProgramAsync('(import file)\n(file->lines "lines.txt")')).toEqual([
       '(list "a" "b" "c")',
     ])
   })
 
   test('a trailing newline does not produce a final empty line', async () => {
     await write('lines.txt', 'a\nb\nc\n')
-    expect(await runFileProgram('(import file)\n(file->lines "lines.txt")')).toEqual([
+    expect(await runProgramAsync('(import file)\n(file->lines "lines.txt")')).toEqual([
       '(list "a" "b" "c")',
     ])
   })
@@ -161,28 +112,28 @@ describe('file->lines', () => {
   test('only one trailing empty line is dropped', async () => {
     // "a\n\n" is a line "a" followed by a genuinely blank line.
     await write('lines.txt', 'a\n\n')
-    expect(await runFileProgram('(import file)\n(file->lines "lines.txt")')).toEqual([
+    expect(await runProgramAsync('(import file)\n(file->lines "lines.txt")')).toEqual([
       '(list "a" "")',
     ])
   })
 
   test('handles CRLF line endings', async () => {
     await write('crlf.txt', 'a\r\nb\r\n')
-    expect(await runFileProgram('(import file)\n(file->lines "crlf.txt")')).toEqual([
+    expect(await runProgramAsync('(import file)\n(file->lines "crlf.txt")')).toEqual([
       '(list "a" "b")',
     ])
   })
 
   test('an empty file reads as the empty list', async () => {
     await write('empty.txt', '')
-    expect(await runFileProgram('(import file)\n(file->lines "empty.txt")')).toEqual(['null'])
+    expect(await runProgramAsync('(import file)\n(file->lines "empty.txt")')).toEqual(['null'])
   })
 })
 
 describe('string->file', () => {
   test('creates a file and round-trips through file->string', async () => {
     expect(
-      await runFileProgram(`
+      await runProgramAsync(`
 (import file)
 (string->file "some text" "out.txt")
 (file->string "out.txt")
@@ -194,7 +145,7 @@ describe('string->file', () => {
   test('replaces the contents of an existing file', async () => {
     await write('out.txt', 'original contents, much longer')
     expect(
-      await runFileProgram(`
+      await runProgramAsync(`
 (import file)
 (string->file "new" "out.txt")
 (file->string "out.txt")
@@ -207,14 +158,14 @@ describe('string->file', () => {
 describe('lines->file', () => {
   test('writes one line each, ending with a trailing newline', async () => {
     expect(
-      await runFileProgram('(import file)\n(lines->file (list "a" "b" "c") "out.txt")'),
+      await runProgramAsync('(import file)\n(lines->file (list "a" "b" "c") "out.txt")'),
     ).toEqual(['void'])
     expect(await read('out.txt')).toBe('a\nb\nc\n')
   })
 
   test('round-trips with file->lines', async () => {
     expect(
-      await runFileProgram(`
+      await runProgramAsync(`
 (import file)
 (lines->file (list "one" "two" "three") "out.txt")
 (file->lines "out.txt")
@@ -223,13 +174,13 @@ describe('lines->file', () => {
   })
 
   test('the empty list writes an empty file, not a lone newline', async () => {
-    expect(await runFileProgram('(import file)\n(lines->file null "out.txt")')).toEqual(['void'])
+    expect(await runProgramAsync('(import file)\n(lines->file null "out.txt")')).toEqual(['void'])
     expect(await read('out.txt')).toBe('')
   })
 
   test('a non-string element is a runtime error', async () => {
     expect(
-      await runFileProgram('(import file)\n(lines->file (list "a" 5) "out.txt")'),
+      await runProgramAsync('(import file)\n(lines->file (list "a" 5) "out.txt")'),
     ).toEqual([
       'Runtime error: lines->file: expected a list of strings, but the list contains number',
     ])
@@ -241,17 +192,14 @@ describe('lines->file', () => {
 describe('argument contracts', () => {
   test('reject non-string filenames', async () => {
     expect(
-      await runProgram(
-        `
+      await runProgram(`
 (import file)
 (file-exists? 5)
 (file->string 5)
 (file->lines 5)
 (string->file "s" 5)
 (lines->file (list "a") 5)
-`,
-        { stripRanges: true },
-      ),
+`),
     ).toEqual([
       'Runtime error: (error) expected a string, received number',
       'Runtime error: (error) expected a string, received number',
@@ -263,14 +211,11 @@ describe('argument contracts', () => {
 
   test('reject wrong argument types for the written value', async () => {
     expect(
-      await runProgram(
-        `
+      await runProgram(`
 (import file)
 (string->file 5 "out.txt")
 (lines->file "not a list" "out.txt")
-`,
-        { stripRanges: true },
-      ),
+`),
     ).toEqual([
       'Runtime error: (error) expected a string, received number',
       'Runtime error: (error) expected a list, received string',

--- a/test/libs/file.test.ts
+++ b/test/libs/file.test.ts
@@ -1,0 +1,237 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import * as Scheme from '../../src/scheme'
+import * as LPM from '../../src/lpm'
+import { Fiber } from '../../src/lpm/fiber'
+import { Scheduler } from '../../src/lpm/scheduler'
+import { diagnosticToError } from '../../src/scheme/diagnostic'
+import { setFS } from '../../src/fs'
+import NodeFileSystem from '../../src/fs/node'
+import { runProgram } from '../harness.js'
+
+// The `file` library (issue #315): whole-file reads and writes, each of which
+// suspends the fiber on an async filesystem action (SuspendSignal / Scheduler
+// `block-on`). Because those only resolve under the scheduler, the happy path
+// cannot run on test/harness.ts's synchronous runProgram -- runFileProgram
+// below drives a real Scheduler instead. Argument contracts still fail eagerly,
+// so those cases use the ordinary harness.
+
+let dir: string
+
+beforeAll(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'scamper-file-'))
+  // Mirror the CLI: a Node-backed FS rooted at a scratch directory.
+  setFS(await NodeFileSystem.create(dir))
+})
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+afterEach(async () => {
+  // Each test starts from an empty directory so writes can't leak between them.
+  for (const f of await (await import('node:fs/promises')).readdir(dir)) {
+    await rm(path.join(dir, f), { force: true })
+  }
+})
+
+/** Strips the `[line:col-line:col]` span from an error line. Library contract
+ *  errors point into the .scm source, so their ranges shift on any library
+ *  edit; the messages are what these tests are about. */
+const stripRanges = (s: string): string => s.replace(/ \[\d+:\d+-\d+:\d+\]/g, '')
+
+/** Compiles and runs `src` under a real Scheduler, returning its output lines. */
+async function runFileProgram(src: string): Promise<string[]> {
+  const out = new LPM.LoggingChannel()
+  const { prog, diagnostics } = await Scheme.compile(src.trim())
+  diagnostics.forEach((d) => {
+    out.report(diagnosticToError(d))
+  })
+  if (out.log.length !== 0) {
+    return (out.log as string[]).map(stripRanges)
+  }
+  if (prog === undefined) {
+    throw new Error('compile produced no program and no logged errors')
+  }
+  const fiber = new Fiber(prog, Scheme.mkInitialEnv())
+  const sched = new Scheduler()
+  await new Promise<void>((resolve) => {
+    sched.schedule({
+      id: crypto.randomUUID(),
+      fiber,
+      out,
+      err: out,
+      isTracing: false,
+      onComplete: resolve,
+    })
+  })
+  return (out.log as string[]).map(stripRanges)
+}
+
+const read = (name: string) => readFile(path.join(dir, name), 'utf-8')
+const write = (name: string, contents: string) =>
+  writeFile(path.join(dir, name), contents, 'utf-8')
+
+describe('file->string', () => {
+  test('reads a file back as a string', async () => {
+    await write('greet.txt', 'hello\nworld\n')
+    expect(await runFileProgram('(import file)\n(file->string "greet.txt")')).toEqual([
+      '"hello\nworld\n"',
+    ])
+  })
+
+  test('reads an empty file as the empty string', async () => {
+    await write('empty.txt', '')
+    expect(await runFileProgram('(import file)\n(file->string "empty.txt")')).toEqual(['""'])
+  })
+
+  test('a missing file raises a runtime error', async () => {
+    expect(await runFileProgram('(import file)\n(file->string "nope.txt")')).toEqual([
+      'Runtime error: File "nope.txt" does not exist',
+    ])
+  })
+
+  test('a missing file is catchable by with-handler', async () => {
+    expect(
+      await runFileProgram(`
+(import file)
+(with-handler (lambda (e) "caught") (lambda () (file->string "nope.txt")))
+`),
+    ).toEqual(['"caught"'])
+  })
+})
+
+describe('file->lines', () => {
+  test('splits on newlines', async () => {
+    await write('lines.txt', 'a\nb\nc')
+    expect(await runFileProgram('(import file)\n(file->lines "lines.txt")')).toEqual([
+      '(list "a" "b" "c")',
+    ])
+  })
+
+  test('a trailing newline does not produce a final empty line', async () => {
+    await write('lines.txt', 'a\nb\nc\n')
+    expect(await runFileProgram('(import file)\n(file->lines "lines.txt")')).toEqual([
+      '(list "a" "b" "c")',
+    ])
+  })
+
+  test('only one trailing empty line is dropped', async () => {
+    // "a\n\n" is a line "a" followed by a genuinely blank line.
+    await write('lines.txt', 'a\n\n')
+    expect(await runFileProgram('(import file)\n(file->lines "lines.txt")')).toEqual([
+      '(list "a" "")',
+    ])
+  })
+
+  test('handles CRLF line endings', async () => {
+    await write('crlf.txt', 'a\r\nb\r\n')
+    expect(await runFileProgram('(import file)\n(file->lines "crlf.txt")')).toEqual([
+      '(list "a" "b")',
+    ])
+  })
+
+  test('an empty file reads as the empty list', async () => {
+    await write('empty.txt', '')
+    expect(await runFileProgram('(import file)\n(file->lines "empty.txt")')).toEqual(['null'])
+  })
+})
+
+describe('string->file', () => {
+  test('creates a file and round-trips through file->string', async () => {
+    expect(
+      await runFileProgram(`
+(import file)
+(string->file "some text" "out.txt")
+(file->string "out.txt")
+`),
+    ).toEqual(['void', '"some text"'])
+    expect(await read('out.txt')).toBe('some text')
+  })
+
+  test('replaces the contents of an existing file', async () => {
+    await write('out.txt', 'original contents, much longer')
+    expect(
+      await runFileProgram(`
+(import file)
+(string->file "new" "out.txt")
+(file->string "out.txt")
+`),
+    ).toEqual(['void', '"new"'])
+    expect(await read('out.txt')).toBe('new')
+  })
+})
+
+describe('lines->file', () => {
+  test('writes one line each, ending with a trailing newline', async () => {
+    expect(
+      await runFileProgram('(import file)\n(lines->file (list "a" "b" "c") "out.txt")'),
+    ).toEqual(['void'])
+    expect(await read('out.txt')).toBe('a\nb\nc\n')
+  })
+
+  test('round-trips with file->lines', async () => {
+    expect(
+      await runFileProgram(`
+(import file)
+(lines->file (list "one" "two" "three") "out.txt")
+(file->lines "out.txt")
+`),
+    ).toEqual(['void', '(list "one" "two" "three")'])
+  })
+
+  test('the empty list writes an empty file, not a lone newline', async () => {
+    expect(await runFileProgram('(import file)\n(lines->file null "out.txt")')).toEqual(['void'])
+    expect(await read('out.txt')).toBe('')
+  })
+
+  test('a non-string element is a runtime error', async () => {
+    expect(
+      await runFileProgram('(import file)\n(lines->file (list "a" 5) "out.txt")'),
+    ).toEqual([
+      'Runtime error: lines->file: expected a list of strings, but the list contains number',
+    ])
+  })
+})
+
+// Argument contracts are checked before the primitive suspends, so these fail
+// eagerly and run on the ordinary synchronous harness.
+describe('argument contracts', () => {
+  test('reject non-string filenames', async () => {
+    expect(
+      await runProgram(
+        `
+(import file)
+(file->string 5)
+(file->lines 5)
+(string->file "s" 5)
+(lines->file (list "a") 5)
+`,
+        { stripRanges: true },
+      ),
+    ).toEqual([
+      'Runtime error: (error) expected a string, received number',
+      'Runtime error: (error) expected a string, received number',
+      'Runtime error: (error) expected a string, received number',
+      'Runtime error: (error) expected a string, received number',
+    ])
+  })
+
+  test('reject wrong argument types for the written value', async () => {
+    expect(
+      await runProgram(
+        `
+(import file)
+(string->file 5 "out.txt")
+(lines->file "not a list" "out.txt")
+`,
+        { stripRanges: true },
+      ),
+    ).toEqual([
+      'Runtime error: (error) expected a string, received number',
+      'Runtime error: (error) expected a list, received string',
+    ])
+  })
+})

--- a/test/libs/file.test.ts
+++ b/test/libs/file.test.ts
@@ -175,6 +175,9 @@ describe('lines->file', () => {
 
   test('the empty list writes an empty file, not a lone newline', async () => {
     expect(await runProgramAsync('(import file)\n(lines->file null "out.txt")')).toEqual(['void'])
+    // The existence check matters: without it this passes even if nothing is
+    // written at all, so long as reading a missing file yields "".
+    expect(await fs.fileExists('out.txt')).toBe(true)
     expect(await read('out.txt')).toBe('')
   })
 

--- a/test/libs/harness.ts
+++ b/test/libs/harness.ts
@@ -3,9 +3,22 @@
 // don't shift when its own source string is reflowed. Range *reporting* is
 // covered directly by test/lpm/range.test.ts, and the call-site attribution of
 // contract errors by test/regressions/contract-error-call-site.test.ts.
-import { runProgram as runProgramWithRanges } from '../harness.js'
+import {
+  runProgram as runProgramWithRanges,
+  runProgramAsync as runProgramAsyncWithRanges,
+} from '../harness.js'
 
 /** Like {@link runProgramWithRanges} but drops `[line:col]` ranges from error output. */
 export function runProgram (src: string): Promise<string[]> {
   return runProgramWithRanges(src, { stripRanges: true })
+}
+
+/**
+ * Like {@link runProgram}, but drives a real Scheduler so *blocking* primitives
+ * (`with-file`, the `file` library, `with-image-from-url`) can run: those
+ * suspend the fiber mid-expression and are resumed by the scheduler, which the
+ * synchronous runner cannot service. Prefer runProgram otherwise.
+ */
+export function runProgramAsync (src: string): Promise<string[]> {
+  return runProgramAsyncWithRanges(src, { stripRanges: true })
 }

--- a/test/libs/prelude.test.ts
+++ b/test/libs/prelude.test.ts
@@ -1,7 +1,16 @@
-import { beforeEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 import { runProgram, runProgramAsync } from './harness.js'
-import { setFS } from '../../src/fs'
+import { getFS, setFS, type t as FS } from '../../src/fs'
 import { MockFileSystem } from '../stubs/mock-file-system'
+
+/** getFS throws when no file system is installed; this reports that as undefined. */
+function tryGetFS(): FS | undefined {
+  try {
+    return getFS()
+  } catch {
+    return undefined
+  }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -2762,10 +2771,21 @@ void
 // are behavior coverage, though, not a guard for that invariant: they pass
 // either way. The scheduler's own tests are what pin it down.
 describe('with-file', () => {
+  // N.B., setFS is a global, so it is restored afterwards -- otherwise every
+  // test *following* this block would silently run against the mock.
+  let previousFS: FS | undefined
+
   beforeEach(async () => {
+    previousFS = tryGetFS()
     const fs = await MockFileSystem.create()
     await fs.saveFile('greet.txt', 'hello\nthere\n')
     setFS(fs)
+  })
+
+  afterEach(() => {
+    if (previousFS !== undefined) {
+      setFS(previousFS)
+    }
   })
 
   test('passes the file contents to its callback', async () => {

--- a/test/libs/prelude.test.ts
+++ b/test/libs/prelude.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from 'vitest'
-import { runProgram } from './harness.js'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { runProgram, runProgramAsync } from './harness.js'
+import { setFS } from '../../src/fs'
+import { MockFileSystem } from '../stubs/mock-file-system'
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -2749,18 +2751,64 @@ void
   ])
 })
 
-// N.B., with-file now blocks the fiber to load the file (SuspendSignal /
-// Scheduler `block-on`) and applies the callback in Scheme, so its happy path
-// runs only under the async scheduler (validated end-to-end via the CLI), not
-// this synchronous harness. The argument contract still fails eagerly.
-test('with-file rejects a non-string filename via its contract', async () => {
-  expect(
-    await runProgram(`
+// with-file blocks the fiber to load the file (SuspendSignal / Scheduler
+// `block-on`) and applies the callback in Scheme, so its happy path only runs
+// under the async scheduler -- runProgramAsync, not the synchronous runProgram.
+// The argument contract still fails eagerly.
+//
+// N.B., this happy path went untested for a while -- the CLI was the only thing
+// exercising it -- which is part of why a scheduler bug on the block-on path
+// survived (see the block-on tests in test/lpm/scheduler.test.ts). These cases
+// are behavior coverage, though, not a guard for that invariant: they pass
+// either way. The scheduler's own tests are what pin it down.
+describe('with-file', () => {
+  beforeEach(async () => {
+    const fs = await MockFileSystem.create()
+    await fs.saveFile('greet.txt', 'hello\nthere\n')
+    setFS(fs)
+  })
+
+  test('passes the file contents to its callback', async () => {
+    expect(
+      await runProgramAsync(`
+(with-file "greet.txt" (lambda (s) (string-length s)))
+`),
+    ).toEqual(['12'])
+  })
+
+  test('returns the callback result, which renders at the top level', async () => {
+    expect(
+      await runProgramAsync(`
+(with-file "greet.txt" (lambda (s) s))
+`),
+    ).toEqual(['"hello\nthere\n"'])
+  })
+
+  test('a missing file raises a runtime error', async () => {
+    expect(
+      await runProgramAsync(`
+(with-file "nope.txt" (lambda (s) s))
+`),
+    ).toEqual(['Runtime error: File "nope.txt" does not exist'])
+  })
+
+  test('a missing file is catchable by with-handler', async () => {
+    // The idiomatic (with-handler h (lambda () (with-file ...))) shape: the
+    // rejection routes through fiber.handleError rather than unwinding.
+    expect(
+      await runProgramAsync(`
+(with-handler (lambda (e) "caught") (lambda () (with-file "nope.txt" (lambda (s) s))))
+`),
+    ).toEqual(['"caught"'])
+  })
+
+  test('rejects a non-string filename via its contract', async () => {
+    expect(
+      await runProgram(`
 (with-file 5 (lambda (s) s))
 `),
-  ).toEqual([
-    'Runtime error: (error) expected a string, received number',
-  ])
+    ).toEqual(['Runtime error: (error) expected a string, received number'])
+  })
 })
 
 test('with-file-chooser', async () => {

--- a/test/lpm/scheduler.test.ts
+++ b/test/lpm/scheduler.test.ts
@@ -522,6 +522,51 @@ describe('Scheduler', () => {
       expect(task.ch.log).toContain('after')
     })
 
+    test('an action that completes the program does not corrupt the run queue', async () => {
+      // Regression (found building the `file` library, #315): the block-on
+      // branch dequeues the task and owns re-scheduling it, but execute() then
+      // called moveNextTask anyway. When the action settled fast enough that
+      // advanceStmt finished the program during the intervening `await`,
+      // moveNextTask saw a done fiber and tried to remove a task from an
+      // already-empty queue -- tripping removeTaskFromQueue's atomicity ICE.
+      //
+      // That ICE was thrown inside execute()'s detached promise, so it reached
+      // no caller: the run looked green apart from an unhandled rejection. The
+      // previous test doesn't catch it because its blocking call is followed by
+      // another statement, so the fiber isn't done at that moment. Here the
+      // blocking call IS the last statement.
+      const rejections: unknown[] = []
+      const capture = (e: unknown) => rejections.push(e)
+      process.on('unhandledRejection', capture)
+      try {
+        const sched = new Scheduler()
+        const fiber = makeTestFiber([U.mkDisp([U.mkVar('block'), U.mkAp(0)])])
+        fiber.topLevelEnv = fiber.topLevelEnv.extendWithTopLevel([
+          'block',
+          () => {
+            throw new SuspendSignal(() => Promise.reject(new Error('disk error')))
+          },
+        ])
+        let completed = 0
+        const task = { ...makeTask(fiber), onComplete: () => completed++ }
+
+        sched.schedule(task)
+        await sleep(QUANTUM_WAIT_MS)
+        sched.pauseExecution()
+        await sleep(QUANTUM_WAIT_MS)
+
+        expect(task.ch.errLog).toHaveLength(1)
+        expect(task.ch.errLog[0]).toContain('disk error')
+        // The program completed exactly once, and nothing escaped into a
+        // detached promise.
+        expect(completed).toBe(1)
+        expect(rejections).toEqual([])
+      } finally {
+        await sleep(QUANTUM_WAIT_MS)
+        process.off('unhandledRejection', capture)
+      }
+    })
+
     // N.B., a blockOn rejection under an enclosing `with-handler` (the idiomatic
     // `(with-handler h (lambda () (with-file ...)))` shape) is catchable -- it
     // routes through fiber.handleError. That path needs the compiler's real

--- a/test/stubs/mock-file-system.ts
+++ b/test/stubs/mock-file-system.ts
@@ -22,7 +22,18 @@ export class MockFileSystem implements FS {
   }
 
   loadFile(filename: string) {
-    return Promise.resolve(this.files.get(filename) ?? '')
+    // N.B., rejects for a file that isn't here, like both real implementations
+    // (NodeFileSystem's readFile throws ENOENT, OPFS's getFileHandle throws
+    // NotFoundError). Returning '' instead would make a *missing* file
+    // indistinguishable from an *empty* one, which silently voids any test
+    // asserting that something wrote an empty file.
+    const contents = this.files.get(filename)
+    if (contents === undefined) {
+      return Promise.reject(
+        new Error(`MockFileSystem: file "${filename}" does not exist`),
+      )
+    }
+    return Promise.resolve(contents)
   }
 
   saveFile(filename: string, contents: string) {
@@ -36,7 +47,12 @@ export class MockFileSystem implements FS {
   }
 
   renameFile(from: string, to: string) {
-    const contents = this.files.get(from) ?? ''
+    const contents = this.files.get(from)
+    if (contents === undefined) {
+      return Promise.reject(
+        new Error(`MockFileSystem: file "${from}" does not exist`),
+      )
+    }
     this.files.set(to, contents)
     this.files.delete(from)
     return Promise.resolve()


### PR DESCRIPTION
Closes #315.

Reading a file meant threading a callback through `with-file`; writing one was impossible. Adds four direct-style procedures in a new builtin library:

```scheme
(import file)

(file-exists? "notes.txt")                  ; => #t
(file->string "notes.txt")                  ; => "line one\nline two\n"
(file->lines  "notes.txt")                  ; => (list "line one" "line two")
(string->file "hello" "out.txt")            ; => void
(lines->file  (list "a" "b") "out.txt")     ; => void
```

`file-exists?` is R7RS `(scheme file)`; no `!`, since it is a query rather than an effect. It exists so a read can be guarded rather than wrapped in a handler:

```scheme
(if (file-exists? "data.txt") (file->string "data.txt") "no such file")
```

`file->string` and `file->lines` point at it from their docstrings — "raises if the file does not exist" is exactly where a reader needs to know it exists.

## Design

**Not ports.** R7RS's file I/O is entirely port-based — `open-input-file` yields a stateful cursor you `read-line` from and must remember to `close`. A cursor whose reads reduce differently on each call fights both Scamper's functional style and its reduction traces, and on OPFS every read would suspend the fiber separately. R7RS's *file-system* vocabulary informs the surface; its port machinery is deliberately not adopted.

**Names follow the `x->y` convention.** `with-file`'s existing docstring already cross-referenced `file->string` and `file->lines` by name, so the codebase had effectively picked them. Writing is the dual of reading rather than Racket's `display-to-file`.

**Its own library, not the prelude.** Per the direction to keep the impure fragment separable — `with-file` keeps the pure/reactive framing in the prelude, and these can be regrouped later without breaking programs that already import them. Starting here costs a `(import file)`; moving later would cost every existing use.

**Line semantics round-trip.** `file->lines` drops the single empty element a trailing newline would otherwise produce; `lines->file` writes one. So `file->lines ∘ lines->file` is the identity, and an empty list writes an empty file rather than a lone newline.

Each procedure suspends the fiber on an async filesystem action (`SuspendSignal` / Scheduler `block-on`), the pattern established by `prelude_blockOnReadFile`. Nothing in `src/fs` needed to change.

## A scheduler bug this surfaced

`processStepResult`'s `block-on` and `import-file` branches dequeue the task and own re-scheduling it — but `execute()` called `moveNextTask` afterwards regardless. When the async action settled fast enough to finish the program during the intervening `await`, `moveNextTask` saw a done fiber and tried to remove a task from an already-empty queue, tripping `removeTaskFromQueue`'s atomicity ICE.

That ICE was thrown inside `execute()`'s detached promise, so it reached no caller: the run looked green except for an unhandled rejection. It was reachable by `with-file` too, but nothing exercised that path under the scheduler — the existing test notes its happy path "runs only under the async scheduler ... not this synchronous harness."

`processStepResult` now reports whether it took over the queue and `execute` honors it. The same guard fixes the `import-file` missing-file branch, which called `endCurrFiber()` and then fell through to `moveNextTask` as well.

`test/lpm/scheduler.test.ts` gains a named regression test for it (fails with the exact ICE without the fix). The `file` tests are a second guard: without the fix the unhandled rejection fails the run outright — verified, exit code 1 vs 0.

## Testing

The happy path can't run on `test/harness.ts`'s synchronous `runProgram`, so this adds **`runProgramAsync`** there (and a range-stripping wrapper in `test/libs/harness.ts`) that drives a real `Scheduler`. Any blocking primitive can now be tested. `test/libs/file.test.ts` runs against the in-memory `test/stubs/mock-file-system.ts`; argument contracts fail eagerly, so those cases use the ordinary harness.

That also closed a standing hole: **`with-file`'s happy path had no unit test at all** — only its contract failure was pinned, with the CLI the sole thing exercising the rest. It now covers the callback result, a missing file, and catching one with `with-handler`. Covered: round-trips both ways, trailing-newline and CRLF handling, "only one trailing empty line is dropped", empty files and empty lists, overwrite-on-write, missing-file errors (including catching one with `with-handler`), non-string list elements, and contract failures on every argument.

`test/apps/cli/cli.test.ts` adds an end-to-end case running the real binary against a temp directory, asserting the bytes that land on disk.

`npm run validate` passes. Lint is +5 warnings, all the same `only-throw-error` on `throw new SuspendSignal(...)` that the five existing suspending primitives already produce.

## Known limitations

- **`scamper --trace` cannot run these.** That path steps a fiber directly and doesn't handle `block-on`; its own comment already says "Synchronous programs only." Pre-existing (it applies to `with-file`), but much easier to hit now.
- In the browser these read and write the **OPFS sandbox** — origin-private, flat — not the user's real filesystem.

## Deferred

`delete-file!`, `rename-file!`, and `file-list` — the rest of the `FS` interface. Note the `!`: Scamper marks effectful procedures that way (`vector-set!`, `on-keydown!`), diverging from R7RS's bare `delete-file`. Also `append-to-file`, which would be load-concat-save since `FS` has no append primitive.

_(Co-created with Claude Code)_

