### PR TITLE
Accept every color representation wherever a color is taken

### DIFF
--- a/src/app/web/patch-notes.ts
+++ b/src/app/web/patch-notes.ts
@@ -19,6 +19,14 @@ export interface PatchNote {
 
 export const patchNotes: PatchNote[] = [
   {
+    version: '3.6.0',
+    title: 'Colors everywhere',
+    notes: [
+      'Every function that takes a color now accepts a color name, an rgb value, or an hsv value — so (solid-square 100 (rgb 255 0 0)) works, where before only "red" did.',
+      'The old `color` function has been removed. Use `rgb` instead: (rgb 255 0 0) in place of (color 255 0 0 255).',
+    ],
+  },
+  {
     version: '3.5.0',
     title: 'Editor upgrades',
     notes: [

--- a/src/js/image/color.ts
+++ b/src/js/image/color.ts
@@ -10,11 +10,11 @@ import colorsys from 'colorsys'
 
 /***** Generic Colors *********************************************************/
 
-// N.B., color is a legacy function from the htdp library. Currently, we standardize
-// on Rgb as the stored color type for shapes.
-export function image_color(r: number, g: number, b: number, a: number): Rgb {
-  return image_rgb(r, g, b, a)
-}
+// N.B., `color` -- a legacy constructor from the htdp library -- was retired in
+// #103. It was a pure alias for `rgb` whose documentation had never matched it:
+// it listed its parameters as `r b g a` (the implementation took r, g, b, a),
+// declared a `string?` return while returning an rgb, and capped alpha at 1.
+// Rgb remains the stored color type for shapes; use `rgb` to build one.
 
 /** Converts between various representations of color in Scamper. */
 export function image_colorToRgb (v: any): Rgb {

--- a/src/lib/image.scm
+++ b/src/lib/image.scm
@@ -10,19 +10,6 @@
 ;;; @category html, typecheck, predicates, canvas?
 (define-export html? (js-var "html_isElement"))
 
-;;; (color r b g a) -> string?
-;;;  r : integer?
-;;;   0 <= r <= 255
-;;;  b : integer?
-;;;   0 <= b <= 255
-;;;  g : integer?
-;;;   0 <= g <= 255
-;;;  a : integer?
-;;;   0 <= a <= 1
-;;; Returns a string of the form `"rgba(r, g, b, a)"` appropriate for use as a color.
-;;; @category color, hsv, image, rgb, color-func, color?, find-colors, all-color-names
-(define-export color (js-var "image_color"))
-
 ;;; (color? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a valid color: a string containing a named color, an `rgb` value, or an `hsv` value.
@@ -319,7 +306,7 @@
 ;;;  width : integer?
 ;;;  height : integer?
 ;;;  fill : boolean?
-;;;  color : string?
+;;;  color : color?
 ;;; Returns a new drawing containing an ellipse with dimensions `width × height`.
 ;;; @category image, shapes, solid-ellipse, outlined-ellipse
 (define-export ellipse (js-var "image_ellipse"))
@@ -328,7 +315,7 @@
 ;;;  radius : number?
 ;;;  fill : string?
 ;;;   either "solid" or "outline"
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a circle of radius `radius`.
 ;;; @category image, shapes, solid-circle, outlined-circle
@@ -339,7 +326,7 @@
 ;;;  height : number?
 ;;;  fill : string?
 ;;;   either "solid" or "outline"
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a rectangle with dimensions `width × height`.
 ;;; @category image, shapes, solid-rectangle, outlined-rectangle
@@ -349,7 +336,7 @@
 ;;;  width : number?
 ;;;  fill : string?
 ;;;   either "solid" or "outline"
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a square with length `width`.
 ;;; @category image, shapes, solid-square, outlined-square
@@ -359,7 +346,7 @@
 ;;;  length : number?
 ;;;  fill : string?
 ;;;   either "solid" or "outline"
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a equilateral triangle with length `length`.
 ;;; @category image, shapes, solid-triangle, outlined-triangle
@@ -370,7 +357,7 @@
 ;;;  height : number?
 ;;;  fill : string?
 ;;;   either "solid" or "outline"
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a isosceles triangle with base `base` and height `height`.
 ;;; @category image, shapes, solid-isosceles-triangle, outlined-isosceles-triangle
@@ -383,7 +370,7 @@
 ;;;   a list of points, pairs of numbers
 ;;;  fill : string?
 ;;;   either "solid" or "outline"
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing with dimensions `width × height` formed by connecting the points in `points` with straight lines. The points are specified as a `pair` of coordinates.
 ;;; @category image, path, with-dash
@@ -471,7 +458,7 @@
 
 ;;; (solid-square width color) -> image?
 ;;;  width : number?
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a solid square with length `width`.
 ;;; @category image, shapes, square, outlined-square
@@ -479,7 +466,7 @@
 
 ;;; (outlined-square width color) -> image?
 ;;;  width : number?
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of an outline square with length `width`.
 ;;; @category image, shapes, square, solid-square
@@ -488,7 +475,7 @@
 ;;; (solid-rectangle width height color) -> image?
 ;;;  width : number?
 ;;;  height : number?
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a solid rectangle with dimensions `width × height`.
 ;;; @category image, shapes, rectangle, outlined-rectangle
@@ -497,7 +484,7 @@
 ;;; (outlined-rectangle width height color) -> image?
 ;;;  width : number?
 ;;;  height : number?
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of an outlined rectangle with dimensions `width × height`.
 ;;; @category image, shapes, rectangle, solid-rectangle
@@ -505,7 +492,7 @@
 
 ;;; (solid-circle radius color) -> image?
 ;;;  radius : number?
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a solid circle of radius `radius`.
 ;;; @category image, shapes, circle, outlined-circle
@@ -513,7 +500,7 @@
 
 ;;; (outlined-circle radius color) -> image?
 ;;;  radius : number?
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of an outlined circle of radius `radius`.
 ;;; @category image, shapes, circle, solid-circle
@@ -522,7 +509,7 @@
 ;;; (solid-ellipse width height color) -> image?
 ;;;  width : integer?
 ;;;  height : integer?
-;;;  color : string?
+;;;  color : color?
 ;;; Returns a new drawing containing a solid ellipse with dimensions `width × height`.
 ;;; @category image, shapes, ellipse, outlined-ellipse
 (define-export solid-ellipse (js-var "image_solidEllipse"))
@@ -530,14 +517,14 @@
 ;;; (outlined-ellipse width height color) -> image?
 ;;;  width : integer?
 ;;;  height : integer?
-;;;  color : string?
+;;;  color : color?
 ;;; Returns a new drawing containing an outlined ellipse with dimensions `width × height`.
 ;;; @category image, shapes, ellipse, solid-ellipse
 (define-export outlined-ellipse (js-var "image_outlinedEllipse"))
 
 ;;; (solid-triangle length color) -> image?
 ;;;  length : number?
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a solid equilateral triangle with length `length`.
 ;;; @category image, shapes, triangle, outlined-triangle
@@ -545,7 +532,7 @@
 
 ;;; (outlined-triangle length color) -> image?
 ;;;  length : number?
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of an outlined equilateral triangle with length `length`.
 ;;; @category image, shapes, triangle, solid-triangle
@@ -554,7 +541,7 @@
 ;;; (solid-isosceles-triangle width height color) -> image?
 ;;;  width : number?
 ;;;  height : number?
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a solid isosceles triangle with base `base` and height `height`.
 ;;; @category image, shapes, isosceles-triangle, outlined-isosceles-triangle
@@ -563,7 +550,7 @@
 ;;; (outlined-isosceles-triangle width height color) -> image?
 ;;;  width : number?
 ;;;  height : number?
-;;;  color : string?
+;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of an outlined isosceles triangle with base `base` and height `height`.
 ;;; @category image, shapes, isosceles-triangle, solid-isosceles-triangle
@@ -581,9 +568,9 @@
 ;;; @category image, image-width
 (define-export image-height (js-var "image_imageHeight"))
 
-;;; (image-color img) -> string?
+;;; (image-color img) -> rgb?
 ;;;  img : image?
-;;; Returns the color of the image.
+;;; Returns the color of the image. For a composite image, this is the average of its parts' colors.
 ;;; @category image, image-recolor
 (define-export image-color (js-var "image_imageColor"))
 

--- a/test/libs/image.test.ts
+++ b/test/libs/image.test.ts
@@ -5,29 +5,12 @@ import { image_isReactiveImageFile, image_withImageFile } from '../../src/js/ima
 import { image_imageWidth, image_imageHeight } from '../../src/js/image/drawing.js'
 
 describe('color', () => {
-  test('color', async () => {
-    expect(
-      await runProgram(`
-(import image)
-(color 255 0 0 255)
-(color 0 0 0 0)
-(color 300 0 0 255)
-(color -10 0 0 255)
-(color 255 0 0)
-(color 255.5 0 0 255)
-`),
-    ).toEqual([
-      '(rgba 255 0 0 255)',
-      '(rgba 0 0 0 0)',
-      // Components are clamped from above (Math.min(r, 255)): an integer above
-      // 255 is silently clamped rather than rejected, since color's own
-      // docstring contract only checks integer?, not the 0-255 range.
-      '(rgba 255 0 0 255)',
-      // ...and now clamped from below too (Math.max(0, ...)), so a negative
-      // integer is clamped to 0 rather than passing through (#259).
-      '(rgba 0 0 0 255)',
-      'Runtime error: Arity mismatch in function call: expected 4 arguments, got 3',
-      'Runtime error: (error) expected an integer, received number',
+  // N.B., the legacy `color` constructor was retired in #103 -- it was a pure
+  // alias for `rgb` whose docstring had never matched it. Its clamping and
+  // arity behavior is `rgb`'s, covered by the `rgb` test below.
+  test('color is no longer bound', async () => {
+    expect(await runProgram('(import image)\n(color 255 0 0 255)')).toEqual([
+      'Runtime error: Variable not found: color',
     ])
   })
 
@@ -623,6 +606,59 @@ describe('font', () => {
   })
 })
 
+// Every color parameter accepts any of the three color representations (#103).
+// Before that, shapes declared `color : string?`, so passing an rgb -- the most
+// natural thing to write -- failed its contract even though the implementation
+// converted it fine via image_colorToRgb.
+describe('color parameters accept every color representation', () => {
+  test('a name, an rgb, and an hsv all produce the same shape', async () => {
+    const red = '(rectangle 10 10 "solid" (rgba 255 0 0 255))'
+    expect(
+      await runProgram(`
+(import image)
+(solid-square 10 "red")
+(solid-square 10 (rgb 255 0 0))
+(solid-square 10 (hsv 0 100 100))
+`),
+    ).toEqual([red, red, red])
+  })
+
+  test('across the shape constructors, not just one', async () => {
+    expect(
+      await runProgram(`
+(import image)
+; N.B., ellipse's fill is a boolean while rectangle's is a "solid"/"outline"
+; string -- an inconsistency in its own right, but a fill-mode one, not a
+; color one, so out of scope here.
+(image-color (ellipse 10 20 #t (rgb 1 2 3)))
+(image-color (rectangle 10 20 "solid" (hsv 0 0 0)))
+(image-color (triangle 10 "solid" "red"))
+(image-color (path 10 10 (list (pair 0 0) (pair 5 5)) "solid" (rgb 4 5 6)))
+`),
+    ).toEqual([
+      '(rgba 1 2 3 255)',
+      '(rgba 0 0 0 255)',
+      '(rgba 255 0 0 255)',
+      '(rgba 4 5 6 255)',
+    ])
+  })
+
+  test('a value that is no color at all is still rejected', async () => {
+    expect(
+      await runProgram(`
+(import image)
+(solid-square 10 5)
+(solid-square 10 "not-a-color")
+(solid-square 10 (list 255 0 0))
+`),
+    ).toEqual([
+      'Runtime error: (error) expected a color, received number',
+      'Runtime error: (error) expected a color, received string',
+      'Runtime error: (error) expected a color, received list',
+    ])
+  })
+})
+
 describe('drawing', () => {
   describe('canvas?', () => {
     test('is true for a value made by make-canvas', async () => {
@@ -712,7 +748,7 @@ describe('drawing', () => {
       ])
     })
 
-    test('rejects a non-boolean fill or a non-string color', async () => {
+    test('rejects a non-boolean fill or a non-color', async () => {
       expect(
         await runProgram(`
 (import image)
@@ -721,7 +757,7 @@ describe('drawing', () => {
 `),
       ).toEqual([
         'Runtime error: (error) expected a boolean, received string',
-        'Runtime error: (error) expected a string, received number',
+        'Runtime error: (error) expected a color, received number',
       ])
     })
 
@@ -799,7 +835,7 @@ describe('drawing', () => {
       ).toEqual(['(rectangle 10 20 "diagonal" (rgba 255 0 0 255))'])
     })
 
-    test('rejects a non-numeric width, an unknown color name, or a non-string color', async () => {
+    test('rejects a non-numeric width, an unknown color name, or a non-color', async () => {
       expect(
         await runProgram(`
 (import image)
@@ -809,8 +845,10 @@ describe('drawing', () => {
 `),
       ).toEqual([
         'Runtime error: (error) expected a number, received string',
-        'Runtime error: (rectangle) color-name->rgb: unknown color name not-a-color',
-        'Runtime error: (error) expected a string, received number',
+        // An unknown name is now caught by the color? contract up front, rather
+      // than deep inside color-name->rgb.
+      'Runtime error: (error) expected a color, received string',
+        'Runtime error: (error) expected a color, received number',
       ])
     })
   })
@@ -1261,7 +1299,7 @@ describe('drawing', () => {
       ])
     })
 
-    test('reject a non-string color', async () => {
+    test('reject a non-color', async () => {
       expect(
         await runProgram(`
 (import image)
@@ -1269,8 +1307,8 @@ describe('drawing', () => {
 (outlined-square 10 5)
 `),
       ).toEqual([
-        'Runtime error: (error) expected a string, received number',
-        'Runtime error: (error) expected a string, received number',
+        'Runtime error: (error) expected a color, received number',
+        'Runtime error: (error) expected a color, received number',
       ])
     })
   })
@@ -1317,14 +1355,14 @@ describe('drawing', () => {
       ])
     })
 
-    test('reject a non-string color', async () => {
+    test('reject a non-color', async () => {
       expect(
         await runProgram(`
 (import image)
 (solid-circle 5 5)
 `),
       ).toEqual([
-        'Runtime error: (error) expected a string, received number',
+        'Runtime error: (error) expected a color, received number',
       ])
     })
   })

--- a/test/regressions/rgb-transform-arithmetic.test.ts
+++ b/test/regressions/rgb-transform-arithmetic.test.ts
@@ -68,20 +68,40 @@ describe('rgb-thin lowers alpha by 32 clamped at 0 (#259)', () => {
   })
 })
 
-describe('rgb/color clamps components on both ends of [0, 255] (#259)', () => {
+describe('rgb clamps components on both ends of [0, 255] (#259)', () => {
   // Old code only clamped from above (Math.min(x, 255)); negatives passed
   // through into color math and CSS rendering.
-  test('a negative channel clamps to 0, not through', async () => {
+  //
+  // N.B., these used to call the `color` constructor with an out-of-range
+  // component. That worked only because `color` declared its parameters
+  // `integer?` while `rgb` declares them `rgb-component?` (0-255) -- so `color`
+  // was the lenient door to the same clamping code, not a pure alias for `rgb`
+  // as it looked. With `color` retired in #103, out-of-range components can
+  // only arise the way #259 actually described: from color *arithmetic*. That
+  // is what these now exercise, and it is the reachable path.
+  test('a channel driven below 0 clamps to 0, not through', async () => {
     expect(await runProgram(`
 (import image)
-(color -10 0 0 255)
+(rgb-subtract (rgb 10 0 0) (rgb 50 0 0))
 `)).toEqual(['(rgba 0 0 0 255)'])
   })
 
-  test('an above-range channel still clamps to 255 (upper boundary)', async () => {
+  test('a channel driven above 255 still clamps to 255 (upper boundary)', async () => {
     expect(await runProgram(`
 (import image)
-(color 300 0 0 255)
+(rgb-add (rgb 200 0 0) (rgb 100 0 0))
 `)).toEqual(['(rgba 255 0 0 255)'])
+  })
+
+  test('the constructor itself rejects an out-of-range component', async () => {
+    // The other half of the guarantee: nothing out of range gets *in* by hand.
+    expect(await runProgram(`
+(import image)
+(rgb -10 0 0 255)
+(rgb 300 0 0 255)
+`, { stripRanges: true })).toEqual([
+      'Runtime error: (error) expected a rgb-component, received number',
+      'Runtime error: (error) expected a rgb-component, received number',
+    ])
   })
 })


### PR DESCRIPTION
Part 1 of #103 (the color checkbox). The other boxes stay unchecked.

```scheme
(solid-square 10 "red")             ; worked before
(solid-square 10 (rgb 255 0 0))     ; failed before — now works
(solid-square 10 (hsv 0 100 100))   ; failed before — now works
```

## What was actually wrong

`color?` already meant "named color string, `rgb`, or `hsv`", and every shape primitive already normalized its argument through `image_colorToRgb`. The implementation was universal all along.

But **19 color parameters in `image.scm` were declared `string?`** — and docstrings are what generate the contracts (`src/scheme/contract.ts`). So the contract rejected what the implementation would happily have accepted:

```
> (solid-square 10 (rgb 255 0 0))
Runtime error: (error) expected a string, received [Struct: rgba]
```

Widening those declarations to `color?` is the entire fix. **No JavaScript changed.** `canvas.scm` already declared `color?` throughout, so it needed nothing.

A side benefit: an unknown color name is now caught by the contract up front (`expected a color, received string`) instead of surfacing from deep inside `color-name->rgb`.

## Two documentation bugs found in the same pass

- `image-color` declared `-> string?` while returning an `rgb`.
- `color` declared `(color r b g a)` while the implementation took `(r, g, b, a)`; declared `-> string?` while returning an `rgb`; and capped alpha at `1` while accepting `255`. **Removed** — use `rgb`.

## The one subtlety worth reviewing

`color` looked like a pure alias for `rgb` — `image_color` literally called `image_rgb`. It wasn't, at the contract level: `color` declared its components `integer?` where `rgb` declares them `rgb-component?` (0–255). `color` was the *lenient door* to the same clamping code.

The #259 clamping regression depended on that door, and removing `color` made it unreachable. Rather than delete the regression, it now exercises clamping the way #259 actually described — "negatives passed through into color math" — via `rgb-add`/`rgb-subtract`, which is the reachable path and closer to the original bug:

```scheme
(rgb-subtract (rgb 10 0 0) (rgb 50 0 0))   ; => (rgba 0 0 0 255)
(rgb-add (rgb 200 0 0) (rgb 100 0 0))      ; => (rgba 255 0 0 255)
```

plus a new case pinning the other half of the guarantee: the constructor still rejects out-of-range components outright.

## Needs a version bump before release

The patch-notes entry is filed under **3.6.0** while `package.json` is at `3.5.0`. `patchNotesSince` only shows entries no newer than the current version, so the note stays invisible until someone bumps `package.json`. I left the bump out deliberately — there are three PRs in flight for #103 and each would collide on that line. **Bump it once when the batch ships.**

## Testing

New `describe` covering all three color representations producing identical shapes, across `ellipse`/`rectangle`/`triangle`/`path`, plus rejection of things that are no color at all. Existing contract-message expectations updated from "expected a string" to "expected a color".

Noticed but deliberately not fixed: `ellipse` takes a boolean `fill` while `rectangle` takes a `"solid"`/`"outline"` string. A real inconsistency, but a fill-mode one rather than a color one — it belongs with the deferred part 2.

`npm run validate` passes; lint unchanged at 1092.

_(Co-created with Claude Code)_