### PR TITLE
Split image into drawing / canvas / image

### DIFF
--- a/src/app/web/patch-notes.ts
+++ b/src/app/web/patch-notes.ts
@@ -30,6 +30,9 @@ export const patchNotes: PatchNote[] = [
       'index-of now takes the value first: (index-of "b" lst), matching how member and assoc read.',
       'for-range now takes its function first: (for-range f 0 10), like map, filter, and for-each.',
       'Maps built with { ... } now have functions to work with them: hash-ref, hash-set, hash-set!, hash-keys, and more.',
+      'Pictures built from shapes are now called drawings: image? is drawing?, image-width is drawing-width, and so on. shape? has been removed — use drawing?.',
+      'The pixel functions now say canvas, since that is what they work on: canvas->pixels, pixels->canvas, canvas-get-pixel, and drawing->canvas.',
+      'A shape\'s fill must now be "solid" or "outline". Anything else used to be accepted and then quietly drew nothing.',
     ],
   },
   {

--- a/src/js/canvas/index.ts
+++ b/src/js/canvas/index.ts
@@ -7,6 +7,17 @@ export function canvas_canvasQ(v: any): boolean {
   return v instanceof HTMLCanvasElement
 }
 
+// N.B., canvas-width/canvas-height used to be bound to the *drawing* accessors,
+// which accept either kind via a cast. Splitting them gives each an honest
+// contract (#103).
+export function canvas_canvasWidth(canvas: HTMLCanvasElement): number {
+  return canvas.width
+}
+
+export function canvas_canvasHeight(canvas: HTMLCanvasElement): number {
+  return canvas.height
+}
+
 export function canvas_makeCanvas(width: number, height: number): HTMLCanvasElement {
   const canvas = document.createElement('canvas')
   canvas.width = width

--- a/src/js/canvas/index.ts
+++ b/src/js/canvas/index.ts
@@ -1,7 +1,7 @@
 import * as L from '../../lpm'
-import { Drawing, image_render } from '../image/drawing.js'
-import { image_colorToRgb, image_rgbToString } from '../image/color.js'
-import { Font, image_font, image_fontQ, image_fontToFontString } from '../image/font.js'
+import { Drawing, drawing_render } from '../image/drawing.js'
+import { Rgb, color_colorToRgb, color_rgb, color_rgbToString } from '../image/color.js'
+import { Font, font_font, font_fontQ, font_fontToFontString } from '../image/font.js'
 
 export function canvas_canvasQ(v: any): boolean {
   return v instanceof HTMLCanvasElement
@@ -27,8 +27,8 @@ export function canvas_makeCanvas(width: number, height: number): HTMLCanvasElem
 
 export function canvas_canvasRectangle(canvas: HTMLCanvasElement, x: number, y: number, width: number, height: number, mode: string, color: any): void {
   const ctx = canvas.getContext('2d')!
-  ctx.fillStyle = image_rgbToString(image_colorToRgb(color))
-  ctx.strokeStyle = image_rgbToString(image_colorToRgb(color))
+  ctx.fillStyle = color_rgbToString(color_colorToRgb(color))
+  ctx.strokeStyle = color_rgbToString(color_colorToRgb(color))
   if (mode === 'solid') {
     ctx.fillRect(x, y, width, height)
   } else if (mode === 'outline') {
@@ -40,8 +40,8 @@ export function canvas_canvasRectangle(canvas: HTMLCanvasElement, x: number, y: 
 
 export function canvas_canvasEllipse(canvas: HTMLCanvasElement, x: number, y: number, radiusX: number, radiusY: number, rotation: number, startAngle: number, endAngle: number, mode: string, color: any): void {
   const ctx = canvas.getContext('2d')!
-  ctx.fillStyle = image_rgbToString(image_colorToRgb(color))
-  ctx.strokeStyle = image_rgbToString(image_colorToRgb(color))
+  ctx.fillStyle = color_rgbToString(color_colorToRgb(color))
+  ctx.strokeStyle = color_rgbToString(color_colorToRgb(color))
   ctx.beginPath()
   ctx.ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle)
   if (mode === 'solid') {
@@ -55,8 +55,8 @@ export function canvas_canvasEllipse(canvas: HTMLCanvasElement, x: number, y: nu
 
 export function canvas_canvasCircle(canvas: HTMLCanvasElement, x: number, y: number, radius: number, mode: string, color: string): void {
   const ctx = canvas.getContext('2d')!
-  ctx.fillStyle = image_rgbToString(image_colorToRgb(color))
-  ctx.strokeStyle = image_rgbToString(image_colorToRgb(color))
+  ctx.fillStyle = color_rgbToString(color_colorToRgb(color))
+  ctx.strokeStyle = color_rgbToString(color_colorToRgb(color))
   ctx.beginPath()
   ctx.arc(x, y, radius, 0, 2 * Math.PI)
   if (mode === 'solid') {
@@ -69,11 +69,11 @@ export function canvas_canvasCircle(canvas: HTMLCanvasElement, x: number, y: num
 }
 
 export function canvas_canvasText(canvas: HTMLCanvasElement, x: number, y: number, text: string, size: number, mode: string, color: any, ...rest: any[]): void {
-  let f: Font = image_font('Arial')
+  let f: Font = font_font('Arial')
   if (rest.length > 1) {
     throw new L.ScamperError('Runtime', `wrong number of arguments to canvas-text! provided. Expected 7 or 8, received ${arguments.length}.`)
   } else if (rest.length == 1) {
-    if (image_fontQ(rest[0])) {
+    if (font_fontQ(rest[0])) {
       f = rest[0] as Font
     } else {
       throw new L.ScamperError('Runtime', `expected a font, received ${L.typeOf(rest[0])}`)
@@ -81,9 +81,9 @@ export function canvas_canvasText(canvas: HTMLCanvasElement, x: number, y: numbe
   }
 
   const ctx = canvas.getContext('2d')!
-  ctx.fillStyle = image_rgbToString(image_colorToRgb(color))
-  ctx.strokeStyle = image_rgbToString(image_colorToRgb(color))
-  ctx.font = image_fontToFontString(f, size)
+  ctx.fillStyle = color_rgbToString(color_colorToRgb(color))
+  ctx.strokeStyle = color_rgbToString(color_colorToRgb(color))
+  ctx.font = font_fontToFontString(f, size)
   if (mode === 'solid') {
     ctx.fillText(text, x, y)
   } else if (mode === 'outline') {
@@ -94,7 +94,7 @@ export function canvas_canvasText(canvas: HTMLCanvasElement, x: number, y: numbe
 }
 
 export function canvas_canvasDrawing(canvas: HTMLCanvasElement, x: number, y: number, drawing: Drawing): void {
-  image_render(x, y, drawing, canvas)
+  drawing_render(x, y, drawing, canvas)
 }
 
 export function canvas_canvasPath(canvas: HTMLCanvasElement, lst: L.List, mode: string, color: any): void {
@@ -107,8 +107,8 @@ export function canvas_canvasPath(canvas: HTMLCanvasElement, lst: L.List, mode: 
     return
   }
 
-  ctx.fillStyle = image_rgbToString(image_colorToRgb(color))
-  ctx.strokeStyle = image_rgbToString(image_colorToRgb(color))
+  ctx.fillStyle = color_rgbToString(color_colorToRgb(color))
+  ctx.strokeStyle = color_rgbToString(color_colorToRgb(color))
   ctx.beginPath()
   let p: L.Pair = pairs[0] as L.Pair
   ctx.moveTo(p.fst as number, p.snd as number)
@@ -155,3 +155,74 @@ export function canvas_canvasOnclick(canvas: HTMLCanvasElement, fn: L.ScamperFn)
   )
 }
 
+/***** Per-pixel manipulation *************************************************/
+
+// N.B., pixel-map is now defined in image.scm (Scheme) on top of image->pixels,
+// vector-map, and pixels->image -- a JS implementation can no longer call the
+// per-pixel Scamper function (callScamperFn is disabled).
+
+export function canvas_canvasGetPixel(canvas: HTMLCanvasElement, x: number, y: number): L.Struct {
+  const ctx = canvas.getContext('2d')!
+  const img = ctx.getImageData(x, y, 1, 1)
+  const data = img.data
+  return color_rgb(data[0], data[1], data[2], data[3])
+}
+
+/***** Pixels ****************************************************************/
+
+/**
+ * Pixels: a vector of rgb values, what canvas->pixels produces and
+ * pixels->canvas consumes. There is no distinct runtime type -- this is the
+ * contract the pixel operations were previously declared `any` for.
+ */
+export function canvas_pixelsQ(v: L.Value): boolean {
+  return L.isArray(v) && v.every((p) => L.isStructKind(p, 'rgba'))
+}
+
+export function canvas_canvasToPixels(canvas: HTMLCanvasElement): L.Struct[] {
+  const ctx = canvas.getContext('2d')!
+  const src = ctx.getImageData(0, 0, canvas.width, canvas.height).data
+  const ret = []
+  for (let i = 0; i < src.length; i += 4) {
+    ret.push(color_rgb(src[i], src[i + 1], src[i + 2], src[i + 3]))
+  }
+  return ret
+}
+
+export function canvas_pixelsToCanvas(pixels: L.Struct[], width: number, height: number): HTMLCanvasElement {
+  const ret = document.createElement('canvas')
+  ret.width = width
+  ret.height = height
+  const ctx = ret.getContext('2d')!
+  const outImg = ctx.createImageData(width, height)
+  const data = outImg.data
+  for (let i = 0; i < pixels.length; i++) {
+    const c = pixels[i] as Rgb
+    data[i*4] = c.red
+    data[i*4 + 1] = c.green
+    data[i*4 + 2] = c.blue
+    data[i*4 + 3] = c.alpha
+  }
+  ctx.putImageData(outImg, 0, 0)
+  return ret
+}
+
+export function canvas_canvasSetPixels(canvas: HTMLCanvasElement, pixels: L.Struct[]): void {
+  const ctx = canvas.getContext('2d')!
+  const outImg = ctx.createImageData(canvas.width, canvas.height)
+  const data = outImg.data
+  for (let i = 0; i < pixels.length; i++) {
+    const c = pixels[i] as Rgb
+    data[i*4] = c.red
+    data[i*4 + 1] = c.green
+    data[i*4 + 2] = c.blue
+    data[i*4 + 3] = c.alpha
+  }
+  ctx.putImageData(outImg, 0, 0)
+}
+
+/***** Exports ****************************************************************/
+
+// Image loading
+
+// Per-pixel manipulation

--- a/src/js/image/color.ts
+++ b/src/js/image/color.ts
@@ -17,20 +17,20 @@ import colorsys from 'colorsys'
 // Rgb remains the stored color type for shapes; use `rgb` to build one.
 
 /** Converts between various representations of color in Scamper. */
-export function image_colorToRgb (v: any): Rgb {
+export function color_colorToRgb (v: any): Rgb {
   if (L.isStructKind(v, 'rgba')) {
     return v as Rgb
   } else if (typeof v === 'string') {
-    return image_colorNameToRgb(v)
+    return color_colorNameToRgb(v)
   } else if (L.isStructKind(v, 'hsv')) {
-    return image_hsvToRgb(v as Hsv)
+    return color_hsvToRgb(v as Hsv)
   } else {
     throw new L.ScamperError('Runtime', `Shapes expect a valid color, received a: ${L.typeOf(v)}`)
   }
 }
 
-export function image_colorQ (v: any): boolean {
-  return (typeof v === 'string' && image_isColorName(v)) ||
+export function color_colorQ (v: any): boolean {
+  return (typeof v === 'string' && color_isColorName(v)) ||
     L.isStructKind(v, 'rgba') ||
     L.isStructKind(v, 'hsv')
 }
@@ -45,15 +45,15 @@ export interface Rgb extends L.Struct {
   alpha: number
 }
 
-export function image_isRgbComponent(n: number): boolean {
+export function color_isRgbComponent(n: number): boolean {
   return n >= 0 && n <= 255
 }
 
-export function image_isRgb (v: any): boolean {
+export function color_isRgb (v: any): boolean {
   return L.isStructKind(v, 'rgba')
 }
 
-export function image_rgb(...args: number[]): Rgb {
+export function color_rgb(...args: number[]): Rgb {
   if (args.length !== 3 && args.length !== 4) {
     throw new L.ScamperError('Runtime', `rgb: expects 3 or 4 arguments, but got ${args.length}`)
   }
@@ -67,23 +67,23 @@ export function image_rgb(...args: number[]): Rgb {
   })
 }
 
-export function image_rgbRed(rgba: Rgb): number {
+export function color_rgbRed(rgba: Rgb): number {
   return rgba.red
 }
 
-export function image_rgbGreen(rgba: Rgb): number {
+export function color_rgbGreen(rgba: Rgb): number {
   return rgba.green
 }
 
-export function image_rgbBlue(rgba: Rgb): number {
+export function color_rgbBlue(rgba: Rgb): number {
   return rgba.blue
 }
 
-export function image_rgbAlpha(rgba: Rgb): number {
+export function color_rgbAlpha(rgba: Rgb): number {
   return rgba.alpha
 }
 
-export function image_rgbDistance(rgba1: Rgb, rgba2: Rgb): number {
+export function color_rgbDistance(rgba1: Rgb, rgba2: Rgb): number {
   return Math.sqrt(
     Math.pow(rgba1.red - rgba2.red, 2) +
     Math.pow(rgba1.green - rgba2.green, 2) +
@@ -94,158 +94,158 @@ export function image_rgbDistance(rgba1: Rgb, rgba2: Rgb): number {
 /***** Color Names ************************************************************/
 
 const namedCssColors = new Map<string, Rgb>([
-  ['aliceblue', image_rgb(240, 248, 255)],
-  ['antiquewhite', image_rgb(250, 235, 215)],
-  ['aqua', image_rgb(0, 255, 255)],
-  ['aquamarine', image_rgb(127, 255, 212)],
-  ['azure', image_rgb(240, 255, 255)],
-  ['beige', image_rgb(245, 245, 220)],
-  ['bisque', image_rgb(255, 228, 196)],
-  ['black', image_rgb(0, 0, 0)],
-  ['blanchedalmond', image_rgb(255, 235, 205)],
-  ['blue', image_rgb(0, 0, 255)],
-  ['blueviolet', image_rgb(138, 43, 226)],
-  ['brown', image_rgb(165, 42, 42)],
-  ['burlywood', image_rgb(222, 184, 135)],
-  ['cadetblue', image_rgb(95, 158, 160)],
-  ['chartreuse', image_rgb(127, 255, 0)],
-  ['chocolate', image_rgb(210, 105, 30)],
-  ['coral', image_rgb(255, 127, 80)],
-  ['cornflowerblue', image_rgb(100, 149, 237)],
-  ['cornsilk', image_rgb(255, 248, 220)],
-  ['crimson', image_rgb(220, 20, 60)],
-  ['cyan', image_rgb(0, 255, 255)],
-  ['darkblue', image_rgb(0, 0, 139)],
-  ['darkcyan', image_rgb(0, 139, 139)],
-  ['darkgoldenrod', image_rgb(184, 134, 11)],
-  ['darkgray', image_rgb(169, 169, 169)],
-  ['darkgreen', image_rgb(0, 100, 0)],
-  ['darkkhaki', image_rgb(189, 183, 107)],
-  ['darkmagenta', image_rgb(139, 0, 139)],
-  ['darkolivegreen', image_rgb(85, 107, 47)],
-  ['darkorange', image_rgb(255, 140, 0)],
-  ['darkorchid', image_rgb(153, 50, 204)],
-  ['darkred', image_rgb(139, 0, 0)],
-  ['darksalmon', image_rgb(233, 150, 122)],
-  ['darkseagreen', image_rgb(143, 188, 143)],
-  ['darkslateblue', image_rgb(72, 61, 139)],
-  ['darkslategray', image_rgb(47, 79, 79)],
-  ['darkturquoise', image_rgb(0, 206, 209)],
-  ['darkviolet', image_rgb(148, 0, 211)],
-  ['deeppink', image_rgb(255, 20, 147)],
-  ['deepskyblue', image_rgb(0, 191, 255)],
-  ['dimgray', image_rgb(105, 105, 105)],
-  ['dodgerblue', image_rgb(30, 144, 255)],
-  ['firebrick', image_rgb(178, 34, 34)],
-  ['floralwhite', image_rgb(255, 250, 240)],
-  ['forestgreen', image_rgb(34, 139, 34)],
-  ['fuchsia', image_rgb(255, 0, 255)],
-  ['gainsboro', image_rgb(220, 220, 220)],
-  ['ghostwhite', image_rgb(248, 248, 255)],
-  ['gold', image_rgb(255, 215, 0)],
-  ['goldenrod', image_rgb(218, 165, 32)],
-  ['gray', image_rgb(128, 128, 128)],
-  ['green', image_rgb(0, 128, 0)],
-  ['greenyellow', image_rgb(173, 255, 47)],
-  ['honeydew', image_rgb(240, 255, 240)],
-  ['hotpink', image_rgb(255, 105, 180)],
-  ['indianred', image_rgb(205, 92, 92)],
-  ['indigo', image_rgb(75, 0, 130)],
-  ['ivory', image_rgb(255, 255, 240)],
-  ['khaki', image_rgb(240, 230, 140)],
-  ['lavender', image_rgb(230, 230, 250)],
-  ['lavenderblush', image_rgb(255, 240, 245)],
-  ['lawngreen', image_rgb(124, 252, 0)],
-  ['lemonchiffon', image_rgb(255, 250, 205)],
-  ['lightblue', image_rgb(173, 216, 230)],
-  ['lightcoral', image_rgb(240, 128, 128)],
-  ['lightcyan', image_rgb(224, 255, 255)],
-  ['lightgoldenrodyellow', image_rgb(250, 250, 210)],
-  ['lightgray', image_rgb(211, 211, 211)],
-  ['lightgreen', image_rgb(144, 238, 144)],
-  ['lightpink', image_rgb(255, 182, 193)],
-  ['lightsalmon', image_rgb(255, 160, 122)],
-  ['lightseagreen', image_rgb(32, 178, 170)],
-  ['lightskyblue', image_rgb(135, 206, 250)],
-  ['lightslategray', image_rgb(119, 136, 153)],
-  ['lightsteelblue', image_rgb(176, 196, 222)],
-  ['lightyellow', image_rgb(255, 255, 224)],
-  ['lime', image_rgb(0, 255, 0)],
-  ['limegreen', image_rgb(50, 205, 50)],
-  ['linen', image_rgb(250, 240, 230)],
-  ['magenta', image_rgb(255, 0, 255)],
-  ['maroon', image_rgb(128, 0, 0)],
-  ['mediumaquamarine', image_rgb(102, 205, 170)],
-  ['mediumblue', image_rgb(0, 0, 205)],
-  ['mediumorchid', image_rgb(186, 85, 211)],
-  ['mediumpurple', image_rgb(147, 112, 219)],
-  ['mediumseagreen', image_rgb(60, 179, 113)],
-  ['mediumslateblue', image_rgb(123, 104, 238)],
-  ['mediumspringgreen', image_rgb(0, 250, 154)],
-  ['mediumturquoise', image_rgb(72, 209, 204)],
-  ['mediumvioletred', image_rgb(199, 21, 133)],
-  ['midnightblue', image_rgb(25, 25, 112)],
-  ['mintcream', image_rgb(245, 255, 250)],
-  ['mistyrose', image_rgb(255, 228, 225)],
-  ['moccasin', image_rgb(255, 228, 181)],
-  ['navajowhite', image_rgb(255, 222, 173)],
-  ['navy', image_rgb(0, 0, 128)],
-  ['oldlace', image_rgb(253, 245, 230)],
-  ['olive', image_rgb(128, 128, 0)],
-  ['olivedrab', image_rgb(107, 142, 35)],
-  ['orange', image_rgb(255, 165, 0)],
-  ['orangered', image_rgb(255, 69, 0)],
-  ['orchid', image_rgb(218, 112, 214)],
-  ['palegoldenrod', image_rgb(238, 232, 170)],
-  ['palegreen', image_rgb(152, 251, 152)],
-  ['paleturquoise', image_rgb(175, 238, 238)],
-  ['palevioletred', image_rgb(219, 112, 147)],
-  ['papayawhip', image_rgb(255, 239, 213)],
-  ['peachpuff', image_rgb(255, 218, 185)],
-  ['peru', image_rgb(205, 133, 63)],
-  ['pink', image_rgb(255, 192, 203)],
-  ['plum', image_rgb(221, 160, 221)],
-  ['powderblue', image_rgb(176, 224, 230)],
-  ['purple', image_rgb(128, 0, 128)],
-  ['rebeccapurple', image_rgb(102, 51, 153)],
-  ['red', image_rgb(255, 0, 0)],
-  ['rosybrown', image_rgb(188, 143, 143)],
-  ['royalblue', image_rgb(65, 105, 225)],
-  ['saddlebrown', image_rgb(139, 69, 19)],
-  ['salmon', image_rgb(250, 128, 114)],
-  ['sandybrown', image_rgb(244, 164, 96)],
-  ['seagreen', image_rgb(46, 139, 87)],
-  ['seashell', image_rgb(255, 245, 238)],
-  ['sienna', image_rgb(160, 82, 45)],
-  ['silver', image_rgb(192, 192, 192)],
-  ['skyblue', image_rgb(135, 206, 235)],
-  ['slateblue', image_rgb(106, 90, 205)],
-  ['slategray', image_rgb(112, 128, 144)],
-  ['snow', image_rgb(255, 250, 250)],
-  ['springgreen', image_rgb(0, 255, 127)],
-  ['steelblue', image_rgb(70, 130, 180)],
-  ['tan', image_rgb(210, 180, 140)],
-  ['teal', image_rgb(0, 128, 128)],
-  ['thistle', image_rgb(216, 191, 216)],
-  ['tomato', image_rgb(255, 99, 71)],
-  ['turquoise', image_rgb(64, 224, 208)],
-  ['violet', image_rgb(238, 130, 238)],
-  ['wheat', image_rgb(245, 222, 179)],
-  ['white', image_rgb(255, 255, 255)],
-  ['whitesmoke', image_rgb(245, 245, 245)],
-  ['yellow', image_rgb(255, 255, 0)],
-  ['yellowgreen', image_rgb(154, 205, 50)]
+  ['aliceblue', color_rgb(240, 248, 255)],
+  ['antiquewhite', color_rgb(250, 235, 215)],
+  ['aqua', color_rgb(0, 255, 255)],
+  ['aquamarine', color_rgb(127, 255, 212)],
+  ['azure', color_rgb(240, 255, 255)],
+  ['beige', color_rgb(245, 245, 220)],
+  ['bisque', color_rgb(255, 228, 196)],
+  ['black', color_rgb(0, 0, 0)],
+  ['blanchedalmond', color_rgb(255, 235, 205)],
+  ['blue', color_rgb(0, 0, 255)],
+  ['blueviolet', color_rgb(138, 43, 226)],
+  ['brown', color_rgb(165, 42, 42)],
+  ['burlywood', color_rgb(222, 184, 135)],
+  ['cadetblue', color_rgb(95, 158, 160)],
+  ['chartreuse', color_rgb(127, 255, 0)],
+  ['chocolate', color_rgb(210, 105, 30)],
+  ['coral', color_rgb(255, 127, 80)],
+  ['cornflowerblue', color_rgb(100, 149, 237)],
+  ['cornsilk', color_rgb(255, 248, 220)],
+  ['crimson', color_rgb(220, 20, 60)],
+  ['cyan', color_rgb(0, 255, 255)],
+  ['darkblue', color_rgb(0, 0, 139)],
+  ['darkcyan', color_rgb(0, 139, 139)],
+  ['darkgoldenrod', color_rgb(184, 134, 11)],
+  ['darkgray', color_rgb(169, 169, 169)],
+  ['darkgreen', color_rgb(0, 100, 0)],
+  ['darkkhaki', color_rgb(189, 183, 107)],
+  ['darkmagenta', color_rgb(139, 0, 139)],
+  ['darkolivegreen', color_rgb(85, 107, 47)],
+  ['darkorange', color_rgb(255, 140, 0)],
+  ['darkorchid', color_rgb(153, 50, 204)],
+  ['darkred', color_rgb(139, 0, 0)],
+  ['darksalmon', color_rgb(233, 150, 122)],
+  ['darkseagreen', color_rgb(143, 188, 143)],
+  ['darkslateblue', color_rgb(72, 61, 139)],
+  ['darkslategray', color_rgb(47, 79, 79)],
+  ['darkturquoise', color_rgb(0, 206, 209)],
+  ['darkviolet', color_rgb(148, 0, 211)],
+  ['deeppink', color_rgb(255, 20, 147)],
+  ['deepskyblue', color_rgb(0, 191, 255)],
+  ['dimgray', color_rgb(105, 105, 105)],
+  ['dodgerblue', color_rgb(30, 144, 255)],
+  ['firebrick', color_rgb(178, 34, 34)],
+  ['floralwhite', color_rgb(255, 250, 240)],
+  ['forestgreen', color_rgb(34, 139, 34)],
+  ['fuchsia', color_rgb(255, 0, 255)],
+  ['gainsboro', color_rgb(220, 220, 220)],
+  ['ghostwhite', color_rgb(248, 248, 255)],
+  ['gold', color_rgb(255, 215, 0)],
+  ['goldenrod', color_rgb(218, 165, 32)],
+  ['gray', color_rgb(128, 128, 128)],
+  ['green', color_rgb(0, 128, 0)],
+  ['greenyellow', color_rgb(173, 255, 47)],
+  ['honeydew', color_rgb(240, 255, 240)],
+  ['hotpink', color_rgb(255, 105, 180)],
+  ['indianred', color_rgb(205, 92, 92)],
+  ['indigo', color_rgb(75, 0, 130)],
+  ['ivory', color_rgb(255, 255, 240)],
+  ['khaki', color_rgb(240, 230, 140)],
+  ['lavender', color_rgb(230, 230, 250)],
+  ['lavenderblush', color_rgb(255, 240, 245)],
+  ['lawngreen', color_rgb(124, 252, 0)],
+  ['lemonchiffon', color_rgb(255, 250, 205)],
+  ['lightblue', color_rgb(173, 216, 230)],
+  ['lightcoral', color_rgb(240, 128, 128)],
+  ['lightcyan', color_rgb(224, 255, 255)],
+  ['lightgoldenrodyellow', color_rgb(250, 250, 210)],
+  ['lightgray', color_rgb(211, 211, 211)],
+  ['lightgreen', color_rgb(144, 238, 144)],
+  ['lightpink', color_rgb(255, 182, 193)],
+  ['lightsalmon', color_rgb(255, 160, 122)],
+  ['lightseagreen', color_rgb(32, 178, 170)],
+  ['lightskyblue', color_rgb(135, 206, 250)],
+  ['lightslategray', color_rgb(119, 136, 153)],
+  ['lightsteelblue', color_rgb(176, 196, 222)],
+  ['lightyellow', color_rgb(255, 255, 224)],
+  ['lime', color_rgb(0, 255, 0)],
+  ['limegreen', color_rgb(50, 205, 50)],
+  ['linen', color_rgb(250, 240, 230)],
+  ['magenta', color_rgb(255, 0, 255)],
+  ['maroon', color_rgb(128, 0, 0)],
+  ['mediumaquamarine', color_rgb(102, 205, 170)],
+  ['mediumblue', color_rgb(0, 0, 205)],
+  ['mediumorchid', color_rgb(186, 85, 211)],
+  ['mediumpurple', color_rgb(147, 112, 219)],
+  ['mediumseagreen', color_rgb(60, 179, 113)],
+  ['mediumslateblue', color_rgb(123, 104, 238)],
+  ['mediumspringgreen', color_rgb(0, 250, 154)],
+  ['mediumturquoise', color_rgb(72, 209, 204)],
+  ['mediumvioletred', color_rgb(199, 21, 133)],
+  ['midnightblue', color_rgb(25, 25, 112)],
+  ['mintcream', color_rgb(245, 255, 250)],
+  ['mistyrose', color_rgb(255, 228, 225)],
+  ['moccasin', color_rgb(255, 228, 181)],
+  ['navajowhite', color_rgb(255, 222, 173)],
+  ['navy', color_rgb(0, 0, 128)],
+  ['oldlace', color_rgb(253, 245, 230)],
+  ['olive', color_rgb(128, 128, 0)],
+  ['olivedrab', color_rgb(107, 142, 35)],
+  ['orange', color_rgb(255, 165, 0)],
+  ['orangered', color_rgb(255, 69, 0)],
+  ['orchid', color_rgb(218, 112, 214)],
+  ['palegoldenrod', color_rgb(238, 232, 170)],
+  ['palegreen', color_rgb(152, 251, 152)],
+  ['paleturquoise', color_rgb(175, 238, 238)],
+  ['palevioletred', color_rgb(219, 112, 147)],
+  ['papayawhip', color_rgb(255, 239, 213)],
+  ['peachpuff', color_rgb(255, 218, 185)],
+  ['peru', color_rgb(205, 133, 63)],
+  ['pink', color_rgb(255, 192, 203)],
+  ['plum', color_rgb(221, 160, 221)],
+  ['powderblue', color_rgb(176, 224, 230)],
+  ['purple', color_rgb(128, 0, 128)],
+  ['rebeccapurple', color_rgb(102, 51, 153)],
+  ['red', color_rgb(255, 0, 0)],
+  ['rosybrown', color_rgb(188, 143, 143)],
+  ['royalblue', color_rgb(65, 105, 225)],
+  ['saddlebrown', color_rgb(139, 69, 19)],
+  ['salmon', color_rgb(250, 128, 114)],
+  ['sandybrown', color_rgb(244, 164, 96)],
+  ['seagreen', color_rgb(46, 139, 87)],
+  ['seashell', color_rgb(255, 245, 238)],
+  ['sienna', color_rgb(160, 82, 45)],
+  ['silver', color_rgb(192, 192, 192)],
+  ['skyblue', color_rgb(135, 206, 235)],
+  ['slateblue', color_rgb(106, 90, 205)],
+  ['slategray', color_rgb(112, 128, 144)],
+  ['snow', color_rgb(255, 250, 250)],
+  ['springgreen', color_rgb(0, 255, 127)],
+  ['steelblue', color_rgb(70, 130, 180)],
+  ['tan', color_rgb(210, 180, 140)],
+  ['teal', color_rgb(0, 128, 128)],
+  ['thistle', color_rgb(216, 191, 216)],
+  ['tomato', color_rgb(255, 99, 71)],
+  ['turquoise', color_rgb(64, 224, 208)],
+  ['violet', color_rgb(238, 130, 238)],
+  ['wheat', color_rgb(245, 222, 179)],
+  ['white', color_rgb(255, 255, 255)],
+  ['whitesmoke', color_rgb(245, 245, 245)],
+  ['yellow', color_rgb(255, 255, 0)],
+  ['yellowgreen', color_rgb(154, 205, 50)]
 ])
 
-export function image_isColorName(name: string): boolean {
+export function color_isColorName(name: string): boolean {
   return namedCssColors.has(name.toLowerCase())
 }
 
-export function image_allColorNames(): L.List {
+export function color_allColorNames(): L.List {
   return L.mkList(...Array.from(namedCssColors.keys()))
 }
 
-export function image_findColors(name: string): L.List {
+export function color_findColors(name: string): L.List {
   const results = []
   for (const [key, _value] of namedCssColors) {
     if (key.includes(name.toLowerCase())) {
@@ -264,7 +264,7 @@ function fracToPercentString(n: number, m: number): string {
   return `${Math.trunc(n/m * 100)}%`
 }
 
-export function image_rgbToString (rgba: Rgb): string {
+export function color_rgbToString (rgba: Rgb): string {
   return `rgb(${rgba.red}  ${rgba.green}  ${rgba.blue} / ${fracToPercentString(rgba.alpha, 255)})`
 }
 
@@ -288,13 +288,13 @@ export interface Hsv extends L.Struct {
   alpha: number
 }
 
-export function image_isHsv(v: any): boolean {
+export function color_isHsv(v: any): boolean {
   return L.isStructKind(v, 'hsv')
 }
 
 // hsv
 
-export function image_hsv(...args: number[]): Hsv {
+export function color_hsv(...args: number[]): Hsv {
   if (args.length !== 3 && args.length !== 4) {
     throw new L.ScamperError('Runtime', `hsv: expects 3 or 4 arguments, but got ${args.length}`)
   }
@@ -324,30 +324,30 @@ export function image_hsv(...args: number[]): Hsv {
   })
 }
 
-export function image_hsvHue(hsv: Hsv): number {
+export function color_hsvHue(hsv: Hsv): number {
   return hsv.hue
 }
 
-export function image_hsvSaturation(hsv: Hsv): number {
+export function color_hsvSaturation(hsv: Hsv): number {
   return hsv.saturation
 }
 
-export function image_hsvValue(hsv: Hsv): number {
+export function color_hsvValue(hsv: Hsv): number {
   return hsv.value
 }
 
-export function image_hsvAlpha(hsv: Hsv): number {
+export function color_hsvAlpha(hsv: Hsv): number {
   return hsv.alpha
 }
 
-export function image_hsvComplement(h: Hsv): Hsv {
-  return image_hsv((h.hue + 180) % 360, h.saturation, h.value, h.alpha)
+export function color_hsvComplement(h: Hsv): Hsv {
+  return color_hsv((h.hue + 180) % 360, h.saturation, h.value, h.alpha)
 }
 
 // N.B., translated from the csc151 mediascheme implementation:
 // https://github.com/grinnell-cs/csc151/blob/8dbcc594fbb5e3579e08ccc897c5fba7d973b779/colors.rkt#L379
 
-export function image_rgbHue(r: Rgb): number {
+export function color_rgbHue(r: Rgb): number {
   return rgbHueHelper(r.red, r.green, r.blue)
 }
 
@@ -371,7 +371,7 @@ function fixHue(h: number): number {
   return Math.round(60 * (h < 0 ? h + 6 : h))
 }
 
-export function image_rgbSaturation(r: Rgb): number {
+export function color_rgbSaturation(r: Rgb): number {
   return rgbSaturationHelper(Math.min(r.red, r.green, r.blue),
                              Math.max(r.red, r.green, r.blue))
 }
@@ -380,16 +380,16 @@ function rgbSaturationHelper(min: number, max: number): number {
   return max === 0 ? 0 : 100 * ((max - min) / max)
 }
 
-export function image_rgbValue(r: Rgb): number {
+export function color_rgbValue(r: Rgb): number {
   return Math.round(100 * (Math.max(r.red, r.green, r.blue) / 255))
 }
 
-export function image_rgbToHsv(r: Rgb) {
+export function color_rgbToHsv(r: Rgb) {
   const ret = colorsys.rgbToHsv(r.red, r.green, r.blue)
-  return image_hsv(ret.h, ret.s, ret.v, r.alpha)
+  return color_hsv(ret.h, ret.s, ret.v, r.alpha)
 }
 
-export function image_hsvToString(hsv: Hsv): string {
+export function color_hsvToString(hsv: Hsv): string {
   return `hsv(${hsv.hue} ${fracToPercentString(hsv.saturation, 100)}  ${fracToPercentString(hsv.value, 100)} / ${fracToPercentString(hsv.alpha, 255)})`
 }
 
@@ -399,8 +399,8 @@ export function image_hsvToString(hsv: Hsv): string {
 
 /***** Color conversion *******************************************************/
 
-export function image_colorNameToRgb(name: string): Rgb {
-  if (!image_isColorName(name)) {
+export function color_colorNameToRgb(name: string): Rgb {
+  if (!color_isColorName(name)) {
     throw new L.ScamperError('Runtime', `color-name->rgb: unknown color name ${name}`)
   }
   return namedCssColors.get(name)!
@@ -409,9 +409,9 @@ export function image_colorNameToRgb(name: string): Rgb {
 // rgb->color-name
 // color->rgb
 
-export function image_hsvToRgb(hsv: Hsv): Rgb {
+export function color_hsvToRgb(hsv: Hsv): Rgb {
   const ret = colorsys.hsvToRgb(hsv.hue, hsv.saturation, hsv.value)
-  return image_rgb(ret.r, ret.g, ret.b, hsv.alpha)
+  return color_rgb(ret.r, ret.g, ret.b, hsv.alpha)
 }
 
 // color->color-name
@@ -432,8 +432,8 @@ export function image_hsvToRgb(hsv: Hsv): Rgb {
 
 /***** Color transformations **************************************************/
 
-export function image_rgbDarker(rgba: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbDarker(rgba: Rgb): Rgb {
+  return color_rgb(
     Math.max(0, rgba.red - 16),
     Math.max(0, rgba.green - 16),
     Math.max(0, rgba.blue - 16),
@@ -441,8 +441,8 @@ export function image_rgbDarker(rgba: Rgb): Rgb {
   )
 }
 
-export function image_rgbLighter(rgba: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbLighter(rgba: Rgb): Rgb {
+  return color_rgb(
     Math.min(255, rgba.red + 16),
     Math.min(255, rgba.green + 16),
     Math.min(255, rgba.blue + 16),
@@ -450,8 +450,8 @@ export function image_rgbLighter(rgba: Rgb): Rgb {
   )
 }
 
-export function image_rgbRedder(rgba: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbRedder(rgba: Rgb): Rgb {
+  return color_rgb(
     Math.min(255, rgba.red + 32),
     Math.max(0, rgba.green - 16),
     Math.max(0, rgba.blue - 16),
@@ -459,8 +459,8 @@ export function image_rgbRedder(rgba: Rgb): Rgb {
   )
 }
 
-export function image_rgbBluer(rgba: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbBluer(rgba: Rgb): Rgb {
+  return color_rgb(
     Math.max(0, rgba.red - 16),
     Math.max(0, rgba.green - 16),
     Math.min(255, rgba.blue + 32),
@@ -468,8 +468,8 @@ export function image_rgbBluer(rgba: Rgb): Rgb {
   )
 }
 
-export function image_rgbGreener(rgba: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbGreener(rgba: Rgb): Rgb {
+  return color_rgb(
     Math.max(0, rgba.red - 16),
     Math.min(255, rgba.green + 32),
     Math.max(0, rgba.blue - 16),
@@ -477,8 +477,8 @@ export function image_rgbGreener(rgba: Rgb): Rgb {
   )
 }
 
-export function image_rgbPseudoComplement(rgba: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbPseudoComplement(rgba: Rgb): Rgb {
+  return color_rgb(
     255 - rgba.red,
     255 - rgba.green,
     255 - rgba.blue,
@@ -488,14 +488,14 @@ export function image_rgbPseudoComplement(rgba: Rgb): Rgb {
 
 // rgb-complement
 
-export function image_rgbGreyscale(rgba: Rgb): Rgb {
+export function color_rgbGreyscale(rgba: Rgb): Rgb {
   const avg = 0.30 * rgba.red + 0.59 * rgba.green + 0.11 * rgba.blue
-  return image_rgb(avg, avg, avg, rgba.alpha)
+  return color_rgb(avg, avg, avg, rgba.alpha)
 }
 
-export function image_rgbPhaseshift(rgba: Rgb): Rgb {
+export function color_rgbPhaseshift(rgba: Rgb): Rgb {
   const shift = 128
-  return image_rgb(
+  return color_rgb(
     (rgba.red + shift) % 256,
     (rgba.green + shift) % 256,
     (rgba.blue + shift) % 256,
@@ -503,12 +503,12 @@ export function image_rgbPhaseshift(rgba: Rgb): Rgb {
   )
 }
 
-export function image_rgbRotateComponents(rgba: Rgb): Rgb {
-  return image_rgb(rgba.green, rgba.blue, rgba.red, rgba.alpha)
+export function color_rgbRotateComponents(rgba: Rgb): Rgb {
+  return color_rgb(rgba.green, rgba.blue, rgba.red, rgba.alpha)
 }
 
-export function image_rgbThin(rgba: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbThin(rgba: Rgb): Rgb {
+  return color_rgb(
     rgba.red,
     rgba.green,
     rgba.blue,
@@ -516,8 +516,8 @@ export function image_rgbThin(rgba: Rgb): Rgb {
   )
 }
 
-export function image_rgbThicken(rgba: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbThicken(rgba: Rgb): Rgb {
+  return color_rgb(
     rgba.red,
     rgba.green,
     rgba.blue,
@@ -527,8 +527,8 @@ export function image_rgbThicken(rgba: Rgb): Rgb {
 
 /***** Color combinations *****************************************************/
 
-export function image_rgbAdd(rgba1: Rgb, rgba2: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbAdd(rgba1: Rgb, rgba2: Rgb): Rgb {
+  return color_rgb(
     Math.min(255, rgba1.red + rgba2.red),
     Math.min(255, rgba1.green + rgba2.green),
     Math.min(255, rgba1.blue + rgba2.blue),
@@ -536,8 +536,8 @@ export function image_rgbAdd(rgba1: Rgb, rgba2: Rgb): Rgb {
   )
 }
 
-export function image_rgbSubtract(rgba1: Rgb, rgba2: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbSubtract(rgba1: Rgb, rgba2: Rgb): Rgb {
+  return color_rgb(
     Math.max(0, rgba1.red - rgba2.red),
     Math.max(0, rgba1.green - rgba2.green),
     Math.max(0, rgba1.blue - rgba2.blue),
@@ -545,8 +545,8 @@ export function image_rgbSubtract(rgba1: Rgb, rgba2: Rgb): Rgb {
   )
 }
 
-export function image_rgbAverage(rgba1: Rgb, rgba2: Rgb): Rgb {
-  return image_rgb(
+export function color_rgbAverage(rgba1: Rgb, rgba2: Rgb): Rgb {
+  return color_rgb(
     (rgba1.red + rgba2.red) / 2,
     (rgba1.green + rgba2.green) / 2,
     (rgba1.blue + rgba2.blue) / 2,

--- a/src/js/image/drawing.ts
+++ b/src/js/image/drawing.ts
@@ -7,6 +7,11 @@ import { Font, image_font, image_fontQ, image_fontToFontString } from './font.js
 type Mode = 'solid' | 'outline'
 export type Drawing = Ellipse | Rectangle | Triangle | Path | Beside | Above | Overlay | OverlayOffset | Rotate | WithDash | DText
 
+/** A fill mode: the string "solid" or "outline". */
+export function image_fillModeQ (v: any): boolean {
+  return v === 'solid' || v === 'outline'
+}
+
 export function image_drawingQ (v: any): boolean {
   return L.isStructKind(v, 'ellipse') || L.isStructKind(v, 'rectangle') ||
          L.isStructKind(v, 'triangle') || L.isStructKind(v, 'path') ||
@@ -486,6 +491,17 @@ export function image_drawingToImage(drawing: Drawing): HTMLCanvasElement {
 
 /***** Rendering **************************************************************/
 
+// N.B., a mode that is neither 'solid' nor 'outline' used to fall through every
+// branch and draw *nothing*, silently -- which is what (ellipse w h #t color)
+// did, the very call ellipse's own (wrong) `boolean?` contract demanded. The
+// fill-mode? contract now stops that at construction; this is the backstop.
+function badMode(mode: unknown): L.ScamperError {
+  return new L.ScamperError(
+    'Runtime',
+    `Cannot draw a shape whose fill is ${JSON.stringify(mode)}: expected "solid" or "outline"`,
+  )
+}
+
 export function image_render (x: number, y: number, drawing: Drawing, canvas: HTMLCanvasElement) {
   const ctx = canvas.getContext('2d')!
   switch (drawing[L.structKind]) {
@@ -502,6 +518,8 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
         ctx.fill()
       } else if (drawing.mode === 'outline') {
         ctx.stroke()
+      } else {
+        throw badMode(drawing.mode)
       }
       break
     }
@@ -512,6 +530,8 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
         ctx.fillRect(x, y, drawing.width, drawing.height)
       } else if (drawing.mode === 'outline') {
         ctx.strokeRect(x, y, drawing.width, drawing.height)
+      } else {
+        throw badMode(drawing.mode)
       }
       break
     }
@@ -531,6 +551,8 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
         ctx.fill()
       } else if (drawing.mode === 'outline') {
         ctx.stroke()
+      } else {
+        throw badMode(drawing.mode)
       }
       break
     }

--- a/src/js/image/drawing.ts
+++ b/src/js/image/drawing.ts
@@ -1,6 +1,6 @@
 import * as L from '../../lpm'
-import { Rgb, image_rgb, image_colorToRgb, image_rgbAverage, image_rgbToString } from './color.js'
-import { Font, image_font, image_fontQ, image_fontToFontString } from './font.js'
+import { Rgb, color_rgb, color_colorToRgb, color_rgbAverage, color_rgbToString } from './color.js'
+import { Font, font_font, font_fontQ, font_fontToFontString } from './font.js'
 
 /***** Core Functions *********************************************************/
 
@@ -8,11 +8,11 @@ type Mode = 'solid' | 'outline'
 export type Drawing = Ellipse | Rectangle | Triangle | Path | Beside | Above | Overlay | OverlayOffset | Rotate | WithDash | DText
 
 /** A fill mode: the string "solid" or "outline". */
-export function image_fillModeQ (v: any): boolean {
+export function drawing_fillModeQ (v: any): boolean {
   return v === 'solid' || v === 'outline'
 }
 
-export function image_drawingQ (v: any): boolean {
+export function drawing_drawingQ (v: any): boolean {
   return L.isStructKind(v, 'ellipse') || L.isStructKind(v, 'rectangle') ||
          L.isStructKind(v, 'triangle') || L.isStructKind(v, 'path') ||
          L.isStructKind(v, 'beside') || L.isStructKind(v, 'above') ||
@@ -35,14 +35,14 @@ interface Ellipse extends L.Struct {
 
 const ellipsePrim = (width: number, height: number, mode: Mode, color: any): Ellipse => ({
   [L.scamperTag]: 'struct', [L.structKind]: 'ellipse',
-  width, height, mode, color: image_colorToRgb(color)
+  width, height, mode, color: color_colorToRgb(color)
 })
 
-export function image_ellipse(width: number, height: number, mode: Mode, color: any): Ellipse {
+export function drawing_ellipse(width: number, height: number, mode: Mode, color: any): Ellipse {
   return ellipsePrim(width, height, mode, color)
 }
 
-export function image_circle(radius: number, mode: Mode, color: any): Ellipse {
+export function drawing_circle(radius: number, mode: Mode, color: any): Ellipse {
   return ellipsePrim(radius * 2, radius * 2, mode, color)
 }
 
@@ -56,14 +56,14 @@ interface Rectangle extends L.Struct {
 
 const rectanglePrim = (width: number, height: number, mode: Mode, color: any): Rectangle => ({
   [L.scamperTag]: 'struct', [L.structKind]: 'rectangle',
-  width, height, mode, color: image_colorToRgb(color)
+  width, height, mode, color: color_colorToRgb(color)
 })
 
-export function image_rectangle(width: number, height: number, mode: Mode, color: any): Rectangle {
+export function drawing_rectangle(width: number, height: number, mode: Mode, color: any): Rectangle {
   return rectanglePrim(width, height, mode, color)
 }
 
-export function image_square(length: number, mode: Mode, color: any): Rectangle {
+export function drawing_square(length: number, mode: Mode, color: any): Rectangle {
   return rectanglePrim(length, length, mode, color)
 }
 
@@ -77,14 +77,14 @@ interface Triangle extends L.Struct {
 
 const trianglePrim = (width: number, height: number, mode: Mode, color: any): Triangle => ({
   [L.scamperTag]: 'struct', [L.structKind]: 'triangle',
-  width, height, mode, color: image_colorToRgb(color)
+  width, height, mode, color: color_colorToRgb(color)
 })
 
-export function image_triangle(length: number, mode: Mode, color: any): Triangle {
+export function drawing_triangle(length: number, mode: Mode, color: any): Triangle {
   return trianglePrim(length, length * Math.sqrt(3) / 2, mode, color)
 }
 
-export function image_isoscelesTriangle(width: number, height: number, mode: Mode, color: any): Triangle {
+export function drawing_isoscelesTriangle(width: number, height: number, mode: Mode, color: any): Triangle {
   return trianglePrim(width, height, mode, color)
 }
 
@@ -99,10 +99,10 @@ interface Path extends L.Struct {
 
 const pathPrim = (width: number, height: number, points: [number, number][], mode: Mode, color: any): Path => ({
   [L.scamperTag]: 'struct', [L.structKind]: 'path',
-  width, height, points, mode, color: image_colorToRgb(color)
+  width, height, points, mode, color: color_colorToRgb(color)
 })
 
-export function image_path(width: number, height: number, points: L.List, mode: Mode, color: any): Path {
+export function drawing_path(width: number, height: number, points: L.List, mode: Mode, color: any): Path {
   return pathPrim(width, height,
     L.listToVector(points).map((p: L.Value) => [(p as L.Pair).fst, (p as L.Pair).snd]) as [number, number][],
     mode, color)
@@ -124,11 +124,11 @@ const besideAlignPrim = (align: string, ...drawings: Drawing[]): Beside => ({
   drawings
 })
 
-export function image_beside(...drawings: Drawing[]): Beside {
+export function drawing_beside(...drawings: Drawing[]): Beside {
   return besideAlignPrim('center', ...drawings)
 }
 
-export function image_besideAlign(align: string, ...drawings: Drawing[]): Beside {
+export function drawing_besideAlign(align: string, ...drawings: Drawing[]): Beside {
   return besideAlignPrim(align, ...drawings)
 }
 
@@ -148,11 +148,11 @@ const aboveAlignPrim = (align: string, ...drawings: Drawing[]): Above => ({
   drawings
 })
 
-export function image_above(...drawings: Drawing[]): Above {
+export function drawing_above(...drawings: Drawing[]): Above {
   return aboveAlignPrim('middle', ...drawings)
 }
 
-export function image_aboveAlign(align: string, ...drawings: Drawing[]): Above {
+export function drawing_aboveAlign(align: string, ...drawings: Drawing[]): Above {
   return aboveAlignPrim(align, ...drawings)
 }
 
@@ -174,11 +174,11 @@ const overlayAlignPrim = (xAlign: string, yAlign: string, ...drawings: Drawing[]
   drawings
 })
 
-export function image_overlay(...drawings: Drawing[]) {
+export function drawing_overlay(...drawings: Drawing[]) {
   return overlayAlignPrim('middle', 'center', ...drawings)
 }
 
-export function image_overlayAlign(xAlign: string, yAlign: string, ...drawings: Drawing[]): Overlay {
+export function drawing_overlayAlign(xAlign: string, yAlign: string, ...drawings: Drawing[]): Overlay {
   return overlayAlignPrim(xAlign, yAlign, ...drawings)
 }
 
@@ -204,7 +204,7 @@ function overlayOffsetPrim (dx: number, dy: number, width: number, height: numbe
   }
 }
 
-export function image_overlayOffset(dx: number, dy: number, d1: Drawing, d2: Drawing): OverlayOffset {
+export function drawing_overlayOffset(dx: number, dy: number, d1: Drawing, d2: Drawing): OverlayOffset {
   // N.B., tricky! Need to account for whether (a) we are shifting the smaller
   // or larger image and (b) whether we are shifting it positively or
   // negatively.
@@ -267,7 +267,7 @@ function calculateRotatedBox (points: [number, number][], degrees: number): { wi
   }
 }
 
-export function image_rotate(angle: number, drawing: Drawing): Rotate {
+export function drawing_rotate(angle: number, drawing: Drawing): Rotate {
   // Rotate the drawing's declared bounding-box corners. At angle 0 this is the
   // identity for every shape (box = w x h, dx = dy = 0), so `rotate` never
   // shifts, clips, or resizes a drawing it isn't actually turning.
@@ -297,7 +297,7 @@ interface WithDash extends L.Struct {
   height: number
 }
 
-export function image_withDash(dashSpec: number[], drawing: Drawing): WithDash {
+export function drawing_withDash(dashSpec: number[], drawing: Drawing): WithDash {
   return {
     [L.scamperTag]: 'struct', [L.structKind]: 'withDash',
     dashSpec,
@@ -320,16 +320,16 @@ function textPrim (width: number, height: number, text: string,
     font: Font, size: number, color: any): DText {
   return {
     [L.scamperTag]: 'struct', [L.structKind]: 'text',
-    width, height, text, size, color: image_colorToRgb(color), font
+    width, height, text, size, color: color_colorToRgb(color), font
   }
 }
 
-export function image_text(text: string, size: number, color: Rgb, ...rest: any[]): DText {
-  let f: Font = image_font('Arial')
+export function drawing_text(text: string, size: number, color: Rgb, ...rest: any[]): DText {
+  let f: Font = font_font('Arial')
   if (rest.length > 1) {
     throw new L.ScamperError('Runtime', `wrong number of arguments to text provided. Expected 3 or 4, received ${3 + rest.length}.`)
-  } else if (rest.length == 1 && image_fontQ(rest[0])) {
-    if (image_fontQ(rest[0])) {
+  } else if (rest.length == 1 && font_fontQ(rest[0])) {
+    if (font_fontQ(rest[0])) {
       f = rest[0] as Font
     } else {
       throw new L.ScamperError('Runtime', `expected a font, received ${L.typeOf(rest[0])}`)
@@ -340,8 +340,8 @@ export function image_text(text: string, size: number, color: Rgb, ...rest: any[
   // temporary canvas to measure the text's dimensions.
   const canvas = document.createElement('canvas')
   const ctx = canvas.getContext('2d')!
-  ctx.font = image_fontToFontString(f, size)
-  console.log(image_fontToFontString(f, size))
+  ctx.font = font_fontToFontString(f, size)
+  console.log(font_fontToFontString(f, size))
   const met = ctx.measureText(text)
   const width = met.width
   const height = met.actualBoundingBoxAscent + met.actualBoundingBoxDescent + 1
@@ -351,74 +351,74 @@ export function image_text(text: string, size: number, color: Rgb, ...rest: any[
 
 /***** Extended Functions *****************************************************/
 
-export function image_solidSquare(length: number, color: any): Rectangle {
-  return image_square(length, 'solid', color)
+export function drawing_solidSquare(length: number, color: any): Rectangle {
+  return drawing_square(length, 'solid', color)
 }
 
-export function image_outlinedSquare(length: number, color: any): Rectangle {
-  return image_square(length, 'outline', color)
+export function drawing_outlinedSquare(length: number, color: any): Rectangle {
+  return drawing_square(length, 'outline', color)
 }
 
-export function image_solidRectangle(width: number, height: number, color: any): Rectangle {
-  return image_rectangle(width, height, 'solid', color)
+export function drawing_solidRectangle(width: number, height: number, color: any): Rectangle {
+  return drawing_rectangle(width, height, 'solid', color)
 }
 
-export function image_outlinedRectangle(width: number, height: number, color: any): Rectangle {
-  return image_rectangle(width, height, 'outline', color)
+export function drawing_outlinedRectangle(width: number, height: number, color: any): Rectangle {
+  return drawing_rectangle(width, height, 'outline', color)
 }
 
-export function image_solidCircle(radius: number, color: any): Ellipse {
-  return image_circle(radius, 'solid', color)
+export function drawing_solidCircle(radius: number, color: any): Ellipse {
+  return drawing_circle(radius, 'solid', color)
 }
 
-export function image_outlinedCircle(radius: number, color: any): Ellipse {
-  return image_circle(radius, 'outline', color)
+export function drawing_outlinedCircle(radius: number, color: any): Ellipse {
+  return drawing_circle(radius, 'outline', color)
 }
 
-export function image_solidEllipse(width: number, height: number, color: any): Ellipse {
-  return image_ellipse(width, height, 'solid', color)
+export function drawing_solidEllipse(width: number, height: number, color: any): Ellipse {
+  return drawing_ellipse(width, height, 'solid', color)
 }
 
-export function image_outlinedEllipse(width: number, height: number, color: any): Ellipse {
-  return image_ellipse(width, height, 'outline', color)
+export function drawing_outlinedEllipse(width: number, height: number, color: any): Ellipse {
+  return drawing_ellipse(width, height, 'outline', color)
 }
 
-export function image_solidTriangle(length: number, color: any): Triangle {
-  return image_triangle(length, 'solid', color)
+export function drawing_solidTriangle(length: number, color: any): Triangle {
+  return drawing_triangle(length, 'solid', color)
 }
 
-export function image_outlinedTriangle(length: number, color: any): Triangle {
-  return image_triangle(length, 'outline', color)
+export function drawing_outlinedTriangle(length: number, color: any): Triangle {
+  return drawing_triangle(length, 'outline', color)
 }
 
-export function image_solidIsoscelesTriangle(width: number, height: number, color: any): Triangle {
-  return image_isoscelesTriangle(width, height, 'solid', color)
+export function drawing_solidIsoscelesTriangle(width: number, height: number, color: any): Triangle {
+  return drawing_isoscelesTriangle(width, height, 'solid', color)
 }
 
-export function image_outlinedIsoscelesTriangle(width: number, height: number, color: any): Triangle {
-  return image_isoscelesTriangle(width, height, 'outline', color)
+export function drawing_outlinedIsoscelesTriangle(width: number, height: number, color: any): Triangle {
+  return drawing_isoscelesTriangle(width, height, 'outline', color)
 }
 
 // TODO: this need to be factored out to a general image lib that handles both
 // drawings and canvases.
 
-export function image_imageWidth(drawing: Drawing): number {
-  if (image_drawingQ(drawing)) {
+export function drawing_drawingWidth(drawing: Drawing): number {
+  if (drawing_drawingQ(drawing)) {
     return drawing.width
   } else {
     return (drawing as unknown as HTMLCanvasElement).width
   }
 }
 
-export function image_imageHeight(drawing: Drawing): number {
-  if (image_drawingQ(drawing)) {
+export function drawing_drawingHeight(drawing: Drawing): number {
+  if (drawing_drawingQ(drawing)) {
     return drawing.height
   } else {
     return (drawing as unknown as HTMLCanvasElement).height
   }
 }
 
-export function image_imageColor(drawing: Drawing): Rgb {
+export function drawing_drawingColor(drawing: Drawing): Rgb {
   switch(drawing[L.structKind]) {
     case 'ellipse':
     case 'rectangle':
@@ -429,24 +429,24 @@ export function image_imageColor(drawing: Drawing): Rgb {
     case 'beside':
     case 'above':
     case 'overlay': {
-      let avg = image_imageColor(drawing.drawings[0])
+      let avg = drawing_drawingColor(drawing.drawings[0])
       for (let i = 1; i < drawing.drawings.length; i++) {
-        avg = image_rgbAverage(avg, image_imageColor(drawing.drawings[i]))
+        avg = color_rgbAverage(avg, drawing_drawingColor(drawing.drawings[i]))
       }
       return avg
     }
     case 'overlayOffset':
-      return image_rgbAverage(image_imageColor(drawing.d1), image_imageColor(drawing.d2))
+      return color_rgbAverage(drawing_drawingColor(drawing.d1), drawing_drawingColor(drawing.d2))
     case 'rotate':
-      return image_imageColor(drawing.drawing)
+      return drawing_drawingColor(drawing.drawing)
     case 'withDash':
-      return image_imageColor(drawing.drawing)
+      return drawing_drawingColor(drawing.drawing)
     case 'text':
       return drawing.color
   }
 }
 
-export function image_imageRecolor(drawing: Drawing, color: any): Drawing {
+export function drawing_drawingRecolor(drawing: Drawing, color: any): Drawing {
   switch(drawing[L.structKind]) {
     case 'ellipse':
       return ellipsePrim(drawing.width, drawing.height, drawing.mode, color)
@@ -457,36 +457,36 @@ export function image_imageRecolor(drawing: Drawing, color: any): Drawing {
     case 'path':
       return pathPrim(drawing.width, drawing.height, drawing.points, drawing.mode, color)
     case 'beside':
-      return besideAlignPrim(drawing.align, ...drawing.drawings.map(d => image_imageRecolor(d, color)))
+      return besideAlignPrim(drawing.align, ...drawing.drawings.map(d => drawing_drawingRecolor(d, color)))
     case 'above':
-      return aboveAlignPrim(drawing.align, ...drawing.drawings.map(d => image_imageRecolor(d, color)))
+      return aboveAlignPrim(drawing.align, ...drawing.drawings.map(d => drawing_drawingRecolor(d, color)))
     case 'overlay':
-      return overlayAlignPrim(drawing.xAlign, drawing.yAlign, ...drawing.drawings.map(d => image_imageRecolor(d, color)))
+      return overlayAlignPrim(drawing.xAlign, drawing.yAlign, ...drawing.drawings.map(d => drawing_drawingRecolor(d, color)))
     case 'overlayOffset':
-      return overlayOffsetPrim(drawing.dx, drawing.dy, drawing.width, drawing.height, image_imageRecolor(drawing.d1, color), image_imageRecolor(drawing.d2, color))
+      return overlayOffsetPrim(drawing.dx, drawing.dy, drawing.width, drawing.height, drawing_drawingRecolor(drawing.d1, color), drawing_drawingRecolor(drawing.d2, color))
     case 'rotate':
-      return image_rotate(drawing.angle, image_imageRecolor(drawing.drawing, color))
+      return drawing_rotate(drawing.angle, drawing_drawingRecolor(drawing.drawing, color))
     case 'withDash':
-      return image_withDash(drawing.dashSpec, image_imageRecolor(drawing.drawing, color))
+      return drawing_withDash(drawing.dashSpec, drawing_drawingRecolor(drawing.drawing, color))
     case 'text':
       return textPrim(drawing.width, drawing.height, drawing.text,
         drawing.font, drawing.size, drawing.color)
   }
 }
 
-export function image_drawingToPixels(drawing: Drawing): Rgb[] {
-  const canvas = image_renderer(drawing) as HTMLCanvasElement
+export function drawing_drawingToPixels(drawing: Drawing): Rgb[] {
+  const canvas = drawing_renderer(drawing) as HTMLCanvasElement
   const ctx = canvas.getContext('2d')!
   const src = ctx.getImageData(0, 0, canvas.width, canvas.height).data
   const ret = []
   for (let i = 0; i < src.length; i += 4) {
-    ret.push(image_rgb(src[i], src[i + 1], src[i + 2], src[i + 3]))
+    ret.push(color_rgb(src[i], src[i + 1], src[i + 2], src[i + 3]))
   }
   return ret
 }
 
-export function image_drawingToImage(drawing: Drawing): HTMLCanvasElement {
-  return image_renderer(drawing) as HTMLCanvasElement
+export function drawing_drawingToCanvas(drawing: Drawing): HTMLCanvasElement {
+  return drawing_renderer(drawing) as HTMLCanvasElement
 }
 
 /***** Rendering **************************************************************/
@@ -502,12 +502,12 @@ function badMode(mode: unknown): L.ScamperError {
   )
 }
 
-export function image_render (x: number, y: number, drawing: Drawing, canvas: HTMLCanvasElement) {
+export function drawing_render (x: number, y: number, drawing: Drawing, canvas: HTMLCanvasElement) {
   const ctx = canvas.getContext('2d')!
   switch (drawing[L.structKind]) {
     case 'ellipse': {
-      ctx.fillStyle = image_rgbToString(drawing.color)
-      ctx.strokeStyle = image_rgbToString(drawing.color)
+      ctx.fillStyle = color_rgbToString(drawing.color)
+      ctx.strokeStyle = color_rgbToString(drawing.color)
       const radiusX = drawing.width / 2
       const radiusY = drawing.height / 2
       const centerX = x + radiusX
@@ -524,8 +524,8 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
       break
     }
     case 'rectangle': {
-      ctx.fillStyle = image_rgbToString(drawing.color)
-      ctx.strokeStyle = image_rgbToString(drawing.color)
+      ctx.fillStyle = color_rgbToString(drawing.color)
+      ctx.strokeStyle = color_rgbToString(drawing.color)
       if (drawing.mode === 'solid') {
         ctx.fillRect(x, y, drawing.width, drawing.height)
       } else if (drawing.mode === 'outline') {
@@ -536,8 +536,8 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
       break
     }
     case 'triangle': {
-      ctx.fillStyle = image_rgbToString(drawing.color)
-      ctx.strokeStyle = image_rgbToString(drawing.color)
+      ctx.fillStyle = color_rgbToString(drawing.color)
+      ctx.strokeStyle = color_rgbToString(drawing.color)
       ctx.beginPath()
       // Start in the bottom-left corner of the triangle...
       ctx.moveTo(x, y + drawing.height)
@@ -558,8 +558,8 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
     }
     case 'path': {
       if (drawing.points.length === 0) { break }
-      ctx.fillStyle = image_rgbToString(drawing.color)
-      ctx.strokeStyle = image_rgbToString(drawing.color)
+      ctx.fillStyle = color_rgbToString(drawing.color)
+      ctx.strokeStyle = color_rgbToString(drawing.color)
       ctx.beginPath()
       ctx.moveTo(x + drawing.points[0][0], y + drawing.points[0][1])
       drawing.points.slice(1).forEach(p => {
@@ -574,7 +574,7 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
     }
     case 'beside': {
       drawing.drawings.forEach(d => {
-        image_render(
+        drawing_render(
           x,
           drawing.align === 'top'
             ? y
@@ -590,7 +590,7 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
     }
     case 'above': {
       drawing.drawings.forEach(d => {
-        image_render(
+        drawing_render(
           drawing.align === 'left'
             ? x
             : drawing.align === 'right'
@@ -607,7 +607,7 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
     case 'overlay': {
       // N.B., need to draw in reverse order to get the overlay effect to work
       [...drawing.drawings].reverse().forEach(d => {
-        image_render(
+        drawing_render(
           drawing.xAlign === 'left'
             ? x
             : drawing.xAlign === 'right'
@@ -631,8 +631,8 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
       const x2 = drawing.dx > 0 ? x + drawing.dx : x
       const y2 = drawing.dy > 0 ? y + drawing.dy : y
       // N.B., render d2 first so d1 is on top
-      image_render(x2, y2, drawing.d2, canvas)
-      image_render(x1, y1, drawing.d1, canvas)
+      drawing_render(x2, y2, drawing.d2, canvas)
+      drawing_render(x1, y1, drawing.d1, canvas)
       break
     }
     case 'rotate': {
@@ -645,7 +645,7 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
       ctx.translate(offsetX, offsetY)
       ctx.rotate(angle)
       
-      image_render(0, 0, drawing.drawing, canvas)
+      drawing_render(0, 0, drawing.drawing, canvas)
       
       ctx.rotate(-angle)
       ctx.translate(-offsetX, -offsetY)
@@ -653,13 +653,13 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
     }
     case 'withDash': {
       ctx.setLineDash(drawing.dashSpec)
-      image_render(x, y, drawing.drawing, canvas)
+      drawing_render(x, y, drawing.drawing, canvas)
       ctx.setLineDash([])
       break
     }
     case 'text': {
-      ctx.fillStyle = image_rgbToString(drawing.color)
-      ctx.font = image_fontToFontString(drawing.font, drawing.size) 
+      ctx.fillStyle = color_rgbToString(drawing.color)
+      ctx.font = font_fontToFontString(drawing.font, drawing.size) 
       const metrics = ctx.measureText(drawing.text)
       ctx.fillText(drawing.text, x, y + metrics.actualBoundingBoxAscent + 1)
     }
@@ -672,7 +672,7 @@ export function image_render (x: number, y: number, drawing: Drawing, canvas: HT
  *   *display* pass a themed color (see DrawingRenderer.vue); the default keeps
  *   off-screen/data uses (drawing->pixels, drawing->image) deterministic.
  */
-export function image_clearDrawing (canvas: HTMLCanvasElement, background: string = 'white') {
+export function drawing_clearDrawing (canvas: HTMLCanvasElement, background: string = 'white') {
   const ctx = canvas.getContext('2d')!
   ctx.fillStyle = background
   ctx.strokeStyle = 'black'
@@ -680,13 +680,13 @@ export function image_clearDrawing (canvas: HTMLCanvasElement, background: strin
 }
 
 // TODO: aria labels should be in a central location
-export const image_canvasAriaLabel = 'scamper-canvas'
-export function image_renderer (drawing: Drawing): HTMLElement {
+export const drawing_canvasAriaLabel = 'scamper-canvas'
+export function drawing_renderer (drawing: Drawing): HTMLElement {
   const canvas = document.createElement('canvas')
-  canvas.setAttribute('aria-label', image_canvasAriaLabel)
+  canvas.setAttribute('aria-label', drawing_canvasAriaLabel)
   canvas.width = Math.ceil(drawing.width)
   canvas.height = Math.ceil(drawing.height)
-  image_clearDrawing(canvas)
-  image_render(0, 0, drawing, canvas)
+  drawing_clearDrawing(canvas)
+  drawing_render(0, 0, drawing, canvas)
   return canvas
 }

--- a/src/js/image/font.ts
+++ b/src/js/image/font.ts
@@ -8,11 +8,11 @@ export interface Font extends L.Struct {
   isItalic: boolean
 }
 
-export function image_fontQ(v: any): boolean {
+export function font_fontQ(v: any): boolean {
   return L.isStructKind(v, 'font')
 }
 
-export function image_fontToFontString (f: Font, size: number): string {
+export function font_fontToFontString (f: Font, size: number): string {
   const fontString = `"${f.face}"${f.system ? `, ${f.system}` : ''}`
   return `${f.isItalic ? 'italic ' : ''}${f.isBold ? 'bold ' : ''}${size}px ${fontString}`
 }
@@ -24,7 +24,7 @@ function fontPrim (face: string, system: string, isBold: boolean, isItalic: bool
   }
 }
 
-export function image_font (name: string, system?: string,
+export function font_font (name: string, system?: string,
     isBold?: boolean, isItalic?: boolean): Font {
   return fontPrim(name, system || 'sans-serif', isBold || false, isItalic || false)
 }

--- a/src/js/image/image.ts
+++ b/src/js/image/image.ts
@@ -79,6 +79,15 @@ export function image_imageGetPixel(canvas: HTMLCanvasElement, x: number, y: num
   return image_rgb(data[0], data[1], data[2], data[3])
 }
 
+/**
+ * Pixels: a vector of rgb values, what canvas->pixels produces and
+ * pixels->canvas consumes. There is no distinct runtime type -- this is the
+ * contract the pixel operations were previously declared `any` for.
+ */
+export function image_pixelsQ(v: L.Value): boolean {
+  return L.isArray(v) && v.every((p) => L.isStructKind(p, 'rgba'))
+}
+
 export function image_imageToPixels(canvas: HTMLCanvasElement): L.Struct[] {
   const ctx = canvas.getContext('2d')!
   const src = ctx.getImageData(0, 0, canvas.width, canvas.height).data

--- a/src/js/image/image.ts
+++ b/src/js/image/image.ts
@@ -1,5 +1,4 @@
 import * as L from '../../lpm'
-import { Rgb, image_rgb } from './color.js'
 
 /***** Image loading **********************************************************/
 
@@ -65,73 +64,3 @@ export function image_blockOnFetchImage(url: string): L.Value {
       }),
   )
 }
-
-/***** Per-pixel manipulation *************************************************/
-
-// N.B., pixel-map is now defined in image.scm (Scheme) on top of image->pixels,
-// vector-map, and pixels->image -- a JS implementation can no longer call the
-// per-pixel Scamper function (callScamperFn is disabled).
-
-export function image_imageGetPixel(canvas: HTMLCanvasElement, x: number, y: number): L.Struct {
-  const ctx = canvas.getContext('2d')!
-  const img = ctx.getImageData(x, y, 1, 1)
-  const data = img.data
-  return image_rgb(data[0], data[1], data[2], data[3])
-}
-
-/**
- * Pixels: a vector of rgb values, what canvas->pixels produces and
- * pixels->canvas consumes. There is no distinct runtime type -- this is the
- * contract the pixel operations were previously declared `any` for.
- */
-export function image_pixelsQ(v: L.Value): boolean {
-  return L.isArray(v) && v.every((p) => L.isStructKind(p, 'rgba'))
-}
-
-export function image_imageToPixels(canvas: HTMLCanvasElement): L.Struct[] {
-  const ctx = canvas.getContext('2d')!
-  const src = ctx.getImageData(0, 0, canvas.width, canvas.height).data
-  const ret = []
-  for (let i = 0; i < src.length; i += 4) {
-    ret.push(image_rgb(src[i], src[i + 1], src[i + 2], src[i + 3]))
-  }
-  return ret
-}
-
-export function image_pixelsToImage(pixels: L.Struct[], width: number, height: number): HTMLCanvasElement {
-  const ret = document.createElement('canvas')
-  ret.width = width
-  ret.height = height
-  const ctx = ret.getContext('2d')!
-  const outImg = ctx.createImageData(width, height)
-  const data = outImg.data
-  for (let i = 0; i < pixels.length; i++) {
-    const c = pixels[i] as Rgb
-    data[i*4] = c.red
-    data[i*4 + 1] = c.green
-    data[i*4 + 2] = c.blue
-    data[i*4 + 3] = c.alpha
-  }
-  ctx.putImageData(outImg, 0, 0)
-  return ret
-}
-
-export function image_canvasSetPixels(canvas: HTMLCanvasElement, pixels: L.Struct[]): void {
-  const ctx = canvas.getContext('2d')!
-  const outImg = ctx.createImageData(canvas.width, canvas.height)
-  const data = outImg.data
-  for (let i = 0; i < pixels.length; i++) {
-    const c = pixels[i] as Rgb
-    data[i*4] = c.red
-    data[i*4 + 1] = c.green
-    data[i*4 + 2] = c.blue
-    data[i*4 + 3] = c.alpha
-  }
-  ctx.putImageData(outImg, 0, 0)
-}
-
-/***** Exports ****************************************************************/
-
-// Image loading
-
-// Per-pixel manipulation

--- a/src/js/image/renderers/DrawingRenderer.vue
+++ b/src/js/image/renderers/DrawingRenderer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, watch } from 'vue'
-import { Drawing, image_render, image_clearDrawing, image_canvasAriaLabel } from '../drawing'
+import { Drawing, drawing_render, drawing_clearDrawing, drawing_canvasAriaLabel } from '../drawing'
 import { onThemeChange, readColorToken } from '../../../theme'
 
 const props = defineProps<{ value: Drawing }>()
@@ -12,8 +12,8 @@ function renderDrawing() {
     canvas.value.height = Math.ceil(props.value.height)
     // Themed background for display so the drawing blends into the page instead
     // of being a white box on a dark background.
-    image_clearDrawing(canvas.value, readColorToken('--canvas-surface'))
-    image_render(0, 0, props.value, canvas.value)
+    drawing_clearDrawing(canvas.value, readColorToken('--canvas-surface'))
+    drawing_render(0, 0, props.value, canvas.value)
   }
 }
 
@@ -25,5 +25,5 @@ onUnmounted(unsubscribe)
 </script>
 
 <template>
-  <canvas ref="canvas" :aria-label="image_canvasAriaLabel"></canvas>
+  <canvas ref="canvas" :aria-label="drawing_canvasAriaLabel"></canvas>
 </template>

--- a/src/js/image/renderers/HsvRenderer.vue
+++ b/src/js/image/renderers/HsvRenderer.vue
@@ -2,20 +2,20 @@
 import { computed } from 'vue'
 import {
   Hsv,
-  image_hsvToRgb,
-  image_hsvToString,
-  image_rgbToString,
-  image_rgbPseudoComplement,
+  color_hsvToRgb,
+  color_hsvToString,
+  color_rgbToString,
+  color_rgbPseudoComplement,
 } from '../color'
 
 const props = defineProps<{ value: Hsv }>()
 
-const rgbValue = computed(() => image_hsvToRgb(props.value))
-const backgroundColor = computed(() => image_rgbToString(rgbValue.value))
+const rgbValue = computed(() => color_hsvToRgb(props.value))
+const backgroundColor = computed(() => color_rgbToString(rgbValue.value))
 const textColor = computed(() =>
-  image_rgbToString(image_rgbPseudoComplement(rgbValue.value)),
+  color_rgbToString(color_rgbPseudoComplement(rgbValue.value)),
 )
-const displayText = computed(() => image_hsvToString(props.value))
+const displayText = computed(() => color_hsvToString(props.value))
 </script>
 
 <template>

--- a/src/js/image/renderers/RgbRenderer.vue
+++ b/src/js/image/renderers/RgbRenderer.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Rgb, image_rgbToString, image_rgbPseudoComplement } from '../color'
+import { Rgb, color_rgbToString, color_rgbPseudoComplement } from '../color'
 
 const props = defineProps<{ value: Rgb }>()
 
-const backgroundColor = computed(() => image_rgbToString(props.value))
-const textColor = computed(() => image_rgbToString(image_rgbPseudoComplement(props.value)))
+const backgroundColor = computed(() => color_rgbToString(props.value))
+const textColor = computed(() => color_rgbToString(color_rgbPseudoComplement(props.value)))
 </script>
 
 <template>

--- a/src/js/image/renderers/html.ts
+++ b/src/js/image/renderers/html.ts
@@ -1,43 +1,43 @@
 import * as L from '../../../lpm'
 import HtmlRenderer from '../../../lpm/renderers/html.js'
-import { Rgb, Hsv, image_isRgb, image_isHsv, image_rgbPseudoComplement, image_rgbToString, image_hsvToRgb, image_hsvToString } from '../color.js'
-import { Drawing, image_drawingQ, image_renderer } from '../drawing.js'
+import { Rgb, Hsv, color_isRgb, color_isHsv, color_rgbPseudoComplement, color_rgbToString, color_hsvToRgb, color_hsvToString } from '../color.js'
+import { Drawing, drawing_drawingQ, drawing_renderer } from '../drawing.js'
 import { ReactiveImageFile, image_isReactiveImageFile } from '../image.js'
 
 /***** Colors ******************************************************************/
 
 function renderRgb (rgb: Rgb): HTMLElement {
   const div = document.createElement('div')
-  const textColor = image_rgbPseudoComplement(rgb)
-  div.style.color = image_rgbToString(textColor)
-  div.style.backgroundColor = image_rgbToString(rgb)
+  const textColor = color_rgbPseudoComplement(rgb)
+  div.style.color = color_rgbToString(textColor)
+  div.style.backgroundColor = color_rgbToString(rgb)
   div.style.width = 'fit-content'
   div.style.border = '1px solid var(--border)'
   div.style.padding = '0.25em'
-  div.textContent = image_rgbToString(rgb)
+  div.textContent = color_rgbToString(rgb)
   return div
 }
 
-HtmlRenderer.registerCustomRenderer(image_isRgb, (v: any) => renderRgb(v as Rgb))
+HtmlRenderer.registerCustomRenderer(color_isRgb, (v: any) => renderRgb(v as Rgb))
 
 function renderHsv (hsv: Hsv): HTMLElement {
   const div = document.createElement('div')
-  const rgb = image_hsvToRgb(hsv)
-  const textColor = image_rgbPseudoComplement(rgb)
-  div.style.color = image_rgbToString(textColor)
-  div.style.backgroundColor = image_rgbToString(rgb)
+  const rgb = color_hsvToRgb(hsv)
+  const textColor = color_rgbPseudoComplement(rgb)
+  div.style.color = color_rgbToString(textColor)
+  div.style.backgroundColor = color_rgbToString(rgb)
   div.style.width = 'fit-content'
   div.style.border = '1px solid var(--border)'
   div.style.padding = '0.25em'
-  div.textContent = image_hsvToString(hsv)
+  div.textContent = color_hsvToString(hsv)
   return div
 }
 
-HtmlRenderer.registerCustomRenderer(image_isHsv, (v: any) => renderHsv(v as Hsv))
+HtmlRenderer.registerCustomRenderer(color_isHsv, (v: any) => renderHsv(v as Hsv))
 
 /***** Drawings ****************************************************************/
 
-HtmlRenderer.registerCustomRenderer(image_drawingQ, (v: any) => image_renderer(v as Drawing))
+HtmlRenderer.registerCustomRenderer(drawing_drawingQ, (v: any) => drawing_renderer(v as Drawing))
 
 /***** Reactive image files *****************************************************/
 

--- a/src/js/image/renderers/vue.ts
+++ b/src/js/image/renderers/vue.ts
@@ -1,13 +1,13 @@
 import VueRenderer from '../../../lpm/renderers/vue.js'
-import { image_isRgb, image_isHsv } from '../color.js'
-import { image_drawingQ } from '../drawing.js'
+import { color_isRgb, color_isHsv } from '../color.js'
+import { drawing_drawingQ } from '../drawing.js'
 import { image_isReactiveImageFile } from '../image.js'
 import RgbRenderer from './RgbRenderer.vue'
 import HsvRenderer from './HsvRenderer.vue'
 import DrawingRenderer from './DrawingRenderer.vue'
 import ReactiveImageFileRenderer from './ReactiveImageFileRenderer.vue'
 
-VueRenderer.registerCustomRenderer(image_isRgb, () => RgbRenderer)
-VueRenderer.registerCustomRenderer(image_isHsv, () => HsvRenderer)
-VueRenderer.registerCustomRenderer(image_drawingQ, () => DrawingRenderer)
+VueRenderer.registerCustomRenderer(color_isRgb, () => RgbRenderer)
+VueRenderer.registerCustomRenderer(color_isHsv, () => HsvRenderer)
+VueRenderer.registerCustomRenderer(drawing_drawingQ, () => DrawingRenderer)
 VueRenderer.registerCustomRenderer(image_isReactiveImageFile, () => ReactiveImageFileRenderer)

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -33,9 +33,15 @@ const {
 // the browser -- this map and that file are two independent enumerations of
 // the same library set.
 //
-// Every binding name below is prefixed with its defining module (e.g.
-// `prelude_numberQ`, `canvas_makeCanvas`) so that flattening all modules
-// into a single map can't collide.
+// Every binding name below is prefixed so that flattening all modules into a
+// single map can't collide. The prefix names the *concept*, which for most
+// modules is the same as the module (`prelude_numberQ`, `canvas_makeCanvas`).
+//
+// N.B., `src/js/image/` is the exception: it backs the `image` Scheme library,
+// which covers four concepts, so it exports `drawing_*`, `color_*`, `font_*`,
+// and `image_*` (the last reserved for image *files*) -- see #103. A Scheme
+// module drawing on several JS prefixes is already normal: image.scm binds
+// `canvas?` to `canvas_canvasQ`.
 const internals = new Map<string, L.Value>([
   ...Object.entries(Audio),
   ...Object.entries(Canvas),

--- a/src/lib/canvas.scm
+++ b/src/lib/canvas.scm
@@ -8,13 +8,13 @@
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a valid color: a string containing a named color, an `rgb` value, or an `hsv` value.
 ;;; @category color, hsv, image, predicates, rgb, typecheck
-(define-export color? (js-var "image_colorQ"))
+(define-export color? (js-var "color_colorQ"))
 
 ;;; (drawing? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a drawing: the kind of value the shape constructors build.
 ;;; @category image, predicates, typecheck
-(define-export drawing? (js-var "image_drawingQ"))
+(define-export drawing? (js-var "drawing_drawingQ"))
 
 ;;; (fill-mode? v) -> boolean?
 ;;;  v : any
@@ -23,7 +23,7 @@
 ;;; N.B., re-exported here (like color? and drawing?) because this module's own
 ;;; contracts name it, and a contract predicate must resolve in the module that
 ;;; uses it -- see the cross-module predicate test in test/libs/canvas.test.ts.
-(define-export fill-mode? (js-var "image_fillModeQ"))
+(define-export fill-mode? (js-var "drawing_fillModeQ"))
 
 ;;; (make-canvas width height) -> canvas?
 ;;;  width : integer?

--- a/src/lib/canvas.scm
+++ b/src/lib/canvas.scm
@@ -10,11 +10,20 @@
 ;;; @category color, hsv, image, predicates, rgb, typecheck
 (define-export color? (js-var "image_colorQ"))
 
-;;; (image? v) -> boolean?
+;;; (drawing? v) -> boolean?
 ;;;  v : any
-;;; Returns `#t` if and only `v` is an image.
+;;; Returns `#t` if and only if `v` is a drawing: the kind of value the shape constructors build.
 ;;; @category image, predicates, typecheck
-(define-export image? (js-var "image_drawingQ"))
+(define-export drawing? (js-var "image_drawingQ"))
+
+;;; (fill-mode? v) -> boolean?
+;;;  v : any
+;;; Returns `#t` if and only if `v` is a fill mode: the string `"solid"` or `"outline"`.
+;;; @category canvas, shapes, typecheck, predicates
+;;; N.B., re-exported here (like color? and drawing?) because this module's own
+;;; contracts name it, and a contract predicate must resolve in the module that
+;;; uses it -- see the cross-module predicate test in test/libs/canvas.test.ts.
+(define-export fill-mode? (js-var "image_fillModeQ"))
 
 ;;; (make-canvas width height) -> canvas?
 ;;;  width : integer?
@@ -33,7 +42,7 @@
 ;;;   non-negative
 ;;;  height : integer?
 ;;;   non-negative
-;;;  mode : string?
+;;;  mode : fill-mode?
 ;;;   either `"solid"` or `"outline"`
 ;;;  color : color?
 ;;; Renders a rectangle whose upper-left corner is at `(x, y)`.
@@ -51,7 +60,7 @@
 ;;;  rotation : number?
 ;;;  startAngle : number?
 ;;;  endAngle : number?
-;;;  mode : string?
+;;;  mode : fill-mode?
 ;;;   either `"solid"` or `"outline"`
 ;;;  color : color?
 ;;; Renders an ellipse whose center is at `(x, y)`, radii `radiusX` and `radiusY`, `rotation`, `startAngle`, and `endAngle`.
@@ -64,7 +73,7 @@
 ;;;  y : number?
 ;;;  radius : number?
 ;;;   non-negative
-;;;  mode : string?
+;;;  mode : fill-mode?
 ;;;   either `"solid"` or `"outline"`
 ;;;  color : color?
 ;;; Renders a circle whose center is at `(x, y)` and radius `radius`.
@@ -78,7 +87,7 @@
 ;;;  text : string?
 ;;;  size : number?
 ;;;   positive
-;;;  mode : string?
+;;;  mode : fill-mode?
 ;;;   either `"solid"` or `"outline"`
 ;;;  color : color?
 ;;;  font : string?
@@ -91,7 +100,7 @@
 ;;;  canvas : canvas?
 ;;;  x : integer?
 ;;;  y : integer?
-;;;  drawing : image?
+;;;  drawing : drawing?
 ;;; Draws the given drawing (created via the `image` library) at the given coordinates.
 ;;; @category canvas, mutation, predicates, canvas-text!, canvas-path!
 (define-export canvas-drawing! (js-var "canvas_canvasDrawing"))
@@ -100,7 +109,7 @@
 ;;;  canvas : canvas?
 ;;;  pairs : list?
 ;;;   a list of pairs of numbers
-;;;  mode : string?
+;;;  mode : fill-mode?
 ;;;   either `"solid"` or `"outline"`
 ;;;  color : color?
 ;;; Renders a path from the given list of pairs of numbers.

--- a/src/lib/image.scm
+++ b/src/lib/image.scm
@@ -290,30 +290,30 @@
 ;;; @category image, font?, text
 (define-export font (js-var "image_font"))
 
-;;; (image? v) -> boolean?
+;;; (drawing? v) -> boolean?
 ;;;  v : any
-;;; Returns `#t` if and only `v` is an image.
-;;; @category image, predicates, typecheck, shape?
-(define-export image? (js-var "image_drawingQ"))
+;;; Returns `#t` if and only if `v` is a drawing: the kind of value the shape constructors build. A canvas is not a drawing, and neither is a loaded image file.
+;;; @category image, predicates, typecheck, shapes, canvas?
+(define-export drawing? (js-var "image_drawingQ"))
 
-;;; (shape? v) -> boolean?
+;;; (fill-mode? v) -> boolean?
 ;;;  v : any
-;;; Returns `#t` if and only `v` is a shape.
-;;; @category image, predicates, shapes, typecheck, image?
-(define-export shape? (js-var "image_drawingQ"))
+;;; Returns `#t` if and only if `v` is a fill mode: the string `"solid"` or `"outline"`.
+;;; @category image, shapes, typecheck, predicates, ellipse, rectangle
+(define-export fill-mode? (js-var "image_fillModeQ"))
 
-;;; (ellipse width height fill color) -> image?
+;;; (ellipse width height fill color) -> drawing?
 ;;;  width : integer?
 ;;;  height : integer?
-;;;  fill : boolean?
+;;;  fill : fill-mode?
 ;;;  color : color?
 ;;; Returns a new drawing containing an ellipse with dimensions `width × height`.
 ;;; @category image, shapes, solid-ellipse, outlined-ellipse
 (define-export ellipse (js-var "image_ellipse"))
 
-;;; (circle radius fill color) -> image?
+;;; (circle radius fill color) -> drawing?
 ;;;  radius : number?
-;;;  fill : string?
+;;;  fill : fill-mode?
 ;;;   either "solid" or "outline"
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -321,10 +321,10 @@
 ;;; @category image, shapes, solid-circle, outlined-circle
 (define-export circle (js-var "image_circle"))
 
-;;; (rectangle width height fill color) -> image?
+;;; (rectangle width height fill color) -> drawing?
 ;;;  width : number?
 ;;;  height : number?
-;;;  fill : string?
+;;;  fill : fill-mode?
 ;;;   either "solid" or "outline"
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -332,9 +332,9 @@
 ;;; @category image, shapes, solid-rectangle, outlined-rectangle
 (define-export rectangle (js-var "image_rectangle"))
 
-;;; (square width fill color) -> image?
+;;; (square width fill color) -> drawing?
 ;;;  width : number?
-;;;  fill : string?
+;;;  fill : fill-mode?
 ;;;   either "solid" or "outline"
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -342,9 +342,9 @@
 ;;; @category image, shapes, solid-square, outlined-square
 (define-export square (js-var "image_square"))
 
-;;; (triangle length fill color) -> image?
+;;; (triangle length fill color) -> drawing?
 ;;;  length : number?
-;;;  fill : string?
+;;;  fill : fill-mode?
 ;;;   either "solid" or "outline"
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -352,10 +352,10 @@
 ;;; @category image, shapes, solid-triangle, outlined-triangle
 (define-export triangle (js-var "image_triangle"))
 
-;;; (isosceles-triangle width height fill color) -> image?
+;;; (isosceles-triangle width height fill color) -> drawing?
 ;;;  width : number?
 ;;;  height : number?
-;;;  fill : string?
+;;;  fill : fill-mode?
 ;;;   either "solid" or "outline"
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -363,12 +363,12 @@
 ;;; @category image, shapes, solid-isosceles-triangle, outlined-isosceles-triangle
 (define-export isosceles-triangle (js-var "image_isoscelesTriangle"))
 
-;;; (path width height points fill color) -> image?
+;;; (path width height points fill color) -> drawing?
 ;;;  width : number?
 ;;;  height : number?
 ;;;  points : list?
 ;;;   a list of points, pairs of numbers
-;;;  fill : string?
+;;;  fill : fill-mode?
 ;;;   either "solid" or "outline"
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -376,76 +376,76 @@
 ;;; @category image, path, with-dash
 (define-export path (js-var "image_path"))
 
-;;; (beside & d1) -> image?
-;;;  d1 : image?
+;;; (beside & d1) -> drawing?
+;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., beside each other (horizontally).
 ;;; @category composition/placement, image, beside/align, above, above/align, overlay, overlay/align, overlay/offset, rotate
 (define-export beside (js-var "image_beside"))
 
-;;; (beside/align align & d1) -> image?
+;;; (beside/align align & d1) -> drawing?
 ;;;  align : string?
 ;;;   either "top", "center", or "bottom"
-;;;  d1 : image?
+;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., beside each other on the x-axis, aligning them along the y-axis according to `align`.
 ;;; @category composition/placement, image, beside, above, above/align, overlay, overlay/align, overlay/offset, rotate
 (define-export beside/align (js-var "image_besideAlign"))
 
-;;; (above & d1) -> image?
-;;;  d1 : image?
+;;; (above & d1) -> drawing?
+;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., above each other (vertically in descending order).
 ;;; @category composition/placement, image, beside, beside/align, above/align, overlay, overlay/align, overlay/offset, rotate
 (define-export above (js-var "image_above"))
 
-;;; (above/align align & d1) -> image?
+;;; (above/align align & d1) -> drawing?
 ;;;  align : string?
 ;;;   either "left", "middle", or "right"
-;;;  d1 : image?
+;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., above each other on the y-axis, aligning them along the x-axis according to `align`.
 ;;; @category composition/placement, image, beside, beside/align, above, overlay, overlay/align, overlay/offset, rotate
 (define-export above/align (js-var "image_aboveAlign"))
 
-;;; (overlay & d1) -> image?
-;;;  d1 : image?
+;;; (overlay & d1) -> drawing?
+;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., on top of each other. (`d1` is the topmost drawing).
 ;;; @category composition/placement, image, beside, beside/align, above, above/align, overlay/align, overlay/offset, rotate
 (define-export overlay (js-var "image_overlay"))
 
-;;; (overlay/align xAlign yAlign & d1) -> image?
+;;; (overlay/align xAlign yAlign & d1) -> drawing?
 ;;;  xAlign : string?
 ;;;   either "left", "middle", or "right"
 ;;;  yAlign : string?
 ;;;   either "top", "center", or "bottom"
-;;;  d1 : image?
+;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., on top of each other, aligning them according to `xAlign` and `yAlign`.
 ;;; @category composition/placement, image, beside, beside/align, above, above/align, overlay, overlay/offset, rotate
 (define-export overlay/align (js-var "image_overlayAlign"))
 
-;;; (overlay/offset dx dy d1 d2) -> image?
+;;; (overlay/offset dx dy d1 d2) -> drawing?
 ;;;  dx : number?
 ;;;  dy : number?
-;;;  d1 : image?
-;;;  d2 : image?
+;;;  d1 : drawing?
+;;;  d2 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1` on top of `d2`, offset by `(dx, dy)`.
 ;;; @category composition/placement, image, beside, beside/align, above, above/align, overlay, overlay/align, rotate
 (define-export overlay/offset (js-var "image_overlayOffset"))
 
-;;; (rotate angle d) -> image?
+;;; (rotate angle d) -> drawing?
 ;;;  angle : number?
 ;;;   in degrees
-;;;  d : image?
+;;;  d : drawing?
 ;;; Returns a new drawing formed by rotating drawing `d` by `angle` degrees around the center of its bounding box. Note: currently buggy and shifts off-center.
 ;;; @category image, beside, beside/align, above, above/align, overlay, overlay/align, overlay/offset
 (define-export rotate (js-var "image_rotate"))
 
-;;; (with-dash dash-spec d) -> image?
+;;; (with-dash dash-spec d) -> drawing?
 ;;;  dash-spec : list?
 ;;;   a list of numbers
-;;;  d : image?
+;;;  d : drawing?
 ;;; Returns a new drawing formed by drawing `d` but with lines drawn according to `dash-spec`. `dash-spec` is an list of numbers where each successive pair of numbers describe the length of a dash and the length of the subsequent gap.
 ;;; @category canvas, image, shapes, path-func
 (define-export with-dash (js-var "image_withDash"))
 
-;;; (text str size color & font) -> image?
+;;; (text str size color & font) -> drawing?
 ;;;  str : string?
 ;;;  size : any
 ;;;   number? A valid font size (in px)
@@ -456,7 +456,7 @@
 ;;; @category image, font, font?
 (define-export text (js-var "image_text"))
 
-;;; (solid-square width color) -> image?
+;;; (solid-square width color) -> drawing?
 ;;;  width : number?
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -464,7 +464,7 @@
 ;;; @category image, shapes, square, outlined-square
 (define-export solid-square (js-var "image_solidSquare"))
 
-;;; (outlined-square width color) -> image?
+;;; (outlined-square width color) -> drawing?
 ;;;  width : number?
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -472,7 +472,7 @@
 ;;; @category image, shapes, square, solid-square
 (define-export outlined-square (js-var "image_outlinedSquare"))
 
-;;; (solid-rectangle width height color) -> image?
+;;; (solid-rectangle width height color) -> drawing?
 ;;;  width : number?
 ;;;  height : number?
 ;;;  color : color?
@@ -481,7 +481,7 @@
 ;;; @category image, shapes, rectangle, outlined-rectangle
 (define-export solid-rectangle (js-var "image_solidRectangle"))
 
-;;; (outlined-rectangle width height color) -> image?
+;;; (outlined-rectangle width height color) -> drawing?
 ;;;  width : number?
 ;;;  height : number?
 ;;;  color : color?
@@ -490,7 +490,7 @@
 ;;; @category image, shapes, rectangle, solid-rectangle
 (define-export outlined-rectangle (js-var "image_outlinedRectangle"))
 
-;;; (solid-circle radius color) -> image?
+;;; (solid-circle radius color) -> drawing?
 ;;;  radius : number?
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -498,7 +498,7 @@
 ;;; @category image, shapes, circle, outlined-circle
 (define-export solid-circle (js-var "image_solidCircle"))
 
-;;; (outlined-circle radius color) -> image?
+;;; (outlined-circle radius color) -> drawing?
 ;;;  radius : number?
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -506,7 +506,7 @@
 ;;; @category image, shapes, circle, solid-circle
 (define-export outlined-circle (js-var "image_outlinedCircle"))
 
-;;; (solid-ellipse width height color) -> image?
+;;; (solid-ellipse width height color) -> drawing?
 ;;;  width : integer?
 ;;;  height : integer?
 ;;;  color : color?
@@ -514,7 +514,7 @@
 ;;; @category image, shapes, ellipse, outlined-ellipse
 (define-export solid-ellipse (js-var "image_solidEllipse"))
 
-;;; (outlined-ellipse width height color) -> image?
+;;; (outlined-ellipse width height color) -> drawing?
 ;;;  width : integer?
 ;;;  height : integer?
 ;;;  color : color?
@@ -522,7 +522,7 @@
 ;;; @category image, shapes, ellipse, solid-ellipse
 (define-export outlined-ellipse (js-var "image_outlinedEllipse"))
 
-;;; (solid-triangle length color) -> image?
+;;; (solid-triangle length color) -> drawing?
 ;;;  length : number?
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -530,7 +530,7 @@
 ;;; @category image, shapes, triangle, outlined-triangle
 (define-export solid-triangle (js-var "image_solidTriangle"))
 
-;;; (outlined-triangle length color) -> image?
+;;; (outlined-triangle length color) -> drawing?
 ;;;  length : number?
 ;;;  color : color?
 ;;;   either a color name or the form "rgba(r, g, b, a)"
@@ -538,7 +538,7 @@
 ;;; @category image, shapes, triangle, solid-triangle
 (define-export outlined-triangle (js-var "image_outlinedTriangle"))
 
-;;; (solid-isosceles-triangle width height color) -> image?
+;;; (solid-isosceles-triangle width height color) -> drawing?
 ;;;  width : number?
 ;;;  height : number?
 ;;;  color : color?
@@ -547,7 +547,7 @@
 ;;; @category image, shapes, isosceles-triangle, outlined-isosceles-triangle
 (define-export solid-isosceles-triangle (js-var "image_solidIsoscelesTriangle"))
 
-;;; (outlined-isosceles-triangle width height color) -> image?
+;;; (outlined-isosceles-triangle width height color) -> drawing?
 ;;;  width : number?
 ;;;  height : number?
 ;;;  color : color?
@@ -556,42 +556,42 @@
 ;;; @category image, shapes, isosceles-triangle, solid-isosceles-triangle
 (define-export outlined-isosceles-triangle (js-var "image_outlinedIsoscelesTriangle"))
 
-;;; (image-width img) -> number?
-;;;  img : image?
-;;; Returns the width of the image.
-;;; @category image, image-height
-(define-export image-width (js-var "image_imageWidth"))
+;;; (drawing-width drawing) -> number?
+;;;  drawing : drawing?
+;;; Returns the width of the drawing.
+;;; @category image, drawing-height
+(define-export drawing-width (js-var "image_imageWidth"))
 
-;;; (image-height img) -> number?
-;;;  img : image?
-;;; Returns the height of the image.
-;;; @category image, image-width
-(define-export image-height (js-var "image_imageHeight"))
+;;; (drawing-height drawing) -> number?
+;;;  drawing : drawing?
+;;; Returns the height of the drawing.
+;;; @category image, drawing-width
+(define-export drawing-height (js-var "image_imageHeight"))
 
-;;; (image-color img) -> rgb?
-;;;  img : image?
-;;; Returns the color of the image. For a composite image, this is the average of its parts' colors.
-;;; @category image, image-recolor
-(define-export image-color (js-var "image_imageColor"))
+;;; (drawing-color drawing) -> rgb?
+;;;  drawing : drawing?
+;;; Returns the color of the drawing. For a composite drawing, this is the average of its parts' colors.
+;;; @category image, drawing-recolor
+(define-export drawing-color (js-var "image_imageColor"))
 
-;;; (image-recolor img color) -> image?
-;;;  img : image?
+;;; (drawing-recolor drawing color) -> drawing?
+;;;  drawing : drawing?
 ;;;  color : color?
-;;; Returns a new image with the same dimensions as `img` but with the color `color`.
-;;; @category image, image-color
-(define-export image-recolor (js-var "image_imageRecolor"))
+;;; Returns a new drawing with the same dimensions as `drawing` but with the color `color`.
+;;; @category image, drawing-color
+(define-export drawing-recolor (js-var "image_imageRecolor"))
 
 ;;; (drawing->pixels d) -> vector?
-;;;  d : image?
+;;;  d : drawing?
 ;;; Returns a vector of rgb values corresponding to the pixels of the given drawing.
-;;; @category image, pixel, drawing->image
+;;; @category image, pixel, drawing->canvas
 (define-export drawing->pixels (js-var "image_drawingToPixels"))
 
-;;; (drawing->image drawing) -> image?
-;;;  drawing : image?
-;;; Returns a new image/canvas created from the provided drawing.
+;;; (drawing->canvas drawing) -> canvas?
+;;;  drawing : drawing?
+;;; Renders `drawing` onto a new canvas and returns it.
 ;;; @category image, pixel, drawing->pixels
-(define-export drawing->image (js-var "image_drawingToImage"))
+(define-export drawing->canvas (js-var "image_drawingToImage"))
 
 ;;; (with-image-file callback) -> html?
 ;;;  callback : procedure?
@@ -608,56 +608,60 @@
   (lambda (url callback)
     (callback ((js-var "image_blockOnFetchImage") url))))
 
-;;; (pixel-map fn img) -> canvas?
+;;; (pixel-map fn canvas) -> canvas?
 ;;;  fn : procedure?
-;;;  img : canvas?
-;;; Returns a new canvas that is the result of applying `fn` to each pixel (represented as a rgb value) of the original `img`.
-;;; @category image, pixel, image-get-pixel, image->pixels, pixels->image, canvas-set-pixels!
+;;;  canvas : canvas?
+;;; Returns a new canvas that is the result of applying `fn` to each pixel (an rgb value) of `canvas`. `canvas` itself is unchanged.
+;;; @category image, pixel, canvas-get-pixel, canvas->pixels, pixels->canvas, canvas-set-pixels!
 (define-export pixel-map
   (lambda (fn img)
-    (pixels->image (vector-map fn (image->pixels img))
+    (pixels->canvas (vector-map fn (canvas->pixels img))
                    (canvas-width img)
                    (canvas-height img))))
 
-;;; (image-get-pixel img x y) -> rgb?
-;;;  img : image?
+;;; (canvas-get-pixel img x y) -> rgb?
+;;;  img : drawing?
 ;;;  x : integer?
 ;;;  y : integer?
-;;; Returns the rgb value of the pixel at position `(x, y)` in the image.
-;;; @category color, image, pixel, rgb, pixel-map, image->pixels, pixels->image, canvas-set-pixels! 
-(define-export image-get-pixel (js-var "image_imageGetPixel"))
+;;; Returns the rgb value of the pixel at position `(x, y)` of `canvas`.
+;;; @category color, image, pixel, rgb, pixel-map, canvas->pixels, pixels->canvas, canvas-set-pixels! 
+(define-export canvas-get-pixel (js-var "image_imageGetPixel"))
 
-;;; (image->pixels img) -> canvas?
-;;;  img : canvas?
-;;; Returns a vector of `rgb` values corresponding to the pixels of the given canvas.
-;;; @category image, pixel-map, image-get-pixel, pixels->image, canvas-set-pixels! 
-(define-export image->pixels (js-var "image_imageToPixels"))
+;;; (pixels? v) -> boolean?
+;;;  v : any
+;;; Returns `#t` if and only if `v` is a vector of `rgb` values, the representation `canvas->pixels` produces and `pixels->canvas` consumes.
+;;; @category image, pixel, typecheck, predicates, canvas->pixels, pixels->canvas
+(define-export pixels? (js-var "image_pixelsQ"))
 
-;;; (pixels->image pixels width height) -> canvas?
-;;;  pixels : any
-;;;   vector? of rgb values
+;;; (canvas->pixels canvas) -> pixels?
+;;;  canvas : canvas?
+;;; Returns the pixels of `canvas` as a vector of `rgb` values, read left-to-right and top-to-bottom. The result is a snapshot: changing it does not change `canvas`. Use `canvas-set-pixels!` to write pixels back.
+;;; @category image, pixel-map, canvas-get-pixel, pixels->canvas, canvas-set-pixels! 
+(define-export canvas->pixels (js-var "image_imageToPixels"))
+
+;;; (pixels->canvas pixels width height) -> canvas?
+;;;  pixels : pixels?
 ;;;  width : integer?
 ;;;  height : integer?
 ;;; Returns a new canvas with the given `pixels` and dimensions `width × height`.
-;;; @category image, pixel, pixel-map, image-get-pixel, image->pixels, canvas-set-pixels! 
-(define-export pixels->image (js-var "image_pixelsToImage"))
+;;; @category image, pixel, pixel-map, canvas-get-pixel, canvas->pixels, canvas-set-pixels! 
+(define-export pixels->canvas (js-var "image_pixelsToImage"))
 
 ;;; (canvas-set-pixels! canvas pixels) -> void?
 ;;;  canvas : canvas?
-;;;  pixels : any
-;;;   vector? of rgb values
-;;; Sets the pixels of the given `canvas` to the given `pixels`.
-;;; @category canvas, image, mutation, pixel, predicates, pixel-map, image-get-pixel, image->pixels, pixels->image
+;;;  pixels : pixels?
+;;; Sets the pixels of `canvas` to `pixels`, mutating it in place.
+;;; @category canvas, image, mutation, pixel, predicates, pixel-map, canvas-get-pixel, canvas->pixels, pixels->canvas
 (define-export canvas-set-pixels! (js-var "image_canvasSetPixels"))
 
 ;;; (canvas-width canvas) -> integer?
 ;;;  canvas : canvas?
 ;;; Returns the width of the canvas in pixels.
 ;;; @category canvas, image
-(define-export canvas-width (js-var "image_imageWidth"))
+(define-export canvas-width (js-var "canvas_canvasWidth"))
 
 ;;; (canvas-height canvas) -> integer?
 ;;;  canvas : canvas?
 ;;; Returns the height of the canvas in pixels.
 ;;; @category canvas, image
-(define-export canvas-height (js-var "image_imageHeight"))
+(define-export canvas-height (js-var "canvas_canvasHeight"))

--- a/src/lib/image.scm
+++ b/src/lib/image.scm
@@ -14,19 +14,19 @@
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a valid color: a string containing a named color, an `rgb` value, or an `hsv` value.
 ;;; @category color, hsv, image, predicates, rgb, typecheck, color-func, find-colors, all-color-names
-(define-export color? (js-var "image_colorQ"))
+(define-export color? (js-var "color_colorQ"))
 
 ;;; (rgb-component? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is an integer between 0 and 255.
 ;;; @category color, image, predicates, rgb, typecheck, rgb-func, color-func, rgb?, rgb-distance
-(define-export rgb-component? (js-var "image_isRgbComponent"))
+(define-export rgb-component? (js-var "color_isRgbComponent"))
 
 ;;; (rgb? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a rgb value.
 ;;; @category color, image, predicates, rgb, typecheck, rgb-func, color-func, rgb-component?, rgb-distance
-(define-export rgb? (js-var "image_isRgb"))
+(define-export rgb? (js-var "color_isRgb"))
 
 ;;; (rgb r g b & a) -> rgb?
 ;;;  r : rgb-component?
@@ -36,68 +36,68 @@
 ;;;   optional
 ;;; Returns an rgb value with the specified components.
 ;;; @category color, image, rgb, color-func, rgb?, rgb-component?, rgb-distance
-(define-export rgb (js-var "image_rgb"))
+(define-export rgb (js-var "color_rgb"))
 
 ;;; (rgb-red rgb) -> rgb-component?
 ;;;  rgb : rgb?
 ;;; Returns the red component of the rgb value.
 ;;; @category color, image, rgb, rgb-blue, rgb-green
-(define-export rgb-red (js-var "image_rgbRed"))
+(define-export rgb-red (js-var "color_rgbRed"))
 
 ;;; (rgb-green rgb) -> rgb-component?
 ;;;  rgb : rgb?
 ;;; Returns the green component of the rgb value.
 ;;; @category color, image, rgb, rgb-blue, rgb-red
-(define-export rgb-green (js-var "image_rgbGreen"))
+(define-export rgb-green (js-var "color_rgbGreen"))
 
 ;;; (rgb-blue rgb) -> rgb-component?
 ;;;  rgb : rgb?
 ;;; Returns the blue component of the rgb value.
 ;;; @category color, image, rgb, rgb-green, rgb-red
-(define-export rgb-blue (js-var "image_rgbBlue"))
+(define-export rgb-blue (js-var "color_rgbBlue"))
 
 ;;; (rgb-alpha rgb) -> rgb-component?
 ;;;  rgb : rgb?
 ;;; Returns the alpha component of the rgb value.
 ;;; @category color, image, rgb, rgb-hue, rgb-pseudo-complement, rgb-saturation, rgb-value
-(define-export rgb-alpha (js-var "image_rgbAlpha"))
+(define-export rgb-alpha (js-var "color_rgbAlpha"))
 
 ;;; (rgb-distance rgb1 rgb2) -> number?
 ;;;  rgb1 : rgb?
 ;;;  rgb2 : rgb?
 ;;; Returns the Euclidean distance between the two rgb values.
 ;;; @category color, image, rgb, rgb-func, color-func, rgb?, rgb-component?
-(define-export rgb-distance (js-var "image_rgbDistance"))
+(define-export rgb-distance (js-var "color_rgbDistance"))
 
 ;;; (color-name? v) -> boolean?
 ;;;  v : string?
 ;;; Returns `#t` if and only if `v` is a valid color name.
 ;;; @category color, image, predicates, typecheck, color-func, all-color-names, find-colors
-(define-export color-name? (js-var "image_isColorName"))
+(define-export color-name? (js-var "color_isColorName"))
 
 ;;; (all-color-names x1) -> list?
 ;;;  x1 : any
 ;;; Returns a list of all valid color names.
 ;;; @category color, constants, image, color-func, color?, find-colors, color-name?
-(define-export all-color-names (js-var "image_allColorNames"))
+(define-export all-color-names (js-var "color_allColorNames"))
 
 ;;; (find-colors color-name) -> list?
 ;;;  color-name : string?
 ;;; Returns a list of all color names that contain `color`, case-insensitive.
 ;;; @category image, color-func, color?, all-color-names, color-name?
-(define-export find-colors (js-var "image_findColors"))
+(define-export find-colors (js-var "color_findColors"))
 
 ;;; (rgb->string rgb) -> string?
 ;;;  rgb : rgb?
 ;;; Returns a string representation of the rgb value, e.g., approrpiate for use as a shape color.
 ;;; @category color, image, rgb, color-name->rgb, hsv->rgb, rgb->hsv, hsv->string
-(define-export rgb->string (js-var "image_rgbToString"))
+(define-export rgb->string (js-var "color_rgbToString"))
 
 ;;; (hsv? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a hsv value.
 ;;; @category color, image, hsv, predicates, typecheck, hsv-func
-(define-export hsv? (js-var "image_isHsv"))
+(define-export hsv? (js-var "color_isHsv"))
 
 ;;; (hsv h s v & a) -> hsv?
 ;;;  h : number?
@@ -110,172 +110,172 @@
 ;;;   0 <= a <= 255
 ;;; Returns a hsv value with the specified components.
 ;;; @category color, hsv, image, hsv?
-(define-export hsv (js-var "image_hsv"))
+(define-export hsv (js-var "color_hsv"))
 
 ;;; (hsv-hue hsv) -> number?
 ;;;  hsv : hsv?
 ;;; Returns the hue component of the hsv value.
 ;;; @category color, hsv, image, hsv-alpha, hsv-complement, hsv-saturation, hsv-value
-(define-export hsv-hue (js-var "image_hsvHue"))
+(define-export hsv-hue (js-var "color_hsvHue"))
 
 ;;; (hsv-saturation hsv) -> number?
 ;;;  hsv : hsv?
 ;;; Returns the saturation component of the hsv value.
 ;;; @category color, hsv, image, hsv-alpha, hsv-hue, hsv-complement, hsv-value
-(define-export hsv-saturation (js-var "image_hsvSaturation"))
+(define-export hsv-saturation (js-var "color_hsvSaturation"))
 
 ;;; (hsv-value hsv) -> number?
 ;;;  hsv : hsv?
 ;;; Returns the value component of the hsv value.
 ;;; @category color, hsv, image, hsv-alpha, hsv-hue, hsv-complement, hsv-saturation
-(define-export hsv-value (js-var "image_hsvValue"))
+(define-export hsv-value (js-var "color_hsvValue"))
 
 ;;; (hsv-alpha hsv) -> number?
 ;;;  hsv : hsv?
 ;;; Returns the alpha component of the hsv value.
 ;;; @category color, hsv, image, hsv-hue, hsv-complement, hsv-saturation, hsv-value
-(define-export hsv-alpha (js-var "image_hsvAlpha"))
+(define-export hsv-alpha (js-var "color_hsvAlpha"))
 
 ;;; (hsv-complement hsv) -> hsv?
 ;;;  hsv : hsv?
 ;;; Returns the complement of the hsv value.
 ;;; @category color, hsv, image, hsv-alpha, hsv-hue, hsv-saturation, hsv-value
-(define-export hsv-complement (js-var "image_hsvComplement"))
+(define-export hsv-complement (js-var "color_hsvComplement"))
 
 ;;; (rgb-hue rgb) -> number?
 ;;;  rgb : rgb?
 ;;; Returns the hue component of the rgb value.
 ;;; @category color, hsv, image, rgb, rgb-alpha, rgb-pseudo-complement, rgb-saturation, rgb-value
-(define-export rgb-hue (js-var "image_rgbHue"))
+(define-export rgb-hue (js-var "color_rgbHue"))
 
 ;;; (rgb-saturation rgb) -> number?
 ;;;  rgb : rgb?
 ;;; Returns the saturation component of the rgb value.
 ;;; @category color, hsv, image, rgb, rgb-alpha, rgb-hue, rgb-pseudo-complement, rgb-value
-(define-export rgb-saturation (js-var "image_rgbSaturation"))
+(define-export rgb-saturation (js-var "color_rgbSaturation"))
 
 ;;; (rgb-value rgb) -> number?
 ;;;  rgb : rgb?
 ;;; Returns the value component of the rgb value.
 ;;; @category color, hsv, image, rgb, rgb-alpha, rgb-hue, rgb-pseudo-complement, rgb-saturation
-(define-export rgb-value (js-var "image_rgbValue"))
+(define-export rgb-value (js-var "color_rgbValue"))
 
 ;;; (rgb->hsv rgb) -> hsv?
 ;;;  rgb : rgb?
 ;;; Converts the rgb value to an hsv value.
 ;;; @category color, hsv, image, rgb, color-name->rgb, hsv->rgb, rgb->string
-(define-export rgb->hsv (js-var "image_rgbToHsv"))
+(define-export rgb->hsv (js-var "color_rgbToHsv"))
 
 ;;; (hsv->string hsv) -> string?
 ;;;  hsv : hsv?
 ;;; Returns a string representation of the hsv value.
 ;;; @category color, hsv, image, rgb->hsv, hcv->rgb
-(define-export hsv->string (js-var "image_hsvToString"))
+(define-export hsv->string (js-var "color_hsvToString"))
 
 ;;; (color-name->rgb color-name) -> rgb?
 ;;;  color-name : string?
 ;;; Returns the rgb value of the color name.
 ;;; @category color, image, rgb, hsv->rgb, rgb->hsv, rgb->string
-(define-export color-name->rgb (js-var "image_colorNameToRgb"))
+(define-export color-name->rgb (js-var "color_colorNameToRgb"))
 
 ;;; (hsv->rgb hsv) -> rgb?
 ;;;  hsv : hsv?
 ;;; Converts the hsv value to an rgb value.
 ;;; @category color, hsv, image, rgb, color-name->rgb, rgb->hsv, rgb->string, hsv->string
-(define-export hsv->rgb (js-var "image_hsvToRgb"))
+(define-export hsv->rgb (js-var "color_hsvToRgb"))
 
 ;;; (rgb-darker rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a darker version of the rgb value.
 ;;; @category color, image, rgb, rgb-lighter
-(define-export rgb-darker (js-var "image_rgbDarker"))
+(define-export rgb-darker (js-var "color_rgbDarker"))
 
 ;;; (rgb-lighter rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a lighter version of the rgb value.
 ;;; @category color, image, rgb, rgb-lighter
-(define-export rgb-lighter (js-var "image_rgbLighter"))
+(define-export rgb-lighter (js-var "color_rgbLighter"))
 
 ;;; (rgb-redder rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a redder version of the rgb value.
 ;;; @category color, image, rgb, rgb-bluer, rgb-greener
-(define-export rgb-redder (js-var "image_rgbRedder"))
+(define-export rgb-redder (js-var "color_rgbRedder"))
 
 ;;; (rgb-bluer rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a bluer version of the rgb value.
 ;;; @category color, image, rgb, rgb-greener, rgb-redder
-(define-export rgb-bluer (js-var "image_rgbBluer"))
+(define-export rgb-bluer (js-var "color_rgbBluer"))
 
 ;;; (rgb-greener rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a greener version of the rgb value.
 ;;; @category color, image, rgb, rgb-bluer, rgb-redder
-(define-export rgb-greener (js-var "image_rgbGreener"))
+(define-export rgb-greener (js-var "color_rgbGreener"))
 
 ;;; (rgb-pseudo-complement rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a pseudo-complement of the rgb value.
 ;;; @category color, image, rgb, rgb-greyscale, rgb-phaseshift, rgb-rotate-components
-(define-export rgb-pseudo-complement (js-var "image_rgbPseudoComplement"))
+(define-export rgb-pseudo-complement (js-var "color_rgbPseudoComplement"))
 
 ;;; (rgb-greyscale rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a greyscale version of the rgb value.
 ;;; @category color, image, rgb, rgb-phaseshift, rgb-rotate-components
-(define-export rgb-greyscale (js-var "image_rgbGreyscale"))
+(define-export rgb-greyscale (js-var "color_rgbGreyscale"))
 
 ;;; (rgb-phaseshift rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a phaseshifted version of the rgb value.
 ;;; @category color, image, rgb, rgb-greyscale, rgb-rotate-components
-(define-export rgb-phaseshift (js-var "image_rgbPhaseshift"))
+(define-export rgb-phaseshift (js-var "color_rgbPhaseshift"))
 
 ;;; (rgb-rotate-components rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a rotated version of the rgb value.
 ;;; @category color, image, rgb, rgb-greyscale, rgb-phaseshift
-(define-export rgb-rotate-components (js-var "image_rgbRotateComponents"))
+(define-export rgb-rotate-components (js-var "color_rgbRotateComponents"))
 
 ;;; (rgb-thin rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a thinner version of the rgb value.
 ;;; @category color, image, rgb, rgb-thicken
-(define-export rgb-thin (js-var "image_rgbThin"))
+(define-export rgb-thin (js-var "color_rgbThin"))
 
 ;;; (rgb-thicken rgb) -> rgb?
 ;;;  rgb : rgb?
 ;;; Returns a thicker version of the rgb value.
 ;;; @category color, image, rgb, rgb-thin
-(define-export rgb-thicken (js-var "image_rgbThicken"))
+(define-export rgb-thicken (js-var "color_rgbThicken"))
 
 ;;; (rgb-add rgb1 rgb2) -> rgb?
 ;;;  rgb1 : rgb?
 ;;;  rgb2 : rgb?
 ;;; Returns the sum of the two rgb values.
 ;;; @category color, image, rgb, rgb-subtract, rgb-average
-(define-export rgb-add (js-var "image_rgbAdd"))
+(define-export rgb-add (js-var "color_rgbAdd"))
 
 ;;; (rgb-subtract rgb1 rgb2) -> rgb?
 ;;;  rgb1 : rgb?
 ;;;  rgb2 : rgb?
 ;;; Returns the difference of the two rgb values.
 ;;; @category color, image, rgb, rgb-add, rgb-average
-(define-export rgb-subtract (js-var "image_rgbSubtract"))
+(define-export rgb-subtract (js-var "color_rgbSubtract"))
 
 ;;; (rgb-average rgb1 rgb2) -> rgb?
 ;;;  rgb1 : rgb?
 ;;;  rgb2 : rgb?
 ;;; Returns the average of the two rgb values.
 ;;; @category color, image, rgb, rgb-add, rgb-subtract
-(define-export rgb-average (js-var "image_rgbAverage"))
+(define-export rgb-average (js-var "color_rgbAverage"))
 
 ;;; (font? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a font.
 ;;; @category image, typecheck, font, text
-(define-export font? (js-var "image_fontQ"))
+(define-export font? (js-var "font_fontQ"))
 
 ;;; (font face system-face bold? italic?) -> font?
 ;;;  face : any
@@ -288,19 +288,19 @@
 ;;;   boolean? (optional, default #f)
 ;;; Returns a new font value with the given arguments. The `system-face` name is drawn from one of the possible system font families, a list can be found on [MDN (font-family)](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#syntax)
 ;;; @category image, font?, text
-(define-export font (js-var "image_font"))
+(define-export font (js-var "font_font"))
 
 ;;; (drawing? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a drawing: the kind of value the shape constructors build. A canvas is not a drawing, and neither is a loaded image file.
 ;;; @category image, predicates, typecheck, shapes, canvas?
-(define-export drawing? (js-var "image_drawingQ"))
+(define-export drawing? (js-var "drawing_drawingQ"))
 
 ;;; (fill-mode? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a fill mode: the string `"solid"` or `"outline"`.
 ;;; @category image, shapes, typecheck, predicates, ellipse, rectangle
-(define-export fill-mode? (js-var "image_fillModeQ"))
+(define-export fill-mode? (js-var "drawing_fillModeQ"))
 
 ;;; (ellipse width height fill color) -> drawing?
 ;;;  width : integer?
@@ -309,7 +309,7 @@
 ;;;  color : color?
 ;;; Returns a new drawing containing an ellipse with dimensions `width × height`.
 ;;; @category image, shapes, solid-ellipse, outlined-ellipse
-(define-export ellipse (js-var "image_ellipse"))
+(define-export ellipse (js-var "drawing_ellipse"))
 
 ;;; (circle radius fill color) -> drawing?
 ;;;  radius : number?
@@ -319,7 +319,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a circle of radius `radius`.
 ;;; @category image, shapes, solid-circle, outlined-circle
-(define-export circle (js-var "image_circle"))
+(define-export circle (js-var "drawing_circle"))
 
 ;;; (rectangle width height fill color) -> drawing?
 ;;;  width : number?
@@ -330,7 +330,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a rectangle with dimensions `width × height`.
 ;;; @category image, shapes, solid-rectangle, outlined-rectangle
-(define-export rectangle (js-var "image_rectangle"))
+(define-export rectangle (js-var "drawing_rectangle"))
 
 ;;; (square width fill color) -> drawing?
 ;;;  width : number?
@@ -340,7 +340,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a square with length `width`.
 ;;; @category image, shapes, solid-square, outlined-square
-(define-export square (js-var "image_square"))
+(define-export square (js-var "drawing_square"))
 
 ;;; (triangle length fill color) -> drawing?
 ;;;  length : number?
@@ -350,7 +350,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a equilateral triangle with length `length`.
 ;;; @category image, shapes, solid-triangle, outlined-triangle
-(define-export triangle (js-var "image_triangle"))
+(define-export triangle (js-var "drawing_triangle"))
 
 ;;; (isosceles-triangle width height fill color) -> drawing?
 ;;;  width : number?
@@ -361,7 +361,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a isosceles triangle with base `base` and height `height`.
 ;;; @category image, shapes, solid-isosceles-triangle, outlined-isosceles-triangle
-(define-export isosceles-triangle (js-var "image_isoscelesTriangle"))
+(define-export isosceles-triangle (js-var "drawing_isoscelesTriangle"))
 
 ;;; (path width height points fill color) -> drawing?
 ;;;  width : number?
@@ -374,13 +374,13 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing with dimensions `width × height` formed by connecting the points in `points` with straight lines. The points are specified as a `pair` of coordinates.
 ;;; @category image, path, with-dash
-(define-export path (js-var "image_path"))
+(define-export path (js-var "drawing_path"))
 
 ;;; (beside & d1) -> drawing?
 ;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., beside each other (horizontally).
 ;;; @category composition/placement, image, beside/align, above, above/align, overlay, overlay/align, overlay/offset, rotate
-(define-export beside (js-var "image_beside"))
+(define-export beside (js-var "drawing_beside"))
 
 ;;; (beside/align align & d1) -> drawing?
 ;;;  align : string?
@@ -388,13 +388,13 @@
 ;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., beside each other on the x-axis, aligning them along the y-axis according to `align`.
 ;;; @category composition/placement, image, beside, above, above/align, overlay, overlay/align, overlay/offset, rotate
-(define-export beside/align (js-var "image_besideAlign"))
+(define-export beside/align (js-var "drawing_besideAlign"))
 
 ;;; (above & d1) -> drawing?
 ;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., above each other (vertically in descending order).
 ;;; @category composition/placement, image, beside, beside/align, above/align, overlay, overlay/align, overlay/offset, rotate
-(define-export above (js-var "image_above"))
+(define-export above (js-var "drawing_above"))
 
 ;;; (above/align align & d1) -> drawing?
 ;;;  align : string?
@@ -402,13 +402,13 @@
 ;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., above each other on the y-axis, aligning them along the x-axis according to `align`.
 ;;; @category composition/placement, image, beside, beside/align, above, overlay, overlay/align, overlay/offset, rotate
-(define-export above/align (js-var "image_aboveAlign"))
+(define-export above/align (js-var "drawing_aboveAlign"))
 
 ;;; (overlay & d1) -> drawing?
 ;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., on top of each other. (`d1` is the topmost drawing).
 ;;; @category composition/placement, image, beside, beside/align, above, above/align, overlay/align, overlay/offset, rotate
-(define-export overlay (js-var "image_overlay"))
+(define-export overlay (js-var "drawing_overlay"))
 
 ;;; (overlay/align xAlign yAlign & d1) -> drawing?
 ;;;  xAlign : string?
@@ -418,7 +418,7 @@
 ;;;  d1 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1`, `d2`, ..., on top of each other, aligning them according to `xAlign` and `yAlign`.
 ;;; @category composition/placement, image, beside, beside/align, above, above/align, overlay, overlay/offset, rotate
-(define-export overlay/align (js-var "image_overlayAlign"))
+(define-export overlay/align (js-var "drawing_overlayAlign"))
 
 ;;; (overlay/offset dx dy d1 d2) -> drawing?
 ;;;  dx : number?
@@ -427,7 +427,7 @@
 ;;;  d2 : drawing?
 ;;; Creates a new drawing formed by places the drawing `d1` on top of `d2`, offset by `(dx, dy)`.
 ;;; @category composition/placement, image, beside, beside/align, above, above/align, overlay, overlay/align, rotate
-(define-export overlay/offset (js-var "image_overlayOffset"))
+(define-export overlay/offset (js-var "drawing_overlayOffset"))
 
 ;;; (rotate angle d) -> drawing?
 ;;;  angle : number?
@@ -435,7 +435,7 @@
 ;;;  d : drawing?
 ;;; Returns a new drawing formed by rotating drawing `d` by `angle` degrees around the center of its bounding box. Note: currently buggy and shifts off-center.
 ;;; @category image, beside, beside/align, above, above/align, overlay, overlay/align, overlay/offset
-(define-export rotate (js-var "image_rotate"))
+(define-export rotate (js-var "drawing_rotate"))
 
 ;;; (with-dash dash-spec d) -> drawing?
 ;;;  dash-spec : list?
@@ -443,7 +443,7 @@
 ;;;  d : drawing?
 ;;; Returns a new drawing formed by drawing `d` but with lines drawn according to `dash-spec`. `dash-spec` is an list of numbers where each successive pair of numbers describe the length of a dash and the length of the subsequent gap.
 ;;; @category canvas, image, shapes, path-func
-(define-export with-dash (js-var "image_withDash"))
+(define-export with-dash (js-var "drawing_withDash"))
 
 ;;; (text str size color & font) -> drawing?
 ;;;  str : string?
@@ -454,7 +454,7 @@
 ;;;   font? (optional, default (font "Arial"))
 ;;; Returns a new drawing formed by drawing `str` with the given arguments.
 ;;; @category image, font, font?
-(define-export text (js-var "image_text"))
+(define-export text (js-var "drawing_text"))
 
 ;;; (solid-square width color) -> drawing?
 ;;;  width : number?
@@ -462,7 +462,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a solid square with length `width`.
 ;;; @category image, shapes, square, outlined-square
-(define-export solid-square (js-var "image_solidSquare"))
+(define-export solid-square (js-var "drawing_solidSquare"))
 
 ;;; (outlined-square width color) -> drawing?
 ;;;  width : number?
@@ -470,7 +470,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of an outline square with length `width`.
 ;;; @category image, shapes, square, solid-square
-(define-export outlined-square (js-var "image_outlinedSquare"))
+(define-export outlined-square (js-var "drawing_outlinedSquare"))
 
 ;;; (solid-rectangle width height color) -> drawing?
 ;;;  width : number?
@@ -479,7 +479,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a solid rectangle with dimensions `width × height`.
 ;;; @category image, shapes, rectangle, outlined-rectangle
-(define-export solid-rectangle (js-var "image_solidRectangle"))
+(define-export solid-rectangle (js-var "drawing_solidRectangle"))
 
 ;;; (outlined-rectangle width height color) -> drawing?
 ;;;  width : number?
@@ -488,7 +488,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of an outlined rectangle with dimensions `width × height`.
 ;;; @category image, shapes, rectangle, solid-rectangle
-(define-export outlined-rectangle (js-var "image_outlinedRectangle"))
+(define-export outlined-rectangle (js-var "drawing_outlinedRectangle"))
 
 ;;; (solid-circle radius color) -> drawing?
 ;;;  radius : number?
@@ -496,7 +496,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a solid circle of radius `radius`.
 ;;; @category image, shapes, circle, outlined-circle
-(define-export solid-circle (js-var "image_solidCircle"))
+(define-export solid-circle (js-var "drawing_solidCircle"))
 
 ;;; (outlined-circle radius color) -> drawing?
 ;;;  radius : number?
@@ -504,7 +504,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of an outlined circle of radius `radius`.
 ;;; @category image, shapes, circle, solid-circle
-(define-export outlined-circle (js-var "image_outlinedCircle"))
+(define-export outlined-circle (js-var "drawing_outlinedCircle"))
 
 ;;; (solid-ellipse width height color) -> drawing?
 ;;;  width : integer?
@@ -512,7 +512,7 @@
 ;;;  color : color?
 ;;; Returns a new drawing containing a solid ellipse with dimensions `width × height`.
 ;;; @category image, shapes, ellipse, outlined-ellipse
-(define-export solid-ellipse (js-var "image_solidEllipse"))
+(define-export solid-ellipse (js-var "drawing_solidEllipse"))
 
 ;;; (outlined-ellipse width height color) -> drawing?
 ;;;  width : integer?
@@ -520,7 +520,7 @@
 ;;;  color : color?
 ;;; Returns a new drawing containing an outlined ellipse with dimensions `width × height`.
 ;;; @category image, shapes, ellipse, solid-ellipse
-(define-export outlined-ellipse (js-var "image_outlinedEllipse"))
+(define-export outlined-ellipse (js-var "drawing_outlinedEllipse"))
 
 ;;; (solid-triangle length color) -> drawing?
 ;;;  length : number?
@@ -528,7 +528,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a solid equilateral triangle with length `length`.
 ;;; @category image, shapes, triangle, outlined-triangle
-(define-export solid-triangle (js-var "image_solidTriangle"))
+(define-export solid-triangle (js-var "drawing_solidTriangle"))
 
 ;;; (outlined-triangle length color) -> drawing?
 ;;;  length : number?
@@ -536,7 +536,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of an outlined equilateral triangle with length `length`.
 ;;; @category image, shapes, triangle, solid-triangle
-(define-export outlined-triangle (js-var "image_outlinedTriangle"))
+(define-export outlined-triangle (js-var "drawing_outlinedTriangle"))
 
 ;;; (solid-isosceles-triangle width height color) -> drawing?
 ;;;  width : number?
@@ -545,7 +545,7 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of a solid isosceles triangle with base `base` and height `height`.
 ;;; @category image, shapes, isosceles-triangle, outlined-isosceles-triangle
-(define-export solid-isosceles-triangle (js-var "image_solidIsoscelesTriangle"))
+(define-export solid-isosceles-triangle (js-var "drawing_solidIsoscelesTriangle"))
 
 ;;; (outlined-isosceles-triangle width height color) -> drawing?
 ;;;  width : number?
@@ -554,44 +554,44 @@
 ;;;   either a color name or the form "rgba(r, g, b, a)"
 ;;; Returns a drawing consisting of an outlined isosceles triangle with base `base` and height `height`.
 ;;; @category image, shapes, isosceles-triangle, solid-isosceles-triangle
-(define-export outlined-isosceles-triangle (js-var "image_outlinedIsoscelesTriangle"))
+(define-export outlined-isosceles-triangle (js-var "drawing_outlinedIsoscelesTriangle"))
 
 ;;; (drawing-width drawing) -> number?
 ;;;  drawing : drawing?
 ;;; Returns the width of the drawing.
 ;;; @category image, drawing-height
-(define-export drawing-width (js-var "image_imageWidth"))
+(define-export drawing-width (js-var "drawing_drawingWidth"))
 
 ;;; (drawing-height drawing) -> number?
 ;;;  drawing : drawing?
 ;;; Returns the height of the drawing.
 ;;; @category image, drawing-width
-(define-export drawing-height (js-var "image_imageHeight"))
+(define-export drawing-height (js-var "drawing_drawingHeight"))
 
 ;;; (drawing-color drawing) -> rgb?
 ;;;  drawing : drawing?
 ;;; Returns the color of the drawing. For a composite drawing, this is the average of its parts' colors.
 ;;; @category image, drawing-recolor
-(define-export drawing-color (js-var "image_imageColor"))
+(define-export drawing-color (js-var "drawing_drawingColor"))
 
 ;;; (drawing-recolor drawing color) -> drawing?
 ;;;  drawing : drawing?
 ;;;  color : color?
 ;;; Returns a new drawing with the same dimensions as `drawing` but with the color `color`.
 ;;; @category image, drawing-color
-(define-export drawing-recolor (js-var "image_imageRecolor"))
+(define-export drawing-recolor (js-var "drawing_drawingRecolor"))
 
 ;;; (drawing->pixels d) -> vector?
 ;;;  d : drawing?
 ;;; Returns a vector of rgb values corresponding to the pixels of the given drawing.
 ;;; @category image, pixel, drawing->canvas
-(define-export drawing->pixels (js-var "image_drawingToPixels"))
+(define-export drawing->pixels (js-var "drawing_drawingToPixels"))
 
 ;;; (drawing->canvas drawing) -> canvas?
 ;;;  drawing : drawing?
 ;;; Renders `drawing` onto a new canvas and returns it.
 ;;; @category image, pixel, drawing->pixels
-(define-export drawing->canvas (js-var "image_drawingToImage"))
+(define-export drawing->canvas (js-var "drawing_drawingToCanvas"))
 
 ;;; (with-image-file callback) -> html?
 ;;;  callback : procedure?
@@ -625,19 +625,19 @@
 ;;;  y : integer?
 ;;; Returns the rgb value of the pixel at position `(x, y)` of `canvas`.
 ;;; @category color, image, pixel, rgb, pixel-map, canvas->pixels, pixels->canvas, canvas-set-pixels! 
-(define-export canvas-get-pixel (js-var "image_imageGetPixel"))
+(define-export canvas-get-pixel (js-var "canvas_canvasGetPixel"))
 
 ;;; (pixels? v) -> boolean?
 ;;;  v : any
 ;;; Returns `#t` if and only if `v` is a vector of `rgb` values, the representation `canvas->pixels` produces and `pixels->canvas` consumes.
 ;;; @category image, pixel, typecheck, predicates, canvas->pixels, pixels->canvas
-(define-export pixels? (js-var "image_pixelsQ"))
+(define-export pixels? (js-var "canvas_pixelsQ"))
 
 ;;; (canvas->pixels canvas) -> pixels?
 ;;;  canvas : canvas?
 ;;; Returns the pixels of `canvas` as a vector of `rgb` values, read left-to-right and top-to-bottom. The result is a snapshot: changing it does not change `canvas`. Use `canvas-set-pixels!` to write pixels back.
 ;;; @category image, pixel-map, canvas-get-pixel, pixels->canvas, canvas-set-pixels! 
-(define-export canvas->pixels (js-var "image_imageToPixels"))
+(define-export canvas->pixels (js-var "canvas_canvasToPixels"))
 
 ;;; (pixels->canvas pixels width height) -> canvas?
 ;;;  pixels : pixels?
@@ -645,14 +645,14 @@
 ;;;  height : integer?
 ;;; Returns a new canvas with the given `pixels` and dimensions `width × height`.
 ;;; @category image, pixel, pixel-map, canvas-get-pixel, canvas->pixels, canvas-set-pixels! 
-(define-export pixels->canvas (js-var "image_pixelsToImage"))
+(define-export pixels->canvas (js-var "canvas_pixelsToCanvas"))
 
 ;;; (canvas-set-pixels! canvas pixels) -> void?
 ;;;  canvas : canvas?
 ;;;  pixels : pixels?
 ;;; Sets the pixels of `canvas` to `pixels`, mutating it in place.
 ;;; @category canvas, image, mutation, pixel, predicates, pixel-map, canvas-get-pixel, canvas->pixels, pixels->canvas
-(define-export canvas-set-pixels! (js-var "image_canvasSetPixels"))
+(define-export canvas-set-pixels! (js-var "canvas_canvasSetPixels"))
 
 ;;; (canvas-width canvas) -> integer?
 ;;;  canvas : canvas?

--- a/test/libs/canvas.browser.test.ts
+++ b/test/libs/canvas.browser.test.ts
@@ -15,8 +15,8 @@ import {
   canvas_canvasRectangle,
   canvas_canvasText,
 } from '../../src/js/canvas/index.js'
-import { image_ellipse } from '../../src/js/image/drawing.js'
-import { image_font } from '../../src/js/image/font.js'
+import { drawing_ellipse } from '../../src/js/image/drawing.js'
+import { font_font } from '../../src/js/image/font.js'
 
 function makeCanvas(width: number, height: number): HTMLCanvasElement {
   const canvas = document.createElement('canvas')
@@ -131,7 +131,7 @@ describe('canvas-text!', () => {
 
   test('solid draws filled glyphs using an explicit font', () => {
     const canvas = makeCanvas(100, 50)
-    canvas_canvasText(canvas, 10, 40, 'W', 24, 'solid', 'red', image_font('Georgia', 'serif', true, true))
+    canvas_canvasText(canvas, 10, 40, 'W', 24, 'solid', 'red', font_font('Georgia', 'serif', true, true))
     expect(hasColorPixel(canvas, 255, 0, 0)).toBe(true)
   })
 
@@ -153,16 +153,16 @@ describe('canvas-text!', () => {
 
   test('2 or more extra arguments throws', () => {
     const canvas = makeCanvas(100, 50)
-    expect(() => { canvas_canvasText(canvas, 10, 40, 'W', 30, 'solid', 'red', image_font('Arial'), 'extra') }).toThrow(L.ScamperError)
+    expect(() => { canvas_canvasText(canvas, 10, 40, 'W', 30, 'solid', 'red', font_font('Arial'), 'extra') }).toThrow(L.ScamperError)
   })
 })
 
 describe('canvas-drawing!', () => {
   test('renders a drawing at the given offset', () => {
     const canvas = makeCanvas(30, 30)
-    const drawing = image_ellipse(10, 10, 'solid', 'purple')
+    const drawing = drawing_ellipse(10, 10, 'solid', 'purple')
     canvas_canvasDrawing(canvas, 5, 5, drawing)
-    // image_render centers the ellipse's bounding box at (x + w/2, y + h/2)
+    // drawing_render centers the ellipse's bounding box at (x + w/2, y + h/2)
     expect(pixel(canvas, 10, 10)).toEqual([128, 0, 128, 255])
     expect(pixel(canvas, 1, 1)).toEqual([0, 0, 0, 0])
   })

--- a/test/libs/canvas.test.ts
+++ b/test/libs/canvas.test.ts
@@ -84,7 +84,7 @@ describe('canvas-onclick!', () => {
 
 // Regression: color? and image? are used in canvas.scm's drawing-function
 // contracts but defined in image.scm. canvas.scm must re-export them; otherwise
-// every drawing call runs `(color? ...)` / `(image? ...)` against an unbound
+// every drawing call runs `(color? ...)` / `(drawing? ...)` against an unbound
 // name and throws "Variable not found" unless the user also imports image.
 describe('cross-module predicates (color?, image?) resolve with only canvas imported', () => {
   test('color? and image? are in scope', async () => {
@@ -92,7 +92,7 @@ describe('cross-module predicates (color?, image?) resolve with only canvas impo
     (import canvas)
     (color? "red")
     (color? 5)
-    (image? 5)
+    (drawing? 5)
     `)).toEqual(['#t', '#f', '#f'])
   })
 

--- a/test/libs/image.browser.test.ts
+++ b/test/libs/image.browser.test.ts
@@ -304,7 +304,7 @@ describe('drawing->pixels', () => {
 // N.B., pixel-map is now defined in Scheme (image.scm) on top of image->pixels,
 // vector-map, and pixels->image, so it is exercised end-to-end via runProgram in
 // image.test.ts rather than by a direct JS call here. The underlying pixel
-// round-trip (image->pixels / pixels->image / image-get-pixel) is covered below.
+// round-trip (canvas->pixels / pixels->image / image-get-pixel) is covered below.
 
 describe('pixels->image, image-get-pixel, image->pixels, canvas-set-pixels!', () => {
   // distinct RGBA per cell, row-major: top-left, top-right, bottom-left, bottom-right

--- a/test/libs/image.browser.test.ts
+++ b/test/libs/image.browser.test.ts
@@ -10,38 +10,38 @@
 import { describe, expect, test } from 'vitest'
 import * as L from '../../src/lpm'
 import {
-  image_colorToRgb,
-  image_hsv,
-  image_hsvAlpha,
-  image_hsvComplement,
-  image_hsvHue,
-  image_hsvSaturation,
-  image_hsvToRgb,
-  image_hsvToString,
-  image_hsvValue,
-  image_rgb,
-  image_rgbToHsv,
+  color_colorToRgb,
+  color_hsv,
+  color_hsvAlpha,
+  color_hsvComplement,
+  color_hsvHue,
+  color_hsvSaturation,
+  color_hsvToRgb,
+  color_hsvToString,
+  color_hsvValue,
+  color_rgb,
+  color_rgbToHsv,
 } from '../../src/js/image/color.js'
 import {
-  image_above,
-  image_beside,
-  image_drawingToImage,
-  image_drawingToPixels,
-  image_ellipse,
-  image_isoscelesTriangle,
-  image_overlay,
-  image_overlayOffset,
-  image_path,
-  image_rectangle,
-  image_rotate,
-  image_text,
-  image_withDash,
+  drawing_above,
+  drawing_beside,
+  drawing_drawingToCanvas,
+  drawing_drawingToPixels,
+  drawing_ellipse,
+  drawing_isoscelesTriangle,
+  drawing_overlay,
+  drawing_overlayOffset,
+  drawing_path,
+  drawing_rectangle,
+  drawing_rotate,
+  drawing_text,
+  drawing_withDash,
 } from '../../src/js/image/drawing.js'
 import {
-  image_canvasSetPixels,
-  image_imageGetPixel,
-  image_imageToPixels,
-  image_pixelsToImage,
+  canvas_canvasSetPixels,
+  canvas_canvasGetPixel,
+  canvas_canvasToPixels,
+  canvas_pixelsToCanvas,
 } from '../../src/js/image/image.js'
 
 function makeCanvas(width: number, height: number): HTMLCanvasElement {
@@ -63,7 +63,7 @@ function pixel(canvas: HTMLCanvasElement, x: number, y: number): number[] {
   return Array.from(context2d(canvas).getImageData(x, y, 1, 1).data)
 }
 
-// True if any pixel departs from the opaque-white background image_clearDrawing
+// True if any pixel departs from the opaque-white background drawing_clearDrawing
 // lays down -- i.e. the drawing actually put ink on the canvas.
 function hasColoredPixel(canvas: HTMLCanvasElement): boolean {
   const data = context2d(canvas).getImageData(0, 0, canvas.width, canvas.height).data
@@ -90,33 +90,33 @@ function redPixelCount(canvas: HTMLCanvasElement): number {
 
 describe('text', () => {
   test('reports positive width and height', () => {
-    const t = image_text('hello', 20, image_rgb(0, 0, 0, 255))
+    const t = drawing_text('hello', 20, color_rgb(0, 0, 0, 255))
     expect(t.width).toBeGreaterThan(0)
     expect(t.height).toBeGreaterThan(0)
   })
 
   test('longer text is wider', () => {
-    const short = image_text('a', 20, image_rgb(0, 0, 0, 255))
-    const long = image_text('a much longer piece of text', 20, image_rgb(0, 0, 0, 255))
+    const short = drawing_text('a', 20, color_rgb(0, 0, 0, 255))
+    const long = drawing_text('a much longer piece of text', 20, color_rgb(0, 0, 0, 255))
     expect(long.width).toBeGreaterThan(short.width)
   })
 
   test('a larger size produces a larger width and height', () => {
-    const small = image_text('hello', 10, image_rgb(0, 0, 0, 255))
-    const big = image_text('hello', 40, image_rgb(0, 0, 0, 255))
+    const small = drawing_text('hello', 10, color_rgb(0, 0, 0, 255))
+    const big = drawing_text('hello', 40, color_rgb(0, 0, 0, 255))
     expect(big.width).toBeGreaterThan(small.width)
     expect(big.height).toBeGreaterThan(small.height)
   })
 
   test('empty text has zero width', () => {
-    const t = image_text('', 20, image_rgb(0, 0, 0, 255))
+    const t = drawing_text('', 20, color_rgb(0, 0, 0, 255))
     expect(t.width).toBe(0)
   })
 })
 
 describe('drawing->image', () => {
   test('renders a single shape to a canvas of the drawing size', () => {
-    const canvas = image_drawingToImage(image_rectangle(2, 2, 'solid', 'red'))
+    const canvas = drawing_drawingToCanvas(drawing_rectangle(2, 2, 'solid', 'red'))
     expect(canvas.width).toBe(2)
     expect(canvas.height).toBe(2)
     expect(pixel(canvas, 0, 0)).toEqual([255, 0, 0, 255])
@@ -124,11 +124,11 @@ describe('drawing->image', () => {
   })
 
   test('renders a composite drawing tree, positioning each subdrawing', () => {
-    const tree = image_beside(
-      image_rectangle(2, 2, 'solid', 'red'),
-      image_rectangle(2, 2, 'solid', 'blue'),
+    const tree = drawing_beside(
+      drawing_rectangle(2, 2, 'solid', 'red'),
+      drawing_rectangle(2, 2, 'solid', 'blue'),
     )
-    const canvas = image_drawingToImage(tree)
+    const canvas = drawing_drawingToCanvas(tree)
     expect(canvas.width).toBe(4)
     expect(canvas.height).toBe(2)
     expect(pixel(canvas, 0, 0)).toEqual([255, 0, 0, 255])
@@ -136,18 +136,18 @@ describe('drawing->image', () => {
   })
 })
 
-// One test per image_render branch, driven end-to-end through a real Canvas2D.
+// One test per drawing_render branch, driven end-to-end through a real Canvas2D.
 // rectangle and beside are already exercised by drawing->image above.
 describe('render per-shape branches', () => {
   test('ellipse fills its interior', () => {
-    const canvas = image_drawingToImage(image_ellipse(10, 10, 'solid', 'red'))
+    const canvas = drawing_drawingToCanvas(drawing_ellipse(10, 10, 'solid', 'red'))
     expect(canvas.width).toBe(10)
     expect(canvas.height).toBe(10)
     expect(pixel(canvas, 5, 5)).toEqual([255, 0, 0, 255])
   })
 
   test('triangle fills its interior', () => {
-    const canvas = image_drawingToImage(image_isoscelesTriangle(10, 10, 'solid', 'blue'))
+    const canvas = drawing_drawingToCanvas(drawing_isoscelesTriangle(10, 10, 'solid', 'blue'))
     expect(canvas.width).toBe(10)
     expect(canvas.height).toBe(10)
     expect(pixel(canvas, 5, 8)).toEqual([0, 0, 255, 255])
@@ -157,7 +157,7 @@ describe('render per-shape branches', () => {
     const points = L.mkList(
       L.mkPair(0, 0), L.mkPair(10, 0), L.mkPair(10, 10), L.mkPair(0, 10),
     )
-    const canvas = image_drawingToImage(image_path(10, 10, points, 'solid', 'green'))
+    const canvas = drawing_drawingToCanvas(drawing_path(10, 10, points, 'solid', 'green'))
     expect(canvas.width).toBe(10)
     expect(canvas.height).toBe(10)
     // green is (0, 128, 0); alpha 255 keeps the mid-range channel exact
@@ -165,14 +165,14 @@ describe('render per-shape branches', () => {
   })
 
   test('ellipse outline strokes its boundary', () => {
-    const canvas = image_drawingToImage(image_ellipse(10, 10, 'outline', 'red'))
+    const canvas = drawing_drawingToCanvas(drawing_ellipse(10, 10, 'outline', 'red'))
     expect(canvas.width).toBe(10)
     expect(canvas.height).toBe(10)
     expect(hasColoredPixel(canvas)).toBe(true)
   })
 
   test('triangle outline strokes its edges', () => {
-    const canvas = image_drawingToImage(image_isoscelesTriangle(10, 10, 'outline', 'blue'))
+    const canvas = drawing_drawingToCanvas(drawing_isoscelesTriangle(10, 10, 'outline', 'blue'))
     expect(canvas.width).toBe(10)
     expect(canvas.height).toBe(10)
     expect(hasColoredPixel(canvas)).toBe(true)
@@ -180,16 +180,16 @@ describe('render per-shape branches', () => {
 
   test('path outline strokes the polyline it traces', () => {
     const points = L.mkList(L.mkPair(1, 1), L.mkPair(8, 1), L.mkPair(4, 8))
-    const canvas = image_drawingToImage(image_path(10, 10, points, 'outline', 'green'))
+    const canvas = drawing_drawingToCanvas(drawing_path(10, 10, points, 'outline', 'green'))
     expect(canvas.width).toBe(10)
     expect(canvas.height).toBe(10)
     expect(hasColoredPixel(canvas)).toBe(true)
   })
 
   test('above stacks subdrawings vertically', () => {
-    const canvas = image_drawingToImage(image_above(
-      image_rectangle(4, 4, 'solid', 'red'),
-      image_rectangle(4, 4, 'solid', 'blue'),
+    const canvas = drawing_drawingToCanvas(drawing_above(
+      drawing_rectangle(4, 4, 'solid', 'red'),
+      drawing_rectangle(4, 4, 'solid', 'blue'),
     ))
     expect(canvas.width).toBe(4)
     expect(canvas.height).toBe(8)
@@ -198,9 +198,9 @@ describe('render per-shape branches', () => {
   })
 
   test('overlay draws the first drawing on top of the rest', () => {
-    const canvas = image_drawingToImage(image_overlay(
-      image_rectangle(4, 4, 'solid', 'blue'),
-      image_rectangle(8, 8, 'solid', 'red'),
+    const canvas = drawing_drawingToCanvas(drawing_overlay(
+      drawing_rectangle(4, 4, 'solid', 'blue'),
+      drawing_rectangle(8, 8, 'solid', 'red'),
     ))
     expect(canvas.width).toBe(8)
     expect(canvas.height).toBe(8)
@@ -209,10 +209,10 @@ describe('render per-shape branches', () => {
   })
 
   test('overlay/offset shifts the second drawing and keeps the first on top', () => {
-    const canvas = image_drawingToImage(image_overlayOffset(
+    const canvas = drawing_drawingToCanvas(drawing_overlayOffset(
       2, 2,
-      image_rectangle(4, 4, 'solid', 'red'),
-      image_rectangle(4, 4, 'solid', 'blue'),
+      drawing_rectangle(4, 4, 'solid', 'red'),
+      drawing_rectangle(4, 4, 'solid', 'blue'),
     ))
     expect(canvas.width).toBe(6)
     expect(canvas.height).toBe(6)
@@ -221,21 +221,21 @@ describe('render per-shape branches', () => {
   })
 
   test('rotate fills the interior of its grown bounding box', () => {
-    const canvas = image_drawingToImage(image_rotate(90, image_rectangle(10, 20, 'solid', 'red')))
+    const canvas = drawing_drawingToCanvas(drawing_rotate(90, drawing_rectangle(10, 20, 'solid', 'red')))
     expect(canvas.width).toBeGreaterThan(0)
     expect(canvas.height).toBeGreaterThan(0)
     expect(pixel(canvas, 10, 5)).toEqual([255, 0, 0, 255])
   })
 
   test('with-dash strokes a dashed outline', () => {
-    const canvas = image_drawingToImage(image_withDash([4, 4], image_rectangle(20, 20, 'outline', 'red')))
+    const canvas = drawing_drawingToCanvas(drawing_withDash([4, 4], drawing_rectangle(20, 20, 'outline', 'red')))
     expect(canvas.width).toBe(20)
     expect(canvas.height).toBe(20)
     expect(hasColoredPixel(canvas)).toBe(true)
   })
 
   test('text draws visible ink on the canvas', () => {
-    const canvas = image_drawingToImage(image_text('H', 40, image_rgb(0, 0, 0, 255)))
+    const canvas = drawing_drawingToCanvas(drawing_text('H', 40, color_rgb(0, 0, 0, 255)))
     expect(canvas.width).toBeGreaterThan(0)
     expect(canvas.height).toBeGreaterThan(0)
     expect(hasColoredPixel(canvas)).toBe(true)
@@ -254,9 +254,9 @@ describe('rotate 0 is a no-op (#102)', () => {
   // top-left origin, so rotate-0 translated the circle down-right by its radius
   // -- its center read as background and ~3/4 of its ink fell off the canvas.
   test('does not shift or clip a circle', () => {
-    const circle = image_ellipse(20, 20, 'solid', 'red')
-    const plain = image_drawingToImage(circle)
-    const rotated = image_drawingToImage(image_rotate(0, circle))
+    const circle = drawing_ellipse(20, 20, 'solid', 'red')
+    const plain = drawing_drawingToCanvas(circle)
+    const rotated = drawing_drawingToCanvas(drawing_rotate(0, circle))
     // center pixel is red, not the white background it clipped to before
     expect(pixel(rotated, 10, 10)).toEqual([255, 0, 0, 255])
     // and about as much red survives as the un-rotated circle, not ~1/4
@@ -267,26 +267,26 @@ describe('rotate 0 is a no-op (#102)', () => {
   // Bug B: the overlay case reversed the shared child array in place, so
   // rotating an overlay flipped its z-order -- and mutated the caller's input.
   test('does not reverse an overlay it wraps', () => {
-    const ov = image_overlay(
-      image_rectangle(20, 20, 'solid', 'red'),
-      image_rectangle(20, 20, 'solid', 'blue'),
+    const ov = drawing_overlay(
+      drawing_rectangle(20, 20, 'solid', 'red'),
+      drawing_rectangle(20, 20, 'solid', 'blue'),
     )
     // red is listed first, so it draws on top: the center is red
-    expect(pixel(image_drawingToImage(ov), 10, 10)).toEqual([255, 0, 0, 255])
+    expect(pixel(drawing_drawingToCanvas(ov), 10, 10)).toEqual([255, 0, 0, 255])
     // rotating the overlay must not touch `ov`...
-    image_rotate(0, ov)
+    drawing_rotate(0, ov)
     // ...so re-rendering the SAME overlay still shows red on top
-    expect(pixel(image_drawingToImage(ov), 10, 10)).toEqual([255, 0, 0, 255])
+    expect(pixel(drawing_drawingToCanvas(ov), 10, 10)).toEqual([255, 0, 0, 255])
   })
 })
 
 describe('drawing->pixels', () => {
   test('flattens a rendered drawing into a row-major Rgb array', () => {
-    const tree = image_beside(
-      image_rectangle(2, 2, 'solid', 'red'),
-      image_rectangle(2, 2, 'solid', 'blue'),
+    const tree = drawing_beside(
+      drawing_rectangle(2, 2, 'solid', 'red'),
+      drawing_rectangle(2, 2, 'solid', 'blue'),
     )
-    const pixels = image_drawingToPixels(tree)
+    const pixels = drawing_drawingToPixels(tree)
     expect(pixels.length).toBe(4 * 2)
     // row 0: red, red, blue, blue
     expect(pixels[0]).toMatchObject({ red: 255, green: 0, blue: 0, alpha: 255 })
@@ -309,14 +309,14 @@ describe('drawing->pixels', () => {
 describe('pixels->image, image-get-pixel, image->pixels, canvas-set-pixels!', () => {
   // distinct RGBA per cell, row-major: top-left, top-right, bottom-left, bottom-right
   const knownPixels = [
-    image_rgb(255, 0, 0, 255),
-    image_rgb(0, 255, 0, 128),
-    image_rgb(0, 0, 255, 64),
-    image_rgb(10, 20, 30, 255),
+    color_rgb(255, 0, 0, 255),
+    color_rgb(0, 255, 0, 128),
+    color_rgb(0, 0, 255, 64),
+    color_rgb(10, 20, 30, 255),
   ]
 
   test('pixels->image places each pixel at its row-major position', () => {
-    const canvas = image_pixelsToImage(knownPixels, 2, 2)
+    const canvas = canvas_pixelsToCanvas(knownPixels, 2, 2)
     expect(canvas.width).toBe(2)
     expect(canvas.height).toBe(2)
     expect(pixel(canvas, 0, 0)).toEqual([255, 0, 0, 255])
@@ -326,22 +326,22 @@ describe('pixels->image, image-get-pixel, image->pixels, canvas-set-pixels!', ()
   })
 
   test('image-get-pixel reads back the exact value at each coordinate', () => {
-    const canvas = image_pixelsToImage(knownPixels, 2, 2)
-    expect(image_imageGetPixel(canvas, 0, 0)).toMatchObject({ red: 255, green: 0, blue: 0, alpha: 255 })
-    expect(image_imageGetPixel(canvas, 1, 0)).toMatchObject({ red: 0, green: 255, blue: 0, alpha: 128 })
-    expect(image_imageGetPixel(canvas, 0, 1)).toMatchObject({ red: 0, green: 0, blue: 255, alpha: 64 })
-    expect(image_imageGetPixel(canvas, 1, 1)).toMatchObject({ red: 10, green: 20, blue: 30, alpha: 255 })
+    const canvas = canvas_pixelsToCanvas(knownPixels, 2, 2)
+    expect(canvas_canvasGetPixel(canvas, 0, 0)).toMatchObject({ red: 255, green: 0, blue: 0, alpha: 255 })
+    expect(canvas_canvasGetPixel(canvas, 1, 0)).toMatchObject({ red: 0, green: 255, blue: 0, alpha: 128 })
+    expect(canvas_canvasGetPixel(canvas, 0, 1)).toMatchObject({ red: 0, green: 0, blue: 255, alpha: 64 })
+    expect(canvas_canvasGetPixel(canvas, 1, 1)).toMatchObject({ red: 10, green: 20, blue: 30, alpha: 255 })
   })
 
   test('image->pixels flattens the canvas back into the original row-major array', () => {
-    const canvas = image_pixelsToImage(knownPixels, 2, 2)
-    const roundTripped = image_imageToPixels(canvas)
+    const canvas = canvas_pixelsToCanvas(knownPixels, 2, 2)
+    const roundTripped = canvas_canvasToPixels(canvas)
     expect(roundTripped).toEqual(knownPixels)
   })
 
   test('canvas-set-pixels! overwrites an existing canvas in place', () => {
     const canvas = makeCanvas(2, 2)
-    image_canvasSetPixels(canvas, knownPixels)
+    canvas_canvasSetPixels(canvas, knownPixels)
     expect(pixel(canvas, 0, 0)).toEqual([255, 0, 0, 255])
     expect(pixel(canvas, 1, 0)).toEqual([0, 255, 0, 128])
     expect(pixel(canvas, 0, 1)).toEqual([0, 0, 255, 64])
@@ -350,12 +350,12 @@ describe('pixels->image, image-get-pixel, image->pixels, canvas-set-pixels!', ()
 
   test('image-get-pixel on a freshly created canvas defaults to transparent black', () => {
     const canvas = makeCanvas(3, 3)
-    expect(image_imageGetPixel(canvas, 1, 1)).toMatchObject({ red: 0, green: 0, blue: 0, alpha: 0 })
+    expect(canvas_canvasGetPixel(canvas, 1, 1)).toMatchObject({ red: 0, green: 0, blue: 0, alpha: 0 })
   })
 
   test('image->pixels on a freshly created canvas is all transparent black', () => {
     const canvas = makeCanvas(2, 2)
-    const pixels = image_imageToPixels(canvas)
+    const pixels = canvas_canvasToPixels(canvas)
     expect(pixels.length).toBe(4)
     pixels.forEach(p => {
       expect(p).toMatchObject({ red: 0, green: 0, blue: 0, alpha: 0 })
@@ -368,59 +368,59 @@ describe('pixels->image, image-get-pixel, image->pixels, canvas-set-pixels!', ()
 // on it. Calling the functions directly here bypasses that layer and also lets
 // colorsys resolve correctly under Vite (see image.test.ts's rgb->hsv skip).
 describe('hsv colors (called directly to bypass #250)', () => {
-  const c = image_hsv(200, 50, 60, 128)
+  const c = color_hsv(200, 50, 60, 128)
 
   test('hsv-hue, hsv-saturation, hsv-value, hsv-alpha read each field', () => {
-    expect(image_hsvHue(c)).toBe(200)
-    expect(image_hsvSaturation(c)).toBe(50)
-    expect(image_hsvValue(c)).toBe(60)
-    expect(image_hsvAlpha(c)).toBe(128)
+    expect(color_hsvHue(c)).toBe(200)
+    expect(color_hsvSaturation(c)).toBe(50)
+    expect(color_hsvValue(c)).toBe(60)
+    expect(color_hsvAlpha(c)).toBe(128)
   })
 
   test('hsv-complement rotates the hue 180 degrees, preserving the other fields', () => {
-    const comp = image_hsvComplement(c)
-    expect(image_hsvHue(comp)).toBe(20)
-    expect(image_hsvSaturation(comp)).toBe(50)
-    expect(image_hsvValue(comp)).toBe(60)
-    expect(image_hsvAlpha(comp)).toBe(128)
+    const comp = color_hsvComplement(c)
+    expect(color_hsvHue(comp)).toBe(20)
+    expect(color_hsvSaturation(comp)).toBe(50)
+    expect(color_hsvValue(comp)).toBe(60)
+    expect(color_hsvAlpha(comp)).toBe(128)
   })
 
   test('hsv->string formats the components as percentages', () => {
-    expect(image_hsvToString(c)).toBe('hsv(200 50%  60% / 50%)')
+    expect(color_hsvToString(c)).toBe('hsv(200 50%  60% / 50%)')
   })
 
   test('rgb->hsv converts red to hue 0, full saturation and value', () => {
-    const hsv = image_rgbToHsv(image_rgb(255, 0, 0))
-    expect(image_hsvHue(hsv)).toBe(0)
-    expect(image_hsvSaturation(hsv)).toBe(100)
-    expect(image_hsvValue(hsv)).toBe(100)
-    expect(image_hsvAlpha(hsv)).toBe(255)
+    const hsv = color_rgbToHsv(color_rgb(255, 0, 0))
+    expect(color_hsvHue(hsv)).toBe(0)
+    expect(color_hsvSaturation(hsv)).toBe(100)
+    expect(color_hsvValue(hsv)).toBe(100)
+    expect(color_hsvAlpha(hsv)).toBe(255)
   })
 
   test('hsv->rgb converts a full-saturation red hue back to rgb red', () => {
-    const rgb = image_hsvToRgb(image_hsv(0, 100, 100, 255))
+    const rgb = color_hsvToRgb(color_hsv(0, 100, 100, 255))
     expect(rgb).toMatchObject({ red: 255, green: 0, blue: 0, alpha: 255 })
   })
 })
 
-describe('image_colorToRgb (colour normalization)', () => {
+describe('color_colorToRgb (colour normalization)', () => {
   // colorToRgb accepts an rgba struct, a colour-name string, or an hsv struct.
   // The hsv branch routes through colorsys (which resolves under Vite here but
   // not in the jsdom suite), and the fall-through rejects anything else.
   test('passes an rgba struct through unchanged', () => {
-    expect(image_colorToRgb(image_rgb(10, 20, 30))).toMatchObject({
+    expect(color_colorToRgb(color_rgb(10, 20, 30))).toMatchObject({
       red: 10, green: 20, blue: 30,
     })
   })
   test('converts a colour-name string', () => {
-    expect(image_colorToRgb('red')).toMatchObject({ red: 255, green: 0, blue: 0 })
+    expect(color_colorToRgb('red')).toMatchObject({ red: 255, green: 0, blue: 0 })
   })
   test('converts an hsv struct via colorsys', () => {
-    expect(image_colorToRgb(image_hsv(0, 100, 100))).toMatchObject({
+    expect(color_colorToRgb(color_hsv(0, 100, 100))).toMatchObject({
       red: 255, green: 0, blue: 0,
     })
   })
   test('throws on a value that is not a colour', () => {
-    expect(() => image_colorToRgb(42)).toThrow(/valid color/)
+    expect(() => color_colorToRgb(42)).toThrow(/valid color/)
   })
 })

--- a/test/libs/image.test.ts
+++ b/test/libs/image.test.ts
@@ -630,10 +630,10 @@ describe('color parameters accept every color representation', () => {
 ; N.B., ellipse's fill is a boolean while rectangle's is a "solid"/"outline"
 ; string -- an inconsistency in its own right, but a fill-mode one, not a
 ; color one, so out of scope here.
-(image-color (ellipse 10 20 #t (rgb 1 2 3)))
-(image-color (rectangle 10 20 "solid" (hsv 0 0 0)))
-(image-color (triangle 10 "solid" "red"))
-(image-color (path 10 10 (list (pair 0 0) (pair 5 5)) "solid" (rgb 4 5 6)))
+(drawing-color (ellipse 10 20 "solid" (rgb 1 2 3)))
+(drawing-color (rectangle 10 20 "solid" (hsv 0 0 0)))
+(drawing-color (triangle 10 "solid" "red"))
+(drawing-color (path 10 10 (list (pair 0 0) (pair 5 5)) "solid" (rgb 4 5 6)))
 `),
     ).toEqual([
       '(rgba 1 2 3 255)',
@@ -707,14 +707,14 @@ describe('drawing', () => {
     })
   })
 
-  describe('image? and shape?', () => {
+  describe('drawing?', () => {
     test('are aliases, true for any drawing', async () => {
       expect(
         await runProgram(`
 (import image)
-(image? (rectangle 10 10 "solid" "red"))
-(shape? (rectangle 10 10 "solid" "red"))
-(image? (beside (rectangle 10 10 "solid" "red") (circle 5 "solid" "blue")))
+(drawing? (rectangle 10 10 "solid" "red"))
+(drawing? (rectangle 10 10 "solid" "red"))
+(drawing? (beside (rectangle 10 10 "solid" "red") (circle 5 "solid" "blue")))
 `),
       ).toEqual(['#t', '#t', '#t'])
     })
@@ -723,9 +723,9 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image? 5)
-(shape? "shape")
-(image? (font "Arial" "sans-serif" #f #f))
+(drawing? 5)
+(drawing? "shape")
+(drawing? (font "Arial" "sans-serif" #f #f))
 `),
       ).toEqual(['#f', '#f', '#f'])
     })
@@ -739,24 +739,29 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(ellipse 10 20 #t "red")
-(ellipse 10 20 #f "blue")
+(ellipse 10 20 "solid" "red")
+(ellipse 10 20 "outline" "blue")
 `),
       ).toEqual([
-        '(ellipse 10 20 #t (rgba 255 0 0 255))',
-        '(ellipse 10 20 #f (rgba 0 0 255 255))',
+        '(ellipse 10 20 "solid" (rgba 255 0 0 255))',
+        '(ellipse 10 20 "outline" (rgba 0 0 255 255))',
       ])
     })
 
-    test('rejects a non-boolean fill or a non-color', async () => {
+    test('rejects a non-fill-mode fill or a non-color', async () => {
+      // #103: ellipse used to declare `fill : boolean?` -- alone among the seven
+      // primitives -- and a boolean matched neither render branch, so the call
+      // its own contract demanded drew nothing at all, silently.
       expect(
         await runProgram(`
 (import image)
-(ellipse 10 20 "solid" "red")
-(ellipse 10 20 #t 5)
+(ellipse 10 20 #t "red")
+(ellipse 10 20 "diagonal" "red")
+(ellipse 10 20 "solid" 5)
 `),
       ).toEqual([
-        'Runtime error: (error) expected a boolean, received string',
+        'Runtime error: (error) expected a fill-mode, received boolean',
+        'Runtime error: (error) expected a fill-mode, received string',
         'Runtime error: (error) expected a color, received number',
       ])
     })
@@ -765,7 +770,7 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(ellipse 10 20 #t)
+(ellipse 10 20 "solid")
 `),
       ).toEqual([
         'Runtime error: Arity mismatch in function call: expected 4 arguments, got 3',
@@ -800,14 +805,14 @@ describe('drawing', () => {
       ])
     })
 
-    test('rejects a non-string fill', async () => {
+    test('rejects a non-fill-mode fill', async () => {
       expect(
         await runProgram(`
 (import image)
 (circle 5 #t "red")
 `),
       ).toEqual([
-        'Runtime error: (error) expected a string, received boolean',
+        'Runtime error: (error) expected a fill-mode, received boolean',
       ])
     })
   })
@@ -826,13 +831,20 @@ describe('drawing', () => {
       ])
     })
 
-    test('accepts any string as fill, not just "solid"/"outline"', async () => {
+    test('rejects a fill that is not "solid" or "outline"', async () => {
+      // #103: an arbitrary fill string used to be accepted and stored, and then
+      // matched no render branch -- the shape silently did not draw. The
+      // fill-mode? contract stops it at the call instead.
       expect(
         await runProgram(`
 (import image)
 (rectangle 10 20 "diagonal" "red")
+(rectangle 10 20 "Solid" "red")
 `),
-      ).toEqual(['(rectangle 10 20 "diagonal" (rgba 255 0 0 255))'])
+      ).toEqual([
+        'Runtime error: (error) expected a fill-mode, received string',
+        'Runtime error: (error) expected a fill-mode, received string',
+      ])
     })
 
     test('rejects a non-numeric width, an unknown color name, or a non-color', async () => {
@@ -953,8 +965,8 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-width (path 100 200 (list (pair 0 0)) "solid" "red"))
-(image-height (path 100 200 (list (pair 0 0)) "solid" "red"))
+(drawing-width (path 100 200 (list (pair 0 0)) "solid" "red"))
+(drawing-height (path 100 200 (list (pair 0 0)) "solid" "red"))
 `),
       ).toEqual(['100', '200'])
     })
@@ -978,10 +990,10 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(beside (rectangle 10 10 "solid" "red") (ellipse 4 6 #t "blue"))
+(beside (rectangle 10 10 "solid" "red") (ellipse 4 6 "solid" "blue"))
 `),
       ).toEqual([
-        '(beside "center" 14 10 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 #t (rgba 0 0 255 255))))',
+        '(beside "center" 14 10 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 "solid" (rgba 0 0 255 255))))',
       ])
     })
 
@@ -989,8 +1001,8 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-width (beside (rectangle 10 10 "solid" "red")))
-(image-height (beside (rectangle 10 10 "solid" "red")))
+(drawing-width (beside (rectangle 10 10 "solid" "red")))
+(drawing-height (beside (rectangle 10 10 "solid" "red")))
 `),
       ).toEqual(['10', '10'])
     })
@@ -1011,7 +1023,7 @@ describe('drawing', () => {
 (beside (rectangle 10 10 "solid" "red") "not-a-drawing")
 `),
       ).toEqual([
-        'Runtime error: (error) expected every value of d1 to be an image, but at least one was not',
+        'Runtime error: (error) expected every value of d1 to be a drawing, but at least one was not',
       ])
     })
   })
@@ -1021,10 +1033,10 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(beside/align "top" (rectangle 10 10 "solid" "red") (ellipse 4 6 #t "blue"))
+(beside/align "top" (rectangle 10 10 "solid" "red") (ellipse 4 6 "solid" "blue"))
 `),
       ).toEqual([
-        '(beside "top" 14 10 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 #t (rgba 0 0 255 255))))',
+        '(beside "top" 14 10 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 "solid" (rgba 0 0 255 255))))',
       ])
     })
 
@@ -1045,10 +1057,10 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(above (rectangle 10 10 "solid" "red") (ellipse 4 6 #t "blue"))
+(above (rectangle 10 10 "solid" "red") (ellipse 4 6 "solid" "blue"))
 `),
       ).toEqual([
-        '(above "middle" 10 16 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 #t (rgba 0 0 255 255))))',
+        '(above "middle" 10 16 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 "solid" (rgba 0 0 255 255))))',
       ])
     })
 
@@ -1067,10 +1079,10 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(above/align "left" (rectangle 10 10 "solid" "red") (ellipse 4 6 #t "blue"))
+(above/align "left" (rectangle 10 10 "solid" "red") (ellipse 4 6 "solid" "blue"))
 `),
       ).toEqual([
-        '(above "left" 10 16 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 #t (rgba 0 0 255 255))))',
+        '(above "left" 10 16 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 "solid" (rgba 0 0 255 255))))',
       ])
     })
 
@@ -1091,10 +1103,10 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(overlay (rectangle 10 10 "solid" "red") (ellipse 4 6 #t "blue"))
+(overlay (rectangle 10 10 "solid" "red") (ellipse 4 6 "solid" "blue"))
 `),
       ).toEqual([
-        '(overlay "middle" "center" 10 10 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 #t (rgba 0 0 255 255))))',
+        '(overlay "middle" "center" 10 10 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 "solid" (rgba 0 0 255 255))))',
       ])
     })
 
@@ -1113,10 +1125,10 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(overlay/align "left" "top" (rectangle 10 10 "solid" "red") (ellipse 4 6 #t "blue"))
+(overlay/align "left" "top" (rectangle 10 10 "solid" "red") (ellipse 4 6 "solid" "blue"))
 `),
       ).toEqual([
-        '(overlay "left" "top" 10 10 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 #t (rgba 0 0 255 255))))',
+        '(overlay "left" "top" 10 10 (vector (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 "solid" (rgba 0 0 255 255))))',
       ])
     })
 
@@ -1137,12 +1149,12 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(overlay/offset 3 4 (rectangle 10 10 "solid" "red") (ellipse 4 6 #t "blue"))
-(overlay/offset -3 -4 (rectangle 10 10 "solid" "red") (ellipse 4 6 #t "blue"))
+(overlay/offset 3 4 (rectangle 10 10 "solid" "red") (ellipse 4 6 "solid" "blue"))
+(overlay/offset -3 -4 (rectangle 10 10 "solid" "red") (ellipse 4 6 "solid" "blue"))
 `),
       ).toEqual([
-        '(overlayOffset 3 4 10 10 (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 #t (rgba 0 0 255 255)))',
-        '(overlayOffset -3 -4 13 14 (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 #t (rgba 0 0 255 255)))',
+        '(overlayOffset 3 4 10 10 (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 "solid" (rgba 0 0 255 255)))',
+        '(overlayOffset -3 -4 13 14 (rectangle 10 10 "solid" (rgba 255 0 0 255)) (ellipse 4 6 "solid" (rgba 0 0 255 255)))',
       ])
     })
 
@@ -1164,7 +1176,7 @@ describe('drawing', () => {
 (overlay/offset 0 0 "not-a-drawing" (rectangle 10 10 "solid" "red"))
 `),
       ).toEqual([
-        'Runtime error: (error) expected an image, received string',
+        'Runtime error: (error) expected a drawing, received string',
       ])
     })
   })
@@ -1199,7 +1211,7 @@ describe('drawing', () => {
 `),
       ).toEqual([
         'Runtime error: (error) expected a number, received string',
-        'Runtime error: (error) expected an image, received number',
+        'Runtime error: (error) expected a drawing, received number',
       ])
     })
   })
@@ -1236,7 +1248,7 @@ describe('drawing', () => {
 `),
       ).toEqual([
         'Runtime error: (error) expected a list, received number',
-        'Runtime error: (error) expected an image, received number',
+        'Runtime error: (error) expected a drawing, received number',
       ])
     })
   })
@@ -1450,8 +1462,8 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-width (rectangle 10 20 "solid" "red"))
-(image-width (beside (rectangle 10 10 "solid" "red") (rectangle 5 5 "solid" "blue")))
+(drawing-width (rectangle 10 20 "solid" "red"))
+(drawing-width (beside (rectangle 10 10 "solid" "red") (rectangle 5 5 "solid" "blue")))
 `),
       ).toEqual(['10', '15'])
     })
@@ -1461,12 +1473,12 @@ describe('drawing', () => {
         await runProgram(`
 (import image)
 (import canvas)
-(image-width 5)
-(image-width (make-canvas 20 15))
+(drawing-width 5)
+(drawing-width (make-canvas 20 15))
 `),
       ).toEqual([
-        'Runtime error: (error) expected an image, received number',
-        'Runtime error: (error) expected an image, received object',
+        'Runtime error: (error) expected a drawing, received number',
+        'Runtime error: (error) expected a drawing, received object',
       ])
     })
   })
@@ -1476,8 +1488,8 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-height (rectangle 10 20 "solid" "red"))
-(image-height (above (rectangle 10 10 "solid" "red") (rectangle 5 5 "solid" "blue")))
+(drawing-height (rectangle 10 20 "solid" "red"))
+(drawing-height (above (rectangle 10 10 "solid" "red") (rectangle 5 5 "solid" "blue")))
 `),
       ).toEqual(['20', '15'])
     })
@@ -1487,12 +1499,12 @@ describe('drawing', () => {
         await runProgram(`
 (import image)
 (import canvas)
-(image-height 5)
-(image-height (make-canvas 20 15))
+(drawing-height 5)
+(drawing-height (make-canvas 20 15))
 `),
       ).toEqual([
-        'Runtime error: (error) expected an image, received number',
-        'Runtime error: (error) expected an image, received object',
+        'Runtime error: (error) expected a drawing, received number',
+        'Runtime error: (error) expected a drawing, received object',
       ])
     })
   })
@@ -1502,7 +1514,7 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-color (rectangle 10 20 "solid" "red"))
+(drawing-color (rectangle 10 20 "solid" "red"))
 `),
       ).toEqual(['(rgba 255 0 0 255)'])
     })
@@ -1511,8 +1523,8 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-color (beside (rectangle 10 10 "solid" "red") (rectangle 5 5 "solid" "blue")))
-(image-color (overlay/offset 3 4 (rectangle 10 10 "solid" "red") (rectangle 5 5 "solid" "blue")))
+(drawing-color (beside (rectangle 10 10 "solid" "red") (rectangle 5 5 "solid" "blue")))
+(drawing-color (overlay/offset 3 4 (rectangle 10 10 "solid" "red") (rectangle 5 5 "solid" "blue")))
 `),
       ).toEqual(['(rgba 127.5 0 127.5 255)', '(rgba 127.5 0 127.5 255)'])
     })
@@ -1521,8 +1533,8 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-color (rotate 45 (rectangle 10 10 "solid" "red")))
-(image-color (with-dash (list 4 2) (rectangle 10 10 "solid" "red")))
+(drawing-color (rotate 45 (rectangle 10 10 "solid" "red")))
+(drawing-color (with-dash (list 4 2) (rectangle 10 10 "solid" "red")))
 `),
       ).toEqual(['(rgba 255 0 0 255)', '(rgba 255 0 0 255)'])
     })
@@ -1531,7 +1543,7 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-color (text "hi" 12 "black"))
+(drawing-color (text "hi" 12 "black"))
 `),
       ).toEqual(['(rgba 0 0 0 255)'])
     })
@@ -1540,10 +1552,10 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-color 5)
+(drawing-color 5)
 `),
       ).toEqual([
-        'Runtime error: (error) expected an image, received number',
+        'Runtime error: (error) expected a drawing, received number',
       ])
     })
   })
@@ -1553,8 +1565,8 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-recolor (rectangle 10 10 "solid" "red") "blue")
-(image-recolor (rectangle 10 10 "solid" "red") (rgb 1 2 3))
+(drawing-recolor (rectangle 10 10 "solid" "red") "blue")
+(drawing-recolor (rectangle 10 10 "solid" "red") (rgb 1 2 3))
 `),
       ).toEqual([
         '(rectangle 10 10 "solid" (rgba 0 0 255 255))',
@@ -1566,12 +1578,12 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-recolor (beside (rectangle 10 10 "solid" "red") (ellipse 4 6 #t "blue")) "green")
-(image-recolor (rotate 45 (rectangle 10 10 "solid" "red")) "green")
-(image-recolor (with-dash (list 4 2) (rectangle 10 10 "solid" "red")) "green")
+(drawing-recolor (beside (rectangle 10 10 "solid" "red") (ellipse 4 6 "solid" "blue")) "green")
+(drawing-recolor (rotate 45 (rectangle 10 10 "solid" "red")) "green")
+(drawing-recolor (with-dash (list 4 2) (rectangle 10 10 "solid" "red")) "green")
 `),
       ).toEqual([
-        '(beside "center" 14 10 (vector (rectangle 10 10 "solid" (rgba 0 128 0 255)) (ellipse 4 6 #t (rgba 0 128 0 255))))',
+        '(beside "center" 14 10 (vector (rectangle 10 10 "solid" (rgba 0 128 0 255)) (ellipse 4 6 "solid" (rgba 0 128 0 255))))',
         '(rotate 14.142135623730951 14.142135623730951 7.071067811865475 0 45 (rectangle 10 10 "solid" (rgba 0 128 0 255)))',
         '(withDash (list 4 2) (rectangle 10 10 "solid" (rgba 0 128 0 255)) 10 10)',
       ])
@@ -1583,7 +1595,7 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-recolor (text "hi" 12 "black") "green")
+(drawing-recolor (text "hi" 12 "black") "green")
 `),
       ).toEqual(['(text 2 1 "hi" 12 (rgba 0 0 0 255) (font "Arial" "sans-serif" #f #f))'])
     })
@@ -1592,11 +1604,11 @@ describe('drawing', () => {
       expect(
         await runProgram(`
 (import image)
-(image-recolor 5 "red")
-(image-recolor (rectangle 10 10 "solid" "red") 5)
+(drawing-recolor 5 "red")
+(drawing-recolor (rectangle 10 10 "solid" "red") 5)
 `),
       ).toEqual([
-        'Runtime error: (error) expected an image, received number',
+        'Runtime error: (error) expected a drawing, received number',
         'Runtime error: (error) expected a color, received number',
       ])
     })
@@ -1681,13 +1693,13 @@ describe('rotate produces a positive box for every shape', () => {
   async function rotatedIsPositive(shape: string): Promise<string[]> {
     return runProgram(`
 (import image)
-(> (image-width (rotate 45 ${shape})) 0)
-(> (image-height (rotate 45 ${shape})) 0)
+(> (drawing-width (rotate 45 ${shape})) 0)
+(> (drawing-height (rotate 45 ${shape})) 0)
 `)
   }
 
   test('ellipse', async () => {
-    expect(await rotatedIsPositive('(ellipse 10 20 #t "red")')).toEqual(['#t', '#t'])
+    expect(await rotatedIsPositive('(ellipse 10 20 "solid" "red")')).toEqual(['#t', '#t'])
   })
   test('rectangle', async () => {
     expect(await rotatedIsPositive('(rectangle 10 20 "solid" "red")')).toEqual(['#t', '#t'])
@@ -1731,13 +1743,13 @@ describe('rotation dimensions (declared-corner correctness)', () => {
   async function rounded90Dims(shape: string): Promise<string[]> {
     return runProgram(`
 (import image)
-(round (image-width (rotate 90 ${shape})))
-(round (image-height (rotate 90 ${shape})))
+(round (drawing-width (rotate 90 ${shape})))
+(round (drawing-height (rotate 90 ${shape})))
 `)
   }
 
   test('ellipse swaps 10x20 -> 20x10', async () => {
-    expect(await rounded90Dims('(ellipse 10 20 #t "red")')).toEqual(['20', '10'])
+    expect(await rounded90Dims('(ellipse 10 20 "solid" "red")')).toEqual(['20', '10'])
   })
   test('rectangle swaps 10x20 -> 20x10', async () => {
     expect(await rounded90Dims('(rectangle 10 20 "solid" "red")')).toEqual(['20', '10'])
@@ -1762,9 +1774,9 @@ describe('image-color of composite drawings', () => {
   test('beside/above/overlay average their children (uniform colour)', async () => {
     expect(await runProgram(`
 (import image)
-(image-color (beside (square 10 "solid" "red") (square 10 "solid" "red")))
-(image-color (above (square 10 "solid" "red") (square 10 "solid" "red")))
-(image-color (overlay (square 10 "solid" "red") (square 10 "solid" "red")))
+(drawing-color (beside (square 10 "solid" "red") (square 10 "solid" "red")))
+(drawing-color (above (square 10 "solid" "red") (square 10 "solid" "red")))
+(drawing-color (overlay (square 10 "solid" "red") (square 10 "solid" "red")))
 `)).toEqual([
       '(rgba 255 0 0 255)',
       '(rgba 255 0 0 255)',
@@ -1774,20 +1786,20 @@ describe('image-color of composite drawings', () => {
   test('overlay/offset averages its two drawings', async () => {
     expect(await runProgram(`
 (import image)
-(image-color (overlay/offset 2 2 (square 10 "solid" "red") (square 10 "solid" "red")))
+(drawing-color (overlay/offset 2 2 (square 10 "solid" "red") (square 10 "solid" "red")))
 `)).toEqual(['(rgba 255 0 0 255)'])
   })
   test('rotate and with-dash delegate to the wrapped drawing', async () => {
     expect(await runProgram(`
 (import image)
-(image-color (rotate 45 (square 10 "solid" "red")))
-(image-color (with-dash (list 5 5) (square 10 "solid" "red")))
+(drawing-color (rotate 45 (square 10 "solid" "red")))
+(drawing-color (with-dash (list 5 5) (square 10 "solid" "red")))
 `)).toEqual(['(rgba 255 0 0 255)', '(rgba 255 0 0 255)'])
   })
   test('text returns its own colour', async () => {
     expect(await runProgram(`
 (import image)
-(image-color (text "hi" 20 "red"))
+(drawing-color (text "hi" 20 "red"))
 `)).toEqual(['(rgba 255 0 0 255)'])
   })
 })
@@ -1798,23 +1810,23 @@ describe('image-recolor of composite drawings', () => {
   test('leaf kinds (triangle, path)', async () => {
     expect(await runProgram(`
 (import image)
-(image-color (image-recolor (triangle 10 "solid" "red") "green"))
-(image-color (image-recolor (path 10 10 (list (pair 0 0) (pair 5 5)) "solid" "red") "green"))
+(drawing-color (drawing-recolor (triangle 10 "solid" "red") "green"))
+(drawing-color (drawing-recolor (path 10 10 (list (pair 0 0) (pair 5 5)) "solid" "red") "green"))
 `)).toEqual(['(rgba 0 128 0 255)', '(rgba 0 128 0 255)'])
   })
   test('aggregate kinds (above, overlay, overlay/offset)', async () => {
     expect(await runProgram(`
 (import image)
-(image-color (image-recolor (above (square 5 "solid" "red") (square 8 "solid" "red")) "green"))
-(image-color (image-recolor (overlay (square 5 "solid" "red") (square 8 "solid" "red")) "green"))
-(image-color (image-recolor (overlay/offset 2 2 (square 5 "solid" "red") (square 8 "solid" "red")) "green"))
+(drawing-color (drawing-recolor (above (square 5 "solid" "red") (square 8 "solid" "red")) "green"))
+(drawing-color (drawing-recolor (overlay (square 5 "solid" "red") (square 8 "solid" "red")) "green"))
+(drawing-color (drawing-recolor (overlay/offset 2 2 (square 5 "solid" "red") (square 8 "solid" "red")) "green"))
 `)).toEqual(['(rgba 0 128 0 255)', '(rgba 0 128 0 255)', '(rgba 0 128 0 255)'])
   })
   test('wrapper kinds (rotate, with-dash)', async () => {
     expect(await runProgram(`
 (import image)
-(image-color (image-recolor (rotate 45 (square 5 "solid" "red")) "green"))
-(image-color (image-recolor (with-dash (list 5 5) (square 5 "solid" "red")) "green"))
+(drawing-color (drawing-recolor (rotate 45 (square 5 "solid" "red")) "green"))
+(drawing-color (drawing-recolor (with-dash (list 5 5) (square 5 "solid" "red")) "green"))
 `)).toEqual(['(rgba 0 128 0 255)', '(rgba 0 128 0 255)'])
   })
 })
@@ -1826,8 +1838,8 @@ describe('overlay/offset dimension branches', () => {
   test('smaller first drawing with positive offset stays positive', async () => {
     expect(await runProgram(`
 (import image)
-(> (image-width (overlay/offset 3 4 (square 5 "solid" "red") (square 20 "solid" "blue"))) 0)
-(> (image-height (overlay/offset 3 4 (square 5 "solid" "red") (square 20 "solid" "blue"))) 0)
+(> (drawing-width (overlay/offset 3 4 (square 5 "solid" "red") (square 20 "solid" "blue"))) 0)
+(> (drawing-height (overlay/offset 3 4 (square 5 "solid" "red") (square 20 "solid" "blue"))) 0)
 `)).toEqual(['#t', '#t'])
   })
 })
@@ -1871,12 +1883,12 @@ describe('pixel-map', () => {
   test('maps over a canvas, returning a same-size canvas of rgb pixels', async () => {
     expect(await runProgram(`
 (import image)
-(define c (drawing->image (solid-square 2 "blue")))
+(define c (drawing->canvas (solid-square 2 "blue")))
 (canvas-width c)
 (canvas-height c)
 (canvas? (pixel-map (lambda (p) p) c))
-(vector-length (image->pixels (pixel-map (lambda (p) p) c)))
-(rgb? (vector-ref (image->pixels (pixel-map (lambda (p) (rgb-greyscale p)) c)) 0))
+(vector-length (canvas->pixels (pixel-map (lambda (p) p) c)))
+(rgb? (vector-ref (canvas->pixels (pixel-map (lambda (p) (rgb-greyscale p)) c)) 0))
 `)).toEqual(['2', '2', '#t', '4', '#t'])
   })
 })

--- a/test/libs/image.test.ts
+++ b/test/libs/image.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest'
 import * as L from '../../src/lpm'
 import { runProgram } from './harness.js'
 import { image_isReactiveImageFile, image_withImageFile } from '../../src/js/image/image.js'
-import { image_imageWidth, image_imageHeight } from '../../src/js/image/drawing.js'
+import { drawing_drawingWidth, drawing_drawingHeight } from '../../src/js/image/drawing.js'
 
 describe('color', () => {
   // N.B., the legacy `color` constructor was retired in #103 -- it was a pure
@@ -222,7 +222,7 @@ describe('color', () => {
       '141',
       '"aliceblue"',
       // the docstring documents a parameter ("x1 : any") that the real
-      // implementation (image_allColorNames, which takes none) never uses,
+      // implementation (color_allColorNames, which takes none) never uses,
       // so calling with the documented arity actually works, and the
       // "expected" zero-argument call is itself the arity failure.
       'Runtime error: Arity mismatch in function call: expected 1 arguments, got 0',
@@ -246,8 +246,8 @@ describe('color', () => {
     ])
   })
 
-  // hsv? is bound to the hsv constructor (image_hsv) instead of the
-  // predicate (image_isHsv) -- calling it tries to construct a struct
+  // hsv? is bound to the hsv constructor (color_hsv) instead of the
+  // predicate (color_isHsv) -- calling it tries to construct a struct
   // instead of testing one (github.com/slag-plt/scamper#250).
   test.skip('hsv?')
 
@@ -609,7 +609,7 @@ describe('font', () => {
 // Every color parameter accepts any of the three color representations (#103).
 // Before that, shapes declared `color : string?`, so passing an rgb -- the most
 // natural thing to write -- failed its contract even though the implementation
-// converted it fine via image_colorToRgb.
+// converted it fine via color_colorToRgb.
 describe('color parameters accept every color representation', () => {
   test('a name, an rgb, and an hsv all produce the same shape', async () => {
     const red = '(rectangle 10 10 "solid" (rgba 255 0 0 255))'
@@ -1274,7 +1274,7 @@ describe('drawing', () => {
       ).toEqual(['(text 2 1 "hi" 12 (rgba 0 0 0 255) (font "Georgia" "serif" #t #f))'])
     })
 
-    // A non-font fourth argument fails the image_fontQ guard, so it is silently
+    // A non-font fourth argument fails the font_fontQ guard, so it is silently
     // dropped rather than rejected and the default font is kept.
     test('silently ignores a non-font fourth argument', async () => {
       expect(
@@ -1852,14 +1852,14 @@ describe('image-width / image-height of a canvas', () => {
     const canvas = document.createElement('canvas')
     canvas.width = 30
     canvas.height = 20
-    expect(image_imageWidth(canvas as unknown as never)).toBe(30)
-    expect(image_imageHeight(canvas as unknown as never)).toBe(20)
+    expect(drawing_drawingWidth(canvas as unknown as never)).toBe(30)
+    expect(drawing_drawingHeight(canvas as unknown as never)).toBe(20)
   })
 })
 
 describe('colour edge cases', () => {
   // Too few args trip the outer call-arity contract; too many (5) reach
-  // image_hsv's own "expects 3 or 4 arguments" guard.
+  // color_hsv's own "expects 3 or 4 arguments" guard.
   test('hsv rejects too many arguments', async () => {
     expect(await runProgram(`
 (import image)

--- a/test/regressions/rotate-above.test.ts
+++ b/test/regressions/rotate-above.test.ts
@@ -28,7 +28,7 @@ describe('rotate of an above drawing (#253)', () => {
   test('the beside sibling still rotates cleanly', async () => {
     const result = await runProgram(`
 (import image)
-(> (image-width (rotate 45 (beside (rectangle 20 20 "solid" "red") (rectangle 20 20 "solid" "blue")))) 0)
+(> (drawing-width (rotate 45 (beside (rectangle 20 20 "solid" "red") (rectangle 20 20 "solid" "blue")))) 0)
 `)
     expect(result).toEqual(['#t'])
   })
@@ -38,8 +38,8 @@ describe('rotate of an above drawing (#253)', () => {
   test('a stacked above keeps its full height when rotated', async () => {
     expect(await runProgram(`
 (import image)
-(round (image-width (rotate 90 (above (rectangle 20 20 "solid" "red") (rectangle 20 30 "solid" "blue")))))
-(round (image-height (rotate 90 (above (rectangle 20 20 "solid" "red") (rectangle 20 30 "solid" "blue")))))
+(round (drawing-width (rotate 90 (above (rectangle 20 20 "solid" "red") (rectangle 20 30 "solid" "blue")))))
+(round (drawing-height (rotate 90 (above (rectangle 20 20 "solid" "red") (rectangle 20 30 "solid" "blue")))))
 `)).toEqual(['50', '20'])
   })
 
@@ -48,7 +48,7 @@ describe('rotate of an above drawing (#253)', () => {
   test('a nested above/beside combination rotates cleanly', async () => {
     expect(await runProgram(`
 (import image)
-(> (image-width (rotate 30 (beside (above (square 5 "solid" "red") (square 8 "solid" "blue")) (square 4 "solid" "green")))) 0)
+(> (drawing-width (rotate 30 (beside (above (square 5 "solid" "red") (square 8 "solid" "blue")) (square 4 "solid" "green")))) 0)
 `)).toEqual(['#t'])
   })
 })

--- a/test/regressions/rotate-bounding-box.test.ts
+++ b/test/regressions/rotate-bounding-box.test.ts
@@ -22,8 +22,8 @@ describe('rotate bounding box (#102)', () => {
   async function dims (shape: string): Promise<string[]> {
     return runProgram(`
 (import image)
-(round (image-width ${shape}))
-(round (image-height ${shape}))
+(round (drawing-width ${shape}))
+(round (drawing-height ${shape}))
 `)
   }
 

--- a/test/regressions/tracing-images.test.ts
+++ b/test/regressions/tracing-images.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 import HTMLDisplay from '../../src/lpm/output/html'
 import { runProgramWithHTML } from '../harness'
 import { getByLabelText } from '@testing-library/dom'
-import { image_canvasAriaLabel } from '../../src/js/image/drawing'
+import { drawing_canvasAriaLabel } from '../../src/js/image/drawing'
 // Registers the image library's HTML custom renderer (drawings -> <canvas>)
 // on the shared HtmlRenderer singleton. Needed here because production code
 // only wires this up via scamper.ts's fire-and-forget dynamic import (see
@@ -22,5 +22,5 @@ test('tracing-images', async () => {
   const mockOut = new HTMLDisplay(mockRoot)
   await runProgramWithHTML(testSrc, mockOut)
 
-  expect(getByLabelText(mockRoot, image_canvasAriaLabel)).toBeVisible()
+  expect(getByLabelText(mockRoot, drawing_canvasAriaLabel)).toBeVisible()
 })


### PR DESCRIPTION
Part 2 of #103 — the image-exchange-types checkbox. Completes the issue: parts 1, 3, and 4 are already on `main` (#344, #345, #343).

Supersedes #346, which GitHub auto-closed when #344's branch was deleted out from under it (it was stacked on that branch, and a closed PR's base cannot be retargeted). Same two commits, rebased onto `main`.

## The problem

`image` was naming two different things. In the shape half, `image?` meant a drawing; in the pixel half, "image" meant a canvas — to the point that `drawing->image` was declared `-> image?` while returning a canvas, which `image?` rejects. All four mislabeled conversions failed the same way.

## The split

Three concrete types, each with its own predicate and its own operations:

- **`drawing?`** — the value the shape constructors build
- **`canvas?`** — the JavaScript Canvas
- **`image`** — reserved for functions that manipulate image *files*

| Now | Was |
|---|---|
| `drawing?` | `image?` (and `shape?`, retired) |
| `drawing-width` / `-height` / `-color` / `-recolor` | `image-*` |
| `drawing->canvas` | `drawing->image` |
| `canvas->pixels` | `image->pixels` |
| `pixels->canvas` | `pixels->image` |
| `canvas-get-pixel` | `image-get-pixel` |

`drawing->pixels`, `canvas-drawing!`, and `canvas-set-pixels!` needed **no change** — they were already using this vocabulary, which is the best evidence it's the right one.

`shape?` is retired: it was a straight alias of `image?`. The `drawing.ts` TODO it carried — that images would generalize beyond shapes — is resolved by rejecting its premise. Images don't generalize shapes; they're a third thing.

## Fixed in the same sweep

- **`canvas-width`/`canvas-height` were bound to the *drawing* accessors**, which accept either kind via a cast. Four names, two functions. Now split, each with an honest contract.
- `canvas->pixels` was declared `-> canvas?` while returning pixels.
- A **`pixels?`** predicate replaces `any` on the pixel parameters — they previously had *no contract at all*.
- The pixel vector is a **snapshot**: `getImageData` builds fresh rgb structs, and Scamper has no rgb mutator, so changing it never writes through. Now stated in the docstrings, because the opposite is the natural guess.

## The fill bug

Keeping `"solid"`/`"outline"`, but two things were wrong:

1. `ellipse` declared `fill : boolean?` — alone among the seven primitives.
2. Worse: `image_render` matched `'solid'`, then `'outline'`, **with no else**. Any other value drew *nothing, silently* — including the boolean `ellipse`'s own contract demanded. `(ellipse 10 20 #t "red")` passed validation and produced an invisible shape.

A `fill-mode?` predicate now rejects it at the call site, and the renderer raises instead of no-op'ing. Putting the mode in one predicate also makes a future switch to booleans a one-line change.

**One existing test had pinned the bug**: it asserted `(rectangle 10 20 "diagonal" "red")` was *accepted*. It now asserts rejection.

`fill-mode?` is re-exported from `canvas.scm` alongside `color?` and `drawing?` — a contract predicate has to resolve in the module naming it, which the cross-module predicate test in `canvas.test.ts` exists to catch.

## Second commit: internal JS rename

`image_*` spanned four concepts. Split into `drawing_*` (41), `color_*` (42), `font_*` (3), `canvas_*` (5, moved into `src/js/canvas/`), leaving `image_*` for the three genuine image-file functions. 91 renames, mechanical, invisible to students, typechecker-covered. `src/js/image/image.ts` is now purely about image files.

Kept as its own commit so it's separable from the user-facing change.

## Not included

Splitting `src/lib/image.scm` into three modules — that changes `(import image)` in essentially every graphics program a student writes, and colors/fonts serve all three kinds. Separate decision; the JS reorganization above makes it cheap later.

`npm run validate` passes; lint unchanged at 1092.

_(Co-created with Claude Code)_
