### PR TITLE
Contain Node file system paths to their root (#340)

### DIFF
--- a/src/fs/node.ts
+++ b/src/fs/node.ts
@@ -24,9 +24,26 @@ export class NodeFileSystem implements FS {
     return new NodeFileSystem(path.resolve(root))
   }
 
-  /** @return the path to `filename` within this file system's root */
+  /**
+   * @return the path to `filename` within this file system's root
+   * @throws ScamperError if `filename` names something outside that root
+   *
+   * N.B., the containment check lives here rather than in the `file` library so
+   * that every consumer -- the library, `with-file`, file imports -- is covered
+   * at once (#340). A program may only reach files in the directory it was run
+   * from; both an escaping relative name ("../x") and an absolute one are
+   * refused. The check is on the name, not the file: a symlink already inside
+   * the root can still point out of it, but Scamper has no way to create one.
+   */
   private resolve(filename: string): string {
-    return path.join(this.root, filename)
+    const target = path.resolve(this.root, filename)
+    if (target !== this.root && !target.startsWith(this.root + path.sep)) {
+      throw new ScamperError(
+        'Runtime',
+        `Cannot access "${filename}": the file is outside the working directory`,
+      )
+    }
+    return target
   }
 
   /** @return the list of files found at the root of the file system */
@@ -72,8 +89,11 @@ export class NodeFileSystem implements FS {
 
   /** @return true iff the given file exists */
   async fileExists(filename: string): Promise<boolean> {
+    // N.B., resolve() is called outside the try: a name we refuse to service is
+    // an error, not a #f. Only the access() failure means "no such file".
+    const target = this.resolve(filename)
     try {
-      await fs.access(this.resolve(filename))
+      await fs.access(target)
       return true
     } catch {
       return false

--- a/src/js/file/index.ts
+++ b/src/js/file/index.ts
@@ -17,7 +17,10 @@ import * as L from '../../lpm'
  * N.B., the host's own failures (a directory rather than a file, a permission
  * error, ...) are rewritten into a Scamper error: a raw "EISDIR: illegal
  * operation on a directory" is not something to put in front of a student, and
- * the wording would differ between Node and OPFS besides.
+ * the wording would differ between Node and OPFS besides. A ScamperError from
+ * the host is passed through untouched: it is already worded for a student and
+ * says something more specific than this can (e.g. a name that reaches outside
+ * the working directory -- see #340).
  */
 async function readFile(filename: string): Promise<string> {
   const { getFS } = await import('../../fs')
@@ -27,17 +30,19 @@ async function readFile(filename: string): Promise<string> {
   }
   try {
     return await fs.loadFile(filename)
-  } catch {
+  } catch (e) {
+    if (e instanceof L.ScamperError) { throw e }
     throw new L.ScamperError('Runtime', `Could not read the file "${filename}"`)
   }
 }
 
-/** Writes `contents` to `filename`, creating or overwriting it. */
+/** Writes `contents` to `filename`, creating or overwriting it. See readFile. */
 async function writeFile(filename: string, contents: string): Promise<void> {
   const { getFS } = await import('../../fs')
   try {
     await getFS().saveFile(filename, contents)
-  } catch {
+  } catch (e) {
+    if (e instanceof L.ScamperError) { throw e }
     throw new L.ScamperError('Runtime', `Could not write to the file "${filename}"`)
   }
 }

--- a/src/lpm/scheduler.ts
+++ b/src/lpm/scheduler.ts
@@ -196,13 +196,27 @@ export class Scheduler {
       return false
     }
     if (stepResult.tag === 'import-file') {
-      // TODO: this branch (and the getFS()/fileExists() call in particular)
-      //  isn't wrapped in a try/catch. If it throws or rejects for any reason
-      //  (e.g. the FS singleton isn't initialized, or a real I/O error), the
-      //  exception escapes execute() uncaught, which kills the scheduler loop
-      //  entirely and silently stops stepping every other running task, not
-      //  just this one. Should report the failure to task.err instead.
-      if (!(await getFS().fileExists(stepResult.filename))) {
+      // The existence probe can fail outright -- the FS singleton may be
+      // uninitialized, or the host may refuse the name (one that reaches
+      // outside the working directory, say -- see #340). Report that to the
+      // task's error channel: letting it escape execute() would kill the
+      // scheduler loop and silently stop stepping every other running task.
+      let exists: boolean
+      try {
+        exists = await getFS().fileExists(stepResult.filename)
+      } catch (e) {
+        task.err.report(
+          e instanceof ScamperError
+            ? e
+            : new ScamperError(
+                'Runtime',
+                `Attempted to import file "${stepResult.filename}" but it could not be read!`,
+              ),
+        )
+        this.endCurrFiber()
+        return true
+      }
+      if (!exists) {
         task.err.report(
           new ScamperError(
             'Runtime',

--- a/src/scheme/scope.ts
+++ b/src/scheme/scope.ts
@@ -396,7 +396,24 @@ async function resolveImport(
   // OPFS implementation into this module's (widely-imported) graph and disturb
   // tests that mock the file system (see symbol-db.ts).
   const { getFS } = await import('../fs')
-  if (!(await getFS().fileExists(s.module))) {
+  let exists: boolean
+  try {
+    exists = await getFS().fileExists(s.module)
+  } catch (e) {
+    // The host can refuse a name outright -- notably one that reaches outside
+    // the working directory (#340). Report its complaint as a diagnostic rather
+    // than letting it abort the whole check.
+    diagnostics.push(
+      mkDiagnostic(
+        'Scope',
+        'warning',
+        e instanceof Error ? e.message : String(e),
+        s.range,
+      ),
+    )
+    return undefined
+  }
+  if (!exists) {
     diagnostics.push(
       mkDiagnostic('Scope', 'warning', `File '${s.module}' does not exist`, s.range),
     )

--- a/test/regressions/fs-path-containment.test.ts
+++ b/test/regressions/fs-path-containment.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { setFS } from '../../src/fs'
+import NodeFileSystem from '../../src/fs/node'
+import { compile } from '../../src/scheme'
+import { runProgramAsync } from '../harness.js'
+
+// Regression test for #340: NodeFileSystem resolved names with path.join and no
+// containment check, so a name that climbed out of the root ("../x") or named
+// an absolute path was honoured. Reads had been escapable for a while; #338
+// added writes, which let a program clobber files outside the directory it was
+// run from. The browser host (OPFS) is unaffected, so this is Node-only.
+//
+// The fix rejects any name that resolves outside the root, in the file system
+// itself -- so the `file` library, `with-file`, and file imports are all
+// covered at once.
+
+let base: string
+let root: string
+
+beforeEach(async () => {
+  base = await mkdtemp(path.join(tmpdir(), 'scamper-340-'))
+  root = path.join(base, 'root')
+  // A file and a module *outside* the root, both of which must stay unreachable.
+  await writeFile(path.join(base, 'secret.txt'), 'classified\n', 'utf-8')
+  await writeFile(path.join(base, 'outside.scm'), '(define-export x 1)\n', 'utf-8')
+  setFS(await NodeFileSystem.create(root))
+})
+
+afterEach(async () => {
+  await rm(base, { recursive: true, force: true })
+})
+
+describe('#340: the Node file system contains names to its root', () => {
+  test('a name that climbs out of the root is rejected', async () => {
+    const fs = await NodeFileSystem.create(root)
+    await expect(fs.loadFile('../secret.txt')).rejects.toThrow(
+      /outside the working directory/,
+    )
+    await expect(fs.fileExists('../secret.txt')).rejects.toThrow(
+      /outside the working directory/,
+    )
+    await expect(fs.deleteFile('../secret.txt')).rejects.toThrow(
+      /outside the working directory/,
+    )
+    await expect(fs.renameFile('../secret.txt', 'mine.txt')).rejects.toThrow(
+      /outside the working directory/,
+    )
+  })
+
+  test('a write that climbs out of the root is rejected and creates nothing', async () => {
+    const fs = await NodeFileSystem.create(root)
+    await expect(fs.saveFile('../escaped.txt', 'PWNED')).rejects.toThrow(
+      /outside the working directory/,
+    )
+    expect(existsSync(path.join(base, 'escaped.txt'))).toBe(false)
+  })
+
+  test('an absolute name is rejected', async () => {
+    const fs = await NodeFileSystem.create(root)
+    await expect(fs.loadFile(path.join(base, 'secret.txt'))).rejects.toThrow(
+      /outside the working directory/,
+    )
+  })
+
+  test('names within the root, including nested ones, still resolve', async () => {
+    const fs = await NodeFileSystem.create(root)
+    await mkdir(path.join(root, 'data'))
+    await fs.saveFile('data/notes.txt', 'hello')
+    expect(await fs.loadFile('data/notes.txt')).toBe('hello')
+    // A ".." that stays inside the root is fine: it is the escape that is
+    // rejected, not the syntax.
+    expect(await fs.loadFile('data/../data/notes.txt')).toBe('hello')
+    expect(await fs.fileExists('data/notes.txt')).toBe(true)
+  })
+})
+
+describe('#340: a program cannot reach outside the working directory', () => {
+  test('a write outside the root reports an error and creates nothing', async () => {
+    const output = await runProgramAsync(`
+(import file)
+(string->file "PWNED" "../escaped.txt")
+`)
+    expect(output.join('\n')).toMatch(/outside the working directory/)
+    expect(existsSync(path.join(base, 'escaped.txt'))).toBe(false)
+  })
+
+  test('a read outside the root reports an error', async () => {
+    const output = await runProgramAsync(`
+(import file)
+(file->string "../secret.txt")
+`)
+    expect(output.join('\n')).toMatch(/outside the working directory/)
+  })
+
+  test('an import from outside the root is a scope diagnostic, not a crash', async () => {
+    const { diagnostics } = await compile('(import "../outside.scm")\n(display x)', {
+      scopeCheck: true,
+    })
+    expect(diagnostics.map((d) => d.message).join('\n')).toMatch(
+      /outside the working directory/,
+    )
+  })
+
+  test('an import from outside the root reports an error and the program finishes', async () => {
+    const output = await runProgramAsync('(import "../outside.scm")\n(display 1)')
+    expect(output.join('\n')).toMatch(/outside the working directory/)
+  })
+})


### PR DESCRIPTION
Fixes #340.

`NodeFileSystem.resolve` was `path.join(this.root, filename)` with no containment check, so a name that climbed out of the root (`"../x"`) or named an absolute path was honoured. Reads had been escapable for a while; #338 added writes, so a shared program could clobber files outside the directory it was run from. The browser host (OPFS) is origin-private and unaffected — this is Node-only.

## The fix

+ **`src/fs/node.ts`** — `resolve` rejects any name that resolves outside the root. Putting the check in the file system (rather than the `file` library) covers the library, `with-file`, and file imports at once. `fileExists` now resolves *outside* its `try`, so a refused name is an error rather than a silent `#f`.
+ **`src/scheme/scope.ts`** — the import-existence probe catches the host's refusal and reports it as a scope diagnostic, so `(import "../x.scm")` gets underlined instead of aborting the whole check.
+ **`src/lpm/scheduler.ts`** — same probe in the `import-file` branch is now wrapped, reporting to the task's error channel. This was a standing `TODO` on that branch: an uncaught throw there escapes `execute()` and kills the scheduler loop, silently stopping every other running task.
+ **`src/js/file/index.ts`** — `readFile`/`writeFile` pass a `ScamperError` from the host through instead of rewriting it, so the student sees `Cannot access "../escaped.txt": the file is outside the working directory` rather than a generic `Could not write to the file`.

## Scope note

The check is on the *name*, not the file: a symlink already inside the root can still point out of it. Scamper has no way to create one, so this only matters if someone plants it from outside — noted in the code comment rather than solved with `realpath` (which cannot be used on the write path, where the file need not exist yet).

## Testing

`test/regressions/fs-path-containment.test.ts` — 8 tests, all failing before the fix except the "names within the root still resolve" guard:

+ file-system level: `..` escapes and absolute names rejected for `loadFile` / `saveFile` / `fileExists` / `deleteFile` / `renameFile`; nested and `..`-that-stays-inside names still resolve.
+ program level: a write outside the root errors and creates nothing; a read outside the root errors; an import from outside the root is a scope diagnostic and, at run time, a reported error rather than a dead scheduler.

`npm run validate` passes (1904 tests).

_(Co-created with Claude Code)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEibkobsfKYhaow5Cm4YaS