### PR TITLE
Guard the import-file re-schedules against a completed fiber (#341)

### DIFF
--- a/src/lpm/scheduler.ts
+++ b/src/lpm/scheduler.ts
@@ -255,7 +255,7 @@ export class Scheduler {
                           mod,
                         )
                   fiber.advanceStmt()
-                  this.schedule(task)
+                  this.resumeOrComplete(task)
                 },
               })
             },
@@ -267,7 +267,7 @@ export class Scheduler {
                 ),
               )
               fiber.advanceStmt()
-              this.schedule(task)
+              this.resumeOrComplete(task)
             },
           )
       }
@@ -302,13 +302,7 @@ export class Scheduler {
             task.err.report(scamperErr)
             fiber.advanceStmt()
           }
-          // advanceStmt may have completed the program; a done fiber must not be
-          // re-scheduled (its completion is signaled instead).
-          if (fiber.isDone()) {
-            task.onComplete?.()
-          } else {
-            this.schedule(task)
-          }
+          this.resumeOrComplete(task)
         },
       )
       // Handled asynchronously; don't fall through to the display-task branch
@@ -523,6 +517,24 @@ export class Scheduler {
         gate.resolve()
       }
       task.onComplete?.()
+    }
+  }
+
+  /**
+   * Returns a task that an async branch dequeued -- a file import, a blocking
+   * primitive -- to the run queue now that its action has settled, or signals
+   * its completion if that action's statement was the program's last.
+   *
+   * N.B., the isDone check is the point: `schedule` rejects a finished fiber, so
+   * re-scheduling one raises an ICE from inside a detached promise, killing the
+   * run silently (#341). The task is already out of the queue at this point, so
+   * completion is signaled directly rather than through endCurrFiber.
+   */
+  private resumeOrComplete(task: SchedulerTask) {
+    if (task.fiber.isDone()) {
+      task.onComplete?.()
+    } else {
+      this.schedule(task)
     }
   }
 

--- a/test/regressions/import-file-last-statement.test.ts
+++ b/test/regressions/import-file-last-statement.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import { setFS } from '../../src/fs'
+import type { FS } from '../../src/fs/fs'
+import { MockFileSystem } from '../stubs/mock-file-system'
+import { runProgramAsync } from '../harness.js'
+
+// Regression test for #341: a `(import "...")` of a *file* as the last
+// statement of a program aborted with
+//
+//   ICE: Scheduling invariant violated: scheduling completed fibers is
+//   disallowed! (Scheduler.schedule)
+//
+// The scheduler's `import-file` branch re-scheduled the importing task
+// unconditionally after `advanceStmt()` -- on both the module-loaded and the
+// load-failed path. When the import was the final statement, advanceStmt
+// completed the program, and `schedule` rejects a finished fiber.
+//
+// Same shape as the `block-on` branch, which already guards with isDone() and
+// signals completion instead. The ICE was thrown inside a detached promise, so
+// it surfaced as an unhandled rejection and the run simply never completed --
+// hence the timeouts these tests would hit before the fix.
+
+let fs: MockFileSystem
+
+beforeEach(async () => {
+  fs = await MockFileSystem.create()
+  setFS(fs)
+})
+
+/** An FS whose every file exists but refuses to load, as a directory would. */
+function unreadableFS(): FS {
+  const nope = () => Promise.reject(new Error('EISDIR'))
+  return {
+    getFileList: () => Promise.resolve([]),
+    fileExists: () => Promise.resolve(true),
+    loadFile: nope,
+    saveFile: nope,
+    deleteFile: nope,
+    renameFile: nope,
+  }
+}
+
+describe('#341: a file import as the last statement of a program', () => {
+  test('completes the program instead of raising a scheduling ICE', async () => {
+    await fs.saveFile('mod.scm', '(define-export helper 42)\n')
+    expect(await runProgramAsync('(display 1)\n(import "mod.scm")')).toEqual(['1'])
+  })
+
+  test('is still the sole statement case', async () => {
+    await fs.saveFile('mod.scm', '(define-export helper 42)\n')
+    expect(await runProgramAsync('(import "mod.scm")')).toEqual([])
+  })
+
+  test("binds the module's exports when it is not the last statement", async () => {
+    // The pre-#341 behavior that must be preserved: a non-final import resumes
+    // the fiber with the module in scope.
+    await fs.saveFile('mod.scm', '(define-export helper 42)\n')
+    expect(await runProgramAsync('(import "mod.scm")\n(display helper)')).toEqual([
+      '42',
+    ])
+  })
+
+  test('reports the failure and completes when the file cannot be loaded', async () => {
+    // The other unguarded re-schedule: the load-failure path also advances the
+    // statement and re-schedules. A file that exists but will not load (a
+    // directory, a permission error) as the last statement hit the same ICE.
+    setFS(unreadableFS())
+    const output = await runProgramAsync('(display 1)\n(import "mod.scm")')
+    expect(output[0]).toBe('1')
+    expect(output.join('\n')).toMatch(/failed to load/)
+  })
+})


### PR DESCRIPTION
Fixes #341.

A `(import "...")` of a *file* as the last statement of a program aborted with:

```
ICE: Scheduling invariant violated: scheduling completed fibers is disallowed! (Scheduler.schedule)
```

The scheduler's `import-file` branch re-scheduled the importing task unconditionally after `fiber.advanceStmt()` — on both the module-loaded path and the load-failure path. When the import was the final statement, `advanceStmt` completed the program, and `schedule` rejects a finished fiber. Because the ICE was thrown inside a detached promise, it surfaced only as an unhandled rejection: the run never completed and never reported anything.

## The fix

The `block-on` branch already got this right. Its check is lifted into a named helper and used at all three sites:

```ts
private resumeOrComplete(task: SchedulerTask) {
  if (task.fiber.isDone()) {
    task.onComplete?.()
  } else {
    this.schedule(task)
  }
}
```

The task is already out of the run queue at each of these points (both branches dequeue before running their async action), so completion is signaled directly rather than through `endCurrFiber`.

## Testing

`test/regressions/import-file-last-statement.test.ts` — 4 tests. Three failed before the fix (as timeouts plus unhandled `ICE` rejections, one per re-schedule site); the fourth is the guard on the behavior that already worked:

+ a file import as the last of several statements completes the program
+ a file import as the *sole* statement completes the program
+ a non-final import still binds the module's exports
+ a file that exists but will not load, as the last statement, reports the failure and completes

`npm run validate` passes (1900 tests).

## Noted, not fixed

The same branch's compile-failure path (`if (prog === undefined) return`, already carrying a `TODO`) returns without re-scheduling *or* completing the task, so importing an unparseable file leaves the run hanging forever. That is a distinct bug from the ICE this PR is about, so it is left alone here.

_(Co-created with Claude Code)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEibkobsfKYhaow5Cm4YaS