### PR TITLE
Standardize list/vector argument order on R7RS

### DIFF
--- a/src/app/web/patch-notes.ts
+++ b/src/app/web/patch-notes.ts
@@ -19,6 +19,14 @@ export interface PatchNote {
 
 export const patchNotes: PatchNote[] = [
   {
+    version: '3.6.0',
+    title: 'Argument order cleanup',
+    notes: [
+      'index-of now takes the value first: (index-of "b" lst), matching how member and assoc read.',
+      'for-range now takes its function first: (for-range f 0 10), like map, filter, and for-each.',
+    ],
+  },
+  {
     version: '3.5.0',
     title: 'Editor upgrades',
     notes: [

--- a/src/js/prelude/index.ts
+++ b/src/js/prelude/index.ts
@@ -537,7 +537,10 @@ export function prelude_listRef(l: L.List, n: number): L.Value {
 
 // Other list functions
 
-export function prelude_indexOf(l: L.List, v: L.Value): number {
+// N.B., the value comes first, matching R7RS's member/assoc family --
+// `(member obj list)`, `(assoc obj alist)` -- rather than the data-first order
+// the accessors use (#103).
+export function prelude_indexOf(v: L.Value, l: L.List): number {
   let i = 0
   while (l !== null) {
     if (L.equals(l.head, v)) {

--- a/src/lib/prelude.scm
+++ b/src/lib/prelude.scm
@@ -537,9 +537,9 @@
 ;;; @category list, association list, assoc-ref, deref, ref, ref-set!, string-ref
 (define-export list-ref (js-var "prelude_listRef"))
 
-;;; (index-of l v) -> integer?
-;;;  l : list?
+;;; (index-of v l) -> integer?
 ;;;  v : any
+;;;  l : list?
 ;;; Returns the index of the first occurrence of `v` in `l` or `-1` if `v` is not in `l`.
 ;;; @category list, list manipulation, association list, range, string-length, vector-length, vector-range, vector-ref 
 (define-export index-of (js-var "prelude_indexOf"))
@@ -953,8 +953,8 @@
 ;;; @category vectors, mutation, predicates, map, string-map, vector-append, vector-fill!, vector-filter, vector-for-each, vector-map, vector-set!
 (define-export vector-map!
   (lambda (f v)
-    (for-range 0 (vector-length v)
-      (lambda (i) (vector-set! v i (f (vector-ref v i)))))))
+    (for-range (lambda (i) (vector-set! v i (f (vector-ref v i))))
+      0 (vector-length v))))
 
 ;;; (vector-for-each f v) -> void?
 ;;;  f : procedure?
@@ -963,30 +963,30 @@
 ;;; @category vectors, vector-append, vector-fill!, vector-filter, vector-map, vector-map!, vector-set!
 (define-export vector-for-each
   (lambda (f v)
-    (for-range 0 (vector-length v)
-      (lambda (i) (f (vector-ref v i))))))
+    (for-range (lambda (i) (f (vector-ref v i)))
+      0 (vector-length v))))
 
-;;; (for-range beg end f) -> void?
+;;; (for-range f beg end) -> void?
+;;;  f : procedure?
 ;;;  beg : number?
 ;;;  end : number?
-;;;  f : procedure?
 ;;; Runs `f` on each integer in the range `[beg, end)`. `f` takes one argument, the current value of integer.
 ;;; @category other, fold-left, fold-right, list-of, map, reduce, reduce-right, apply, filter
 (define-export for-range
-  (lambda (beg end f)
+  (lambda (f beg end)
     (cond
-      [(< beg end) (begin (f beg) (for-range (+ beg 1) end f))]
-      [(> beg end) (begin (f beg) (for-range (- beg 1) end f))]
+      [(< beg end) (begin (f beg) (for-range f (+ beg 1) end))]
+      [(> beg end) (begin (f beg) (for-range f (- beg 1) end))]
       [else void])))
 
-;;; (vector-filter f l) -> list?
+;;; (vector-filter f v) -> vector?
 ;;;  f : procedure?
-;;;  l : vector?
-;;; Returns a new vector containing the elements of `l` for which `f` returns `#t`.
+;;;  v : vector?
+;;; Returns a new vector containing the elements of `v` for which `f` returns `#t`.
 ;;; @category vectors, vector-append, vector-fill!, vector-for-each, vector-map, vector-map!, vector-set!
 (define-export vector-filter
-  (lambda (f l)
-    (list->vector (filter f (vector->list l)))))
+  (lambda (f v)
+    (list->vector (filter f (vector->list v)))))
 
 ;;; (void? v) -> boolean?
 ;;;  v : any
@@ -1036,7 +1036,7 @@
 ;;; @category list, list creation, append, list-drop, list-tail, list-take, make-list, reverse, sort, index-of, length, string-length, vector-length, vector-range, vector-ref 
 (define-export range (js-var "prelude_range"))
 
-;;; (random n) -> list?
+;;; (random n) -> number?
 ;;;  n : integer?
 ;;;   n >= 0
 ;;; Returns a random number in the range 0 to n (exclusive).

--- a/test/libs/prelude.test.ts
+++ b/test/libs/prelude.test.ts
@@ -985,14 +985,27 @@ test('index-of', async () => {
     await runProgram(`
 (define l (list "a" "b" "c" "d" "e"))
 
-(index-of l "a")
-(index-of l "b")
-(index-of l "c")
-(index-of l "d")
-(index-of l "e")
-(index-of l "f")
+(index-of "a" l)
+(index-of "b" l)
+(index-of "c" l)
+(index-of "d" l)
+(index-of "e" l)
+(index-of "f" l)
 `),
   ).toEqual(['0', '1', '2', '3', '4', '-1'])
+})
+
+// Argument order standardized in #103: index-of takes the value first, matching
+// R7RS's member/assoc family -- (member obj list), (assoc obj alist) -- rather
+// than the data-first order the accessors (list-ref, vector-ref) use.
+test('index-of takes the value first', async () => {
+  expect(
+    await runProgram(`
+(index-of 3 (list 1 2 3 4))
+(index-of 9 (list 1 2 3))
+(index-of 1 null)
+`),
+  ).toEqual(['2', '-1', '-1'])
 })
 
 test('integer', async () => {
@@ -3115,13 +3128,13 @@ test('for-range', async () => {
   expect(
     await runProgram(`
 (define asc (ref null))
-(for-range 0 5 (lambda (i) (ref-set! asc (cons i (deref asc)))))
+(for-range (lambda (i) (ref-set! asc (cons i (deref asc)))) 0 5)
 (deref asc)
 (define desc (ref null))
-(for-range 5 0 (lambda (i) (ref-set! desc (cons i (deref desc)))))
+(for-range (lambda (i) (ref-set! desc (cons i (deref desc)))) 5 0)
 (deref desc)
 (define empty (ref null))
-(for-range 3 3 (lambda (i) (ref-set! empty (cons i (deref empty)))))
+(for-range (lambda (i) (ref-set! empty (cons i (deref empty)))) 3 3)
 (deref empty)
 `),
   ).toEqual([
@@ -3159,4 +3172,32 @@ test('with-handler-call', async () => {
   // No error is raised, so the handler is never invoked; with-handler returns
   // the thunk's result: (+ 1 2 3).
   expect(await runProgram('(with-handler + (lambda () (+ 1 2 3)))')).toEqual(['6'])
+})
+
+// #103: for-range takes its procedure first, like every other higher-order
+// function in the library (map, filter, fold, vector-map, vector-for-each,
+// string-map). It was the lone exception with the procedure last.
+test('for-range takes its procedure first, and vector-for-each still drives it', async () => {
+  expect(
+    await runProgram(`
+(define acc (ref null))
+(for-range (lambda (i) (ref-set! acc (cons i (deref acc)))) 0 4)
+(deref acc)
+(define acc2 (ref null))
+(vector-for-each (lambda (x) (ref-set! acc2 (cons x (deref acc2)))) (vector 7 8))
+(deref acc2)
+`),
+  ).toEqual(['void', '(list 3 2 1 0)', 'void', '(list 8 7)'])
+})
+
+// #103: vector-filter returns a vector, and said so only after its docstring
+// was corrected -- it had declared `-> list?`.
+test('vector-filter returns a vector', async () => {
+  expect(
+    await runProgram(`
+(vector-filter even? (vector 1 2 3 4))
+(vector? (vector-filter even? (vector 1 2)))
+(vector-filter even? (vector))
+`),
+  ).toEqual(['(vector 2 4)', '#t', '(vector)'])
 })

--- a/test/regressions/color-name-string-contract.test.ts
+++ b/test/regressions/color-name-string-contract.test.ts
@@ -19,7 +19,7 @@ test('color-name?/find-colors/color-name->rgb accept string arguments', async ()
   (rgb-green (color-name->rgb "red"))
   (rgb-blue (color-name->rgb "red"))
   (list? (find-colors "red"))
-  (>= (index-of (find-colors "red") "red") 0)
+  (>= (index-of "red" (find-colors "red")) 0)
   `)).toEqual([
     '#t',
     '#f',


### PR DESCRIPTION
Part 3 of #103 (the argument-order checkbox). The other boxes stay unchecked.

## The audit came back better than expected

The issue describes the library as split between "OCaml/Haskell convention with the recursive argument last" and "Scheme convention with the recursive argument first". Auditing it, **most of the library already matches R7RS/SRFI-1**:

- Higher-order functions already put the procedure first — `map`, `for-each`, `filter`, `fold`, `fold-left`, `fold-right`, `vector-map`, `vector-for-each`, `string-map`. That *is* the R7RS order; `(map proc list ...)` is what the standard says.
- Accessors already put the data first — `list-ref`, `list-tail`, `vector-ref`, `vector-set!`, `vector-fill!`, `reverse`, `list-take`, `list-drop` (SRFI-1 `take`/`drop`).
- The `assoc-*` family is object-first, matching R7RS `(assoc obj alist)`.

So this PR is small on purpose. **Exactly one procedure diverges from a standard**, and one more from the library's own convention.

## The changes

**`index-of` — the real divergence.** It took the list first. R7RS's `member`/`assoc` family is object-first, so:

```scheme
(index-of "b" lst)    ; was (index-of lst "b")
```

**`for-range` — internal inconsistency.** It was the lone higher-order function with its procedure *last*:

```scheme
(for-range f 0 10)    ; was (for-range 0 10 f)
```

Its two internal callers, `vector-map!` and `vector-for-each`, were updated with it — worth a look, since a miss there would have broken both silently. There's a test asserting `vector-for-each` still drives it correctly.

This is the change I'd most welcome a second opinion on: no standard forces it, and `(for-range 0 10 (lambda (i) ...))` arguably reads better when the body is long. It's here because the plan called for standardizing on the library's own dominant convention where no standard exists, and every other HOF is procedure-first.

**Two docstring bugs** found in the same sweep, neither an ordering issue: `vector-filter` declared `-> list?` while returning a vector (and named its vector parameter `l`), and `random` declared `-> list?` while returning a number.

## Deliberately not changed

- **`sort`** is data-first, `(sort l lt?)`, matching Racket. SRFI-132 is procedure-first, `(list-sort < lst)`. With no R7RS answer and the two conventions disagreeing, following Racket is as defensible as changing it — and it is one of the most-used procedures in course materials.
- **`reduce`** omits SRFI-1's `ridentity`. That's an arity and semantics change, not an ordering one, so it's out of scope here.

## Needs a version bump before release

The patch-notes entry is under **3.6.0** while `package.json` is at `3.5.0`, so it stays invisible until someone bumps it. Left out deliberately — #343, #344, and this PR would all collide on that line. **Bump once when the batch ships.**

`npm run validate` passes; lint unchanged at 1092.

_(Co-created with Claude Code)_