### PR TITLE
Export all files as a zip archive (#42)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "chart.js": "^4.5.1",
         "colorsys": "^1.0.22",
         "highlight.js": "^11.10.0",
+        "jszip": "^3.10.1",
         "papaparse": "^5.5.3",
         "showdown": "^2.1.0",
         "splitpanes": "^4.0.4",
@@ -2729,6 +2730,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -3456,6 +3463,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3538,6 +3551,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -3752,6 +3771,18 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3774,6 +3805,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -4343,6 +4383,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/papaparse": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
@@ -4585,6 +4631,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -4608,6 +4660,21 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -4667,6 +4734,12 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -4692,6 +4765,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4812,6 +4891,15 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -5171,7 +5259,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "chart.js": "^4.5.1",
     "colorsys": "^1.0.22",
     "highlight.js": "^11.10.0",
+    "jszip": "^3.10.1",
     "papaparse": "^5.5.3",
     "showdown": "^2.1.0",
     "splitpanes": "^4.0.4",

--- a/src/app/web/archive.ts
+++ b/src/app/web/archive.ts
@@ -1,0 +1,43 @@
+import type * as FS from '../../fs'
+import { isUserFile } from '../../fs/fs'
+
+// Bundles the user's files into a single zip so a student can take their work
+// with them (issue #42). Internal dotfiles are left out, so the archive holds
+// exactly what the file drawer shows. Directories are skipped as well: the FS
+// interface only lists the root, so there is no way to read their contents.
+//
+// The DOM work of handing the zip to the browser lives at the call site
+// (IdeApp.vue); this module stays framework-free and unit-testable.
+
+/** The archive's date-stamped name, e.g. `scamper-files-2026-08-07.zip`. */
+export function archiveFilename(now: Date = new Date()): string {
+  const pad = (n: number, width = 2) => n.toString().padStart(width, '0')
+  // Local time, not UTC: the stamp should match the day the student sees on
+  // their own clock.
+  const date = `${pad(now.getFullYear(), 4)}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+  return `scamper-files-${date}.zip`
+}
+
+/**
+ * Builds a zip archive of every user file in `fs`.
+ * @returns a promise that resolves to the archive's contents
+ * @throws if a listed file cannot be read
+ */
+export async function buildArchive(fs: FS.t): Promise<Blob> {
+  // JSZip is ~100KB and exporting is a rare, deliberate action, so it is
+  // fetched on first use rather than bundled into the IDE's initial load.
+  const { default: JSZip } = await import('jszip')
+  const zip = new JSZip()
+  const entries = (await fs.getFileList()).filter(isUserFile)
+  for (const entry of entries) {
+    try {
+      zip.file(entry.name, await fs.loadFile(entry.name))
+    } catch (e) {
+      // A file can vanish between the listing and the read. Name it, since the
+      // underlying error usually doesn't.
+      const reason = e instanceof Error ? e.message : String(e)
+      throw new Error(`Could not read "${entry.name}": ${reason}`, { cause: e })
+    }
+  }
+  return zip.generateAsync({ type: 'blob', compression: 'DEFLATE' })
+}

--- a/src/app/web/archive.ts
+++ b/src/app/web/archive.ts
@@ -11,10 +11,10 @@ import { isUserFile } from '../../fs/fs'
 
 /** The archive's date-stamped name, e.g. `scamper-files-2026-08-07.zip`. */
 export function archiveFilename(now: Date = new Date()): string {
-  const pad = (n: number, width = 2) => n.toString().padStart(width, '0')
+  const pad = (n: number) => n.toString().padStart(2, '0')
   // Local time, not UTC: the stamp should match the day the student sees on
   // their own clock.
-  const date = `${pad(now.getFullYear(), 4)}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+  const date = `${now.getFullYear().toString()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
   return `scamper-files-${date}.zip`
 }
 
@@ -24,8 +24,8 @@ export function archiveFilename(now: Date = new Date()): string {
  * @throws if a listed file cannot be read
  */
 export async function buildArchive(fs: FS.t): Promise<Blob> {
-  // JSZip is ~100KB and exporting is a rare, deliberate action, so it is
-  // fetched on first use rather than bundled into the IDE's initial load.
+  // JSZip is 96KB (28KB gzipped) and exporting is a rare, deliberate action, so
+  // it is fetched on first use rather than bundled into the IDE's initial load.
   const { default: JSZip } = await import('jszip')
   const zip = new JSZip()
   const entries = (await fs.getFileList()).filter(isUserFile)

--- a/src/app/web/components/IdeApp.vue
+++ b/src/app/web/components/IdeApp.vue
@@ -14,8 +14,9 @@ import type { ResultsPaneType } from '../composables/use-results-pane'
 import { provideScamperSession } from '../composables/use-scamper-session'
 import Scamper from '../../../scamper'
 import * as FS from '../../../fs'
-import { FileEntry } from '../../../fs/fs'
+import { FileEntry, isUserFile } from '../../../fs/fs'
 import { FileSession } from '../file-session'
+import { archiveFilename, buildArchive } from '../archive'
 import QueryGhostLine from './query/QueryGhostLine.vue'
 import ExpandedQueryModal from './query/ExpandedQueryModal.vue'
 import ModalHost from './ModalHost.vue'
@@ -85,9 +86,7 @@ function abortTraceStep() {
 async function populateFileDrawer() {
   if (!fs) throw new Error('FileSystem not initialized')
   const allFiles = await fs.getFileList()
-  files.value = allFiles.filter(
-    (f: FileEntry) => !f.isDirectory && !f.name.startsWith('.'),
-  )
+  files.value = allFiles.filter(isUserFile)
 }
 
 // ---------- config persistence ----------
@@ -365,6 +364,44 @@ async function handleDownload() {
   a.click()
 }
 
+// Downloads every file in the drawer as one zip archive (issue #42). The open
+// file is saved first so in-progress edits are in the archive too.
+async function handleArchive() {
+  if (!fs) return
+  const count = files.value.length
+  if (count === 0) {
+    await modalAlert({
+      title: 'Export files',
+      message: 'There are no files to export.',
+    })
+    return
+  }
+  const ok = await modalConfirm({
+    title: 'Export files',
+    message: `Download all ${count.toString()} of your files as a zip archive?`,
+    confirmLabel: 'Download',
+  })
+  if (!ok) return
+  try {
+    await saveCurrentFile()
+    const url = URL.createObjectURL(await buildArchive(fs))
+    const a = document.createElement('a')
+    a.href = url
+    a.download = archiveFilename()
+    a.click()
+    // Revoking in the same task can cancel the download the click just started,
+    // so let that task finish first.
+    window.setTimeout(() => {
+      URL.revokeObjectURL(url)
+    }, 0)
+  } catch (e) {
+    await modalAlert({
+      title: 'Export failed',
+      message: `Your files could not be exported. ${e instanceof Error ? e.message : ''}`,
+    })
+  }
+}
+
 async function handleSelectFile(filename: string) {
   if (!isLoadingFile) await switchToFile(filename)
 }
@@ -471,6 +508,7 @@ onUnmounted(() => {
         :rename="handleRename"
         :delete-file="handleDelete"
         :download="handleDownload"
+        :archive="handleArchive"
         :select-file="handleSelectFile"
         :upload-file="handleUploadFile"
         :file-drop="handleFileDrop"

--- a/src/app/web/components/IdeApp.vue
+++ b/src/app/web/components/IdeApp.vue
@@ -354,51 +354,66 @@ async function handleDelete() {
   startAutosaving()
 }
 
-async function handleDownload() {
-  if (!currentFile.value || !fs) return
-  const contents = await fs.loadFile(currentFile.value)
+// How long a generated object URL is kept alive after its download starts.
+// Generous on purpose: the cost of holding a zip a few seconds too long is a
+// little memory, while releasing it too early loses the download.
+const DOWNLOAD_URL_LIFETIME_MS = 10_000
+
+/** Hands `href` to the browser as a download named `filename`. */
+function startDownload(filename: string, href: string) {
   const a = document.createElement('a')
-  a.href = 'data:attachment/text;charset=utf-8,' + encodeURIComponent(contents)
+  a.href = href
   a.target = '_blank'
-  a.download = currentFile.value
+  a.download = filename
   a.click()
 }
 
-// Downloads every file in the drawer as one zip archive (issue #42). The open
-// file is saved first so in-progress edits are in the archive too.
+async function handleDownload() {
+  if (!currentFile.value || !fs) return
+  const contents = await fs.loadFile(currentFile.value)
+  startDownload(
+    currentFile.value,
+    'data:attachment/text;charset=utf-8,' + encodeURIComponent(contents),
+  )
+}
+
+// An archive can take a moment to build, and the button stays clickable while
+// it does; the flag keeps a second click from starting a second export.
+let isArchiving = false
+
+// Downloads every file in the drawer as one zip archive (issue #42).
 async function handleArchive() {
-  if (!fs) return
-  const count = files.value.length
-  if (count === 0) {
-    await modalAlert({
-      title: 'Export files',
-      message: 'There are no files to export.',
-    })
-    return
-  }
+  if (!fs || isArchiving) return
   const ok = await modalConfirm({
     title: 'Export files',
-    message: `Download all ${count.toString()} of your files as a zip archive?`,
+    message: 'Download all of your files as a zip archive?',
     confirmLabel: 'Download',
   })
   if (!ok) return
+  isArchiving = true
   try {
+    // Pause autosave and let any in-flight write settle before reading every
+    // file, the same way the other file operations serialize against the
+    // session (see file-session.ts). Saving first also puts the edits still
+    // sitting in the editor into the archive.
+    stopAutosaving()
     await saveCurrentFile()
     const url = URL.createObjectURL(await buildArchive(fs))
-    const a = document.createElement('a')
-    a.href = url
-    a.download = archiveFilename()
-    a.click()
-    // Revoking in the same task can cancel the download the click just started,
-    // so let that task finish first.
+    startDownload(archiveFilename(), url)
+    // The browser takes its own reference to the blob shortly after the click,
+    // not during it, so revoking immediately can cancel the download. Hold the
+    // URL well past that point, then let the blob go.
     window.setTimeout(() => {
       URL.revokeObjectURL(url)
-    }, 0)
+    }, DOWNLOAD_URL_LIFETIME_MS)
   } catch (e) {
     await modalAlert({
       title: 'Export failed',
-      message: `Your files could not be exported. ${e instanceof Error ? e.message : ''}`,
+      message: `Your files could not be exported.\n\n${e instanceof Error ? e.message : String(e)}`,
     })
+  } finally {
+    isArchiving = false
+    startAutosaving()
   }
 }
 

--- a/src/app/web/components/IdeSidebar.vue
+++ b/src/app/web/components/IdeSidebar.vue
@@ -85,7 +85,8 @@ async function handleFileInputChange(event: Event) {
       ></button>
       <button
         class="fa-solid fa-file-zipper"
-        aria-label="Download zip archive"
+        aria-label="Download all files as a zip archive"
+        :disabled="!props.files?.length"
         @click="archive?.()"
       ></button>
       ⋅

--- a/src/app/web/components/IdeSidebar.vue
+++ b/src/app/web/components/IdeSidebar.vue
@@ -86,7 +86,6 @@ async function handleFileInputChange(event: Event) {
       <button
         class="fa-solid fa-file-zipper"
         aria-label="Download zip archive"
-        disabled
         @click="archive?.()"
       ></button>
       ⋅

--- a/src/app/web/patch-notes.ts
+++ b/src/app/web/patch-notes.ts
@@ -25,6 +25,7 @@ export const patchNotes: PatchNote[] = [
     // in the same block.
     title: 'Library cleanup',
     notes: [
+      'The zip button in the file drawer downloads all of your files at once, so you can keep a copy of your work.',
       'Every function that takes a color now accepts a color name, an rgb value, or an hsv value — so (solid-square 100 (rgb 255 0 0)) works, where before only "red" did.',
       'The old `color` function has been removed. Use `rgb` instead: (rgb 255 0 0) in place of (color 255 0 0 255).',
       'index-of now takes the value first: (index-of "b" lst), matching how member and assoc read.',

--- a/src/fs/fs.ts
+++ b/src/fs/fs.ts
@@ -7,9 +7,9 @@ export interface FileEntry {
 
 /**
  * @returns true iff `entry` is one of the user's own files, i.e., a regular
- *          file that isn't one of the internal dotfiles (the IDE's config,
- *          lock, and swap files). The file drawer and the zip export share this
- *          notion of "the user's files" so they never disagree.
+ *          file whose name isn't dotted. By convention, a dotted name marks a
+ *          file an app keeps for itself. The file drawer and the zip export
+ *          share this notion of "the user's files" so they never disagree.
  */
 export function isUserFile(entry: FileEntry): boolean {
   return !entry.isDirectory && !entry.name.startsWith('.')

--- a/src/fs/fs.ts
+++ b/src/fs/fs.ts
@@ -5,6 +5,16 @@ export interface FileEntry {
   isDirectory: boolean
 }
 
+/**
+ * @returns true iff `entry` is one of the user's own files, i.e., a regular
+ *          file that isn't one of the internal dotfiles (the IDE's config,
+ *          lock, and swap files). The file drawer and the zip export share this
+ *          notion of "the user's files" so they never disagree.
+ */
+export function isUserFile(entry: FileEntry): boolean {
+  return !entry.isDirectory && !entry.name.startsWith('.')
+}
+
 /*
  * A instance of FS provides Scamper with access to the system's underlying file
  * system.

--- a/test/apps/web/archive.test.ts
+++ b/test/apps/web/archive.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest'
+import JSZip from 'jszip'
+import { archiveFilename, buildArchive } from '../../../src/app/web/archive'
+import type { FS, FileEntry } from '../../../src/fs/fs'
+
+/**
+ * An in-memory FS that, unlike MockFileSystem, can report directory entries --
+ * the archive needs to skip those.
+ */
+function mockFS(entries: Record<string, string>, directories: string[] = []): FS {
+  const files = new Map(Object.entries(entries))
+  const list = (): FileEntry[] => [
+    ...[...files.keys()].map((name) => ({ name, preview: null, isDirectory: false })),
+    ...directories.map((name) => ({ name, preview: null, isDirectory: true })),
+  ]
+  return {
+    getFileList: () => Promise.resolve(list()),
+    fileExists: (n) => Promise.resolve(files.has(n)),
+    loadFile: (n) => {
+      const contents = files.get(n)
+      return contents === undefined
+        ? Promise.reject(new Error('NotFoundError'))
+        : Promise.resolve(contents)
+    },
+    saveFile: (n, c) => {
+      files.set(n, c)
+      return Promise.resolve()
+    },
+    deleteFile: (n) => {
+      files.delete(n)
+      return Promise.resolve()
+    },
+    renameFile: () => Promise.reject(new Error('unused')),
+  }
+}
+
+/** @returns the archive's entries as a name -> contents map. */
+async function unzip(blob: Blob): Promise<Record<string, string>> {
+  const zip = await JSZip.loadAsync(await blob.arrayBuffer())
+  const contents: Record<string, string> = {}
+  await Promise.all(
+    Object.values(zip.files).map(async (entry) => {
+      contents[entry.name] = await entry.async('string')
+    }),
+  )
+  return contents
+}
+
+describe('buildArchive', () => {
+  test('archives every user file with its contents', async () => {
+    const fs = mockFS({
+      'hello.scm': '(display "hello")',
+      'shapes.scm': '(solid-square 100 "red")',
+    })
+    expect(await unzip(await buildArchive(fs))).toEqual({
+      'hello.scm': '(display "hello")',
+      'shapes.scm': '(solid-square 100 "red")',
+    })
+  })
+
+  test('leaves out internal dotfiles and directories', async () => {
+    const fs = mockFS(
+      {
+        'hello.scm': '(display "hello")',
+        '.scamper.config': '{}',
+        '.scamper.lock': '2026-08-07T00:00:00.000Z',
+      },
+      ['assets'],
+    )
+    expect(Object.keys(await unzip(await buildArchive(fs)))).toEqual(['hello.scm'])
+  })
+
+  test('produces an empty archive when there are no user files', async () => {
+    expect(await unzip(await buildArchive(mockFS({})))).toEqual({})
+  })
+
+  test('preserves unicode contents through the round trip', async () => {
+    const fs = mockFS({ 'notes.scm': '; λ is a lambda — really\n' })
+    expect((await unzip(await buildArchive(fs)))['notes.scm']).toBe(
+      '; λ is a lambda — really\n',
+    )
+  })
+
+  test('names the unreadable file when a read fails', async () => {
+    const fs = mockFS({ 'gone.scm': '(display 1)' })
+    // The file is listed, but is gone by the time it is read.
+    fs.loadFile = () => Promise.reject(new Error('NotFoundError'))
+    await expect(buildArchive(fs)).rejects.toThrow(/gone\.scm/)
+  })
+})
+
+describe('archiveFilename', () => {
+  test('stamps the archive with the local date', () => {
+    expect(archiveFilename(new Date(2026, 7, 7, 13, 45))).toBe(
+      'scamper-files-2026-08-07.zip',
+    )
+  })
+
+  test('zero-pads single-digit months and days', () => {
+    expect(archiveFilename(new Date(2026, 0, 5))).toBe('scamper-files-2026-01-05.zip')
+  })
+})

--- a/test/apps/web/archive.test.ts
+++ b/test/apps/web/archive.test.ts
@@ -1,38 +1,7 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import JSZip from 'jszip'
 import { archiveFilename, buildArchive } from '../../../src/app/web/archive'
-import type { FS, FileEntry } from '../../../src/fs/fs'
-
-/**
- * An in-memory FS that, unlike MockFileSystem, can report directory entries --
- * the archive needs to skip those.
- */
-function mockFS(entries: Record<string, string>, directories: string[] = []): FS {
-  const files = new Map(Object.entries(entries))
-  const list = (): FileEntry[] => [
-    ...[...files.keys()].map((name) => ({ name, preview: null, isDirectory: false })),
-    ...directories.map((name) => ({ name, preview: null, isDirectory: true })),
-  ]
-  return {
-    getFileList: () => Promise.resolve(list()),
-    fileExists: (n) => Promise.resolve(files.has(n)),
-    loadFile: (n) => {
-      const contents = files.get(n)
-      return contents === undefined
-        ? Promise.reject(new Error('NotFoundError'))
-        : Promise.resolve(contents)
-    },
-    saveFile: (n, c) => {
-      files.set(n, c)
-      return Promise.resolve()
-    },
-    deleteFile: (n) => {
-      files.delete(n)
-      return Promise.resolve()
-    },
-    renameFile: () => Promise.reject(new Error('unused')),
-  }
-}
+import { MockFileSystem } from '../../stubs/mock-file-system'
 
 /** @returns the archive's entries as a name -> contents map. */
 async function unzip(blob: Blob): Promise<Record<string, string>> {
@@ -48,10 +17,10 @@ async function unzip(blob: Blob): Promise<Record<string, string>> {
 
 describe('buildArchive', () => {
   test('archives every user file with its contents', async () => {
-    const fs = mockFS({
-      'hello.scm': '(display "hello")',
-      'shapes.scm': '(solid-square 100 "red")',
-    })
+    const fs = new MockFileSystem()
+    await fs.saveFile('hello.scm', '(display "hello")')
+    await fs.saveFile('shapes.scm', '(solid-square 100 "red")')
+
     expect(await unzip(await buildArchive(fs))).toEqual({
       'hello.scm': '(display "hello")',
       'shapes.scm': '(solid-square 100 "red")',
@@ -59,44 +28,43 @@ describe('buildArchive', () => {
   })
 
   test('leaves out internal dotfiles and directories', async () => {
-    const fs = mockFS(
-      {
-        'hello.scm': '(display "hello")',
-        '.scamper.config': '{}',
-        '.scamper.lock': '2026-08-07T00:00:00.000Z',
-      },
-      ['assets'],
-    )
+    const fs = new MockFileSystem()
+    await fs.saveFile('hello.scm', '(display "hello")')
+    await fs.saveFile('.scamper.config', '{}')
+    await fs.saveFile('.scamper.lock', '2026-08-07T00:00:00.000Z')
+    fs.addDirectory('assets')
+
     expect(Object.keys(await unzip(await buildArchive(fs)))).toEqual(['hello.scm'])
   })
 
   test('produces an empty archive when there are no user files', async () => {
-    expect(await unzip(await buildArchive(mockFS({})))).toEqual({})
+    expect(await unzip(await buildArchive(new MockFileSystem()))).toEqual({})
   })
 
   test('preserves unicode contents through the round trip', async () => {
-    const fs = mockFS({ 'notes.scm': '; λ is a lambda — really\n' })
+    const fs = new MockFileSystem()
+    await fs.saveFile('notes.scm', '; λ is a lambda — really\n')
+
     expect((await unzip(await buildArchive(fs)))['notes.scm']).toBe(
       '; λ is a lambda — really\n',
     )
   })
 
   test('names the unreadable file when a read fails', async () => {
-    const fs = mockFS({ 'gone.scm': '(display 1)' })
+    const fs = new MockFileSystem()
+    await fs.saveFile('gone.scm', '(display 1)')
     // The file is listed, but is gone by the time it is read.
-    fs.loadFile = () => Promise.reject(new Error('NotFoundError'))
+    vi.spyOn(fs, 'loadFile').mockRejectedValue(new Error('NotFoundError'))
+
     await expect(buildArchive(fs)).rejects.toThrow(/gone\.scm/)
   })
 })
 
 describe('archiveFilename', () => {
-  test('stamps the archive with the local date', () => {
-    expect(archiveFilename(new Date(2026, 7, 7, 13, 45))).toBe(
-      'scamper-files-2026-08-07.zip',
+  test('stamps the archive with the local date, zero-padded', () => {
+    // Late enough in the day that a UTC-based stamp would name the next one.
+    expect(archiveFilename(new Date(2026, 0, 5, 23, 30))).toBe(
+      'scamper-files-2026-01-05.zip',
     )
-  })
-
-  test('zero-pads single-digit months and days', () => {
-    expect(archiveFilename(new Date(2026, 0, 5))).toBe('scamper-files-2026-01-05.zip')
   })
 })

--- a/test/apps/web/ide-archive.test.ts
+++ b/test/apps/web/ide-archive.test.ts
@@ -1,5 +1,5 @@
 import { flushPromises, mount } from '@vue/test-utils'
-import { findByRole, getByRole, queryByRole, waitFor } from '@testing-library/dom'
+import { fireEvent, findByRole, getByRole, waitFor } from '@testing-library/dom'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import JSZip from 'jszip'
 import IdeApp from '../../../src/app/web/components/IdeApp.vue'
@@ -24,6 +24,8 @@ vi.mock(
 
 await initialize()
 
+const EXPORT_BUTTON = 'Download all files as a zip archive'
+
 // Exporting the file drawer as a zip (issue #42). These tests drive the whole
 // path: the sidebar button, the confirmation, and the download the browser is
 // handed.
@@ -33,7 +35,6 @@ describe('IDE zip export', () => {
   let blobs: Map<string, Blob>
   /** The `download` name of every anchor that was clicked. */
   let downloads: { name: string; url: string }[]
-  let revoked: string[]
 
   beforeEach(() => {
     fs = new MockFileSystem()
@@ -41,16 +42,12 @@ describe('IDE zip export', () => {
 
     // jsdom implements neither half of the object-URL API.
     blobs = new Map()
-    revoked = []
-    let nextUrl = 0
     URL.createObjectURL = vi.fn((blob: Blob) => {
-      const url = `blob:mock/${(nextUrl++).toString()}`
+      const url = `blob:mock/${blobs.size.toString()}`
       blobs.set(url, blob)
       return url
     })
-    URL.revokeObjectURL = vi.fn((url: string) => {
-      revoked.push(url)
-    })
+    URL.revokeObjectURL = vi.fn()
 
     downloads = []
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(
@@ -73,8 +70,23 @@ describe('IDE zip export', () => {
     return wrapper
   }
 
-  function clickExport() {
-    getByRole(document.body, 'button', { name: 'Download zip archive' }).click()
+  /** Clicks the export button and confirms the dialog it raises. */
+  async function exportFiles() {
+    getByRole(document.body, 'button', { name: EXPORT_BUTTON }).click()
+    const dialog = await findByRole(document.body, 'dialog', {
+      name: 'Export files',
+    })
+    getByRole(dialog, 'button', { name: 'Download' }).click()
+  }
+
+  /** @returns the archive handed to the browser by the one download so far. */
+  async function downloadedArchive(): Promise<JSZip> {
+    // Zipping spans several tasks, so wait for the download rather than
+    // flushing a fixed number of them.
+    await waitFor(() => {
+      expect(downloads).toHaveLength(1)
+    })
+    return JSZip.loadAsync(await blobs.get(downloads[0].url)!.arrayBuffer())
   }
 
   test('downloads the drawer as a date-stamped zip once confirmed', async () => {
@@ -85,28 +97,34 @@ describe('IDE zip export', () => {
 
     const wrapper = await mountIde()
     try {
-      clickExport()
-      const dialog = await findByRole(document.body, 'dialog', {
-        name: 'Export files',
-      })
-      expect(dialog.textContent).toContain('all 2 of your files')
-      getByRole(dialog, 'button', { name: 'Download' }).click()
-      // Zipping spans several tasks, so wait for the download rather than
-      // flushing a fixed number of them.
-      await waitFor(() => {
-        expect(downloads).toHaveLength(1)
-      })
-      expect(downloads[0].name).toMatch(/^scamper-files-\d{4}-\d{2}-\d{2}\.zip$/)
+      await exportFiles()
 
-      const zip = await JSZip.loadAsync(await blobs.get(downloads[0].url)!.arrayBuffer())
+      const zip = await downloadedArchive()
+      expect(downloads[0].name).toMatch(/^scamper-files-\d{4}-\d{2}-\d{2}\.zip$/)
       expect(Object.keys(zip.files).sort()).toEqual(['hello.scm', 'shapes.scm'])
       expect(await zip.file('hello.scm')!.async('string')).toBe('(display "hello")')
+    } finally {
+      wrapper.unmount()
+    }
+  })
 
-      // The object URL is released once the download has started, so the blob
-      // isn't pinned in memory for the rest of the session.
-      await waitFor(() => {
-        expect(revoked).toEqual([downloads[0].url])
+  test('archives the edits still sitting in the editor', async () => {
+    await fs.saveFile('hello.scm', '(display "hello")')
+
+    const wrapper = await mountIde()
+    try {
+      getByRole(document.body, 'button', { name: 'Open hello.scm' }).click()
+      await flushPromises()
+      // Typed but never saved: the export has to save the open file first.
+      fireEvent.input(getByRole(document.body, 'textbox', { name: 'Source code' }), {
+        target: { value: '(display "edited")' },
       })
+      await flushPromises()
+
+      await exportFiles()
+
+      const zip = await downloadedArchive()
+      expect(await zip.file('hello.scm')!.async('string')).toBe('(display "edited")')
     } finally {
       wrapper.unmount()
     }
@@ -117,7 +135,7 @@ describe('IDE zip export', () => {
 
     const wrapper = await mountIde()
     try {
-      clickExport()
+      getByRole(document.body, 'button', { name: EXPORT_BUTTON }).click()
       const dialog = await findByRole(document.body, 'dialog', {
         name: 'Export files',
       })
@@ -132,20 +150,24 @@ describe('IDE zip export', () => {
     }
   })
 
-  test('says so when there is nothing to export', async () => {
+  test('offers nothing to export until there is a file', async () => {
     const wrapper = await mountIde()
     try {
-      clickExport()
-      const dialog = await findByRole(document.body, 'dialog', {
-        name: 'Export files',
+      const button = getByRole(document.body, 'button', { name: EXPORT_BUTTON })
+      expect(button).toBeDisabled()
+
+      // Creating a file makes the export available.
+      getByRole(document.body, 'button', { name: 'Create file' }).click()
+      const dialog = await findByRole(document.body, 'dialog', { name: 'New file' })
+      fireEvent.input(getByRole(dialog, 'textbox'), {
+        target: { value: 'hello.scm' },
       })
-      expect(dialog.textContent).toContain('no files to export')
-      // An alert, not a confirmation: there is nothing to go ahead with.
-      expect(queryByRole(dialog, 'button', { name: 'Cancel' })).toBeNull()
       getByRole(dialog, 'button', { name: 'OK' }).click()
       await flushPromises()
 
-      expect(downloads).toEqual([])
+      await waitFor(() => {
+        expect(button).toBeEnabled()
+      })
     } finally {
       wrapper.unmount()
     }
@@ -159,11 +181,7 @@ describe('IDE zip export', () => {
       // The file is listed in the drawer, but is gone by the time it is read.
       vi.spyOn(fs, 'loadFile').mockRejectedValue(new Error('NotFoundError'))
 
-      clickExport()
-      const confirm = await findByRole(document.body, 'dialog', {
-        name: 'Export files',
-      })
-      getByRole(confirm, 'button', { name: 'Download' }).click()
+      await exportFiles()
 
       const failure = await findByRole(document.body, 'dialog', {
         name: 'Export failed',

--- a/test/apps/web/ide-archive.test.ts
+++ b/test/apps/web/ide-archive.test.ts
@@ -1,0 +1,177 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { findByRole, getByRole, queryByRole, waitFor } from '@testing-library/dom'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import JSZip from 'jszip'
+import IdeApp from '../../../src/app/web/components/IdeApp.vue'
+import * as FS from '../../../src/fs'
+import { MockFileSystem } from '../../stubs/mock-file-system'
+import { initialize } from '../../../src/scamper'
+
+vi.mock('../../../src/app/web/lockfile', () => ({
+  acquireLockFile: vi.fn(() => Promise.resolve(true)),
+  releaseLockFile: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock(
+  '../../../src/app/web/components/CodeMirrorEditor.vue',
+  () => import('../../stubs/MockCodeMirrorEditor.vue'),
+)
+
+vi.mock(
+  '../../../src/app/web/components/ResultsPane.vue',
+  () => import('../../stubs/MockResultsPane.vue'),
+)
+
+await initialize()
+
+// Exporting the file drawer as a zip (issue #42). These tests drive the whole
+// path: the sidebar button, the confirmation, and the download the browser is
+// handed.
+describe('IDE zip export', () => {
+  let fs: MockFileSystem
+  /** The blob each object URL was minted from, keyed by URL. */
+  let blobs: Map<string, Blob>
+  /** The `download` name of every anchor that was clicked. */
+  let downloads: { name: string; url: string }[]
+  let revoked: string[]
+
+  beforeEach(() => {
+    fs = new MockFileSystem()
+    FS.setFS(fs)
+
+    // jsdom implements neither half of the object-URL API.
+    blobs = new Map()
+    revoked = []
+    let nextUrl = 0
+    URL.createObjectURL = vi.fn((blob: Blob) => {
+      const url = `blob:mock/${(nextUrl++).toString()}`
+      blobs.set(url, blob)
+      return url
+    })
+    URL.revokeObjectURL = vi.fn((url: string) => {
+      revoked.push(url)
+    })
+
+    downloads = []
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(
+      function (this: HTMLAnchorElement) {
+        downloads.push({ name: this.download, url: this.href })
+      },
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  /** Mounts the IDE and waits for the file drawer to be populated. */
+  async function mountIde() {
+    const wrapper = mount(IdeApp, { attachTo: document.body })
+    await findByRole(document.body, 'button', { name: 'Create file' })
+    await flushPromises()
+    return wrapper
+  }
+
+  function clickExport() {
+    getByRole(document.body, 'button', { name: 'Download zip archive' }).click()
+  }
+
+  test('downloads the drawer as a date-stamped zip once confirmed', async () => {
+    await fs.saveFile('hello.scm', '(display "hello")')
+    await fs.saveFile('shapes.scm', '(solid-square 100 "red")')
+    // Internal state the student never sees in the drawer.
+    await fs.saveFile('.scamper.config', '{}')
+
+    const wrapper = await mountIde()
+    try {
+      clickExport()
+      const dialog = await findByRole(document.body, 'dialog', {
+        name: 'Export files',
+      })
+      expect(dialog.textContent).toContain('all 2 of your files')
+      getByRole(dialog, 'button', { name: 'Download' }).click()
+      // Zipping spans several tasks, so wait for the download rather than
+      // flushing a fixed number of them.
+      await waitFor(() => {
+        expect(downloads).toHaveLength(1)
+      })
+      expect(downloads[0].name).toMatch(/^scamper-files-\d{4}-\d{2}-\d{2}\.zip$/)
+
+      const zip = await JSZip.loadAsync(await blobs.get(downloads[0].url)!.arrayBuffer())
+      expect(Object.keys(zip.files).sort()).toEqual(['hello.scm', 'shapes.scm'])
+      expect(await zip.file('hello.scm')!.async('string')).toBe('(display "hello")')
+
+      // The object URL is released once the download has started, so the blob
+      // isn't pinned in memory for the rest of the session.
+      await waitFor(() => {
+        expect(revoked).toEqual([downloads[0].url])
+      })
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  test('downloads nothing when the confirmation is cancelled', async () => {
+    await fs.saveFile('hello.scm', '(display "hello")')
+
+    const wrapper = await mountIde()
+    try {
+      clickExport()
+      const dialog = await findByRole(document.body, 'dialog', {
+        name: 'Export files',
+      })
+      getByRole(dialog, 'button', { name: 'Cancel' }).click()
+      await flushPromises()
+
+      expect(downloads).toEqual([])
+      // No object URL was minted, so no archive was ever built.
+      expect(blobs.size).toBe(0)
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  test('says so when there is nothing to export', async () => {
+    const wrapper = await mountIde()
+    try {
+      clickExport()
+      const dialog = await findByRole(document.body, 'dialog', {
+        name: 'Export files',
+      })
+      expect(dialog.textContent).toContain('no files to export')
+      // An alert, not a confirmation: there is nothing to go ahead with.
+      expect(queryByRole(dialog, 'button', { name: 'Cancel' })).toBeNull()
+      getByRole(dialog, 'button', { name: 'OK' }).click()
+      await flushPromises()
+
+      expect(downloads).toEqual([])
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  test('reports a failure to read a file instead of downloading a partial zip', async () => {
+    await fs.saveFile('hello.scm', '(display "hello")')
+
+    const wrapper = await mountIde()
+    try {
+      // The file is listed in the drawer, but is gone by the time it is read.
+      vi.spyOn(fs, 'loadFile').mockRejectedValue(new Error('NotFoundError'))
+
+      clickExport()
+      const confirm = await findByRole(document.body, 'dialog', {
+        name: 'Export files',
+      })
+      getByRole(confirm, 'button', { name: 'Download' }).click()
+
+      const failure = await findByRole(document.body, 'dialog', {
+        name: 'Export failed',
+      })
+      expect(failure.textContent).toContain('hello.scm')
+      expect(downloads).toEqual([])
+    } finally {
+      wrapper.unmount()
+    }
+  })
+})

--- a/test/stubs/mock-file-system.ts
+++ b/test/stubs/mock-file-system.ts
@@ -2,19 +2,33 @@ import { FS } from '../../src/fs/fs'
 
 export class MockFileSystem implements FS {
   private files = new Map<string, string>()
+  private directories = new Set<string>()
 
   static create(): Promise<MockFileSystem> {
     return Promise.resolve(new MockFileSystem())
   }
 
+  /**
+   * Adds a directory to the listing. Nothing in the IDE creates one, but both
+   * the file drawer and the zip export have to leave them alone.
+   */
+  addDirectory(name: string): void {
+    this.directories.add(name)
+  }
+
   getFileList() {
-    return Promise.resolve(
-      [...this.files.entries()].map(([name, preview]) => ({
+    return Promise.resolve([
+      ...[...this.files.entries()].map(([name, preview]) => ({
         name,
         preview,
         isDirectory: false,
       })),
-    )
+      ...[...this.directories].map((name) => ({
+        name,
+        preview: null,
+        isDirectory: true,
+      })),
+    ])
   }
 
   fileExists(filename: string) {


### PR DESCRIPTION
Ticks off "Add export all (to zip) functionality" from #42. The file-history work (the other open box on that issue) will follow on this branch.

### What it does

The file drawer's zip button — previously present but disabled — now downloads every file in the drawer as one date-stamped archive (`scamper-files-2026-08-07.zip`), after a confirmation. The open file is saved first, so whatever is in the editor at the time is in the archive.

### How it's put together

+ **`src/app/web/archive.ts`** builds the zip and names it. It re-lists the file system rather than zipping the drawer's cached list, so a file a running program just wrote is included. The DOM side of the download stays at the call site in `IdeApp`, which keeps this module framework-free and unit-testable.
+ **JSZip** is loaded with a dynamic `import`, so it lands in its own 96KB (28KB gzipped) chunk fetched on first export instead of weighing down the IDE's initial load. The trade-off: an export attempted after the network drops mid-session fails with the "Export failed" dialog.
+ **`isUserFile`** moves next to `FileEntry` in `src/fs/fs.ts`. The drawer and the archive now share one notion of "the user's files", so they can't drift apart.
+ Exporting **pauses autosave and settles any in-flight write** before reading, the way `delete`/`rename`/`upload` serialize against the `FileSession` (#184).
+ A read that fails **aborts the whole export** with the offending filename rather than quietly handing back a partial archive.

### Tests

`test/apps/web/archive.test.ts` covers the zip itself (contents, dotfile/directory exclusion, unicode round trip, failure message, filename stamping). `test/apps/web/ide-archive.test.ts` drives the full path through a mounted IDE: button → confirmation → the blob the browser is handed, including that unsaved editor edits make it in and that a cancel downloads nothing. `MockFileSystem` learned about directories so the two suites can share it.

### Reviewed, with one thing left open

An independent review turned up a possible interaction with Chromium's OPFS `.crswap` swap siblings: they aren't dot-prefixed, so `isUserFile` would let one through, and a transient one could fail an export outright. Pausing autosave closes the window this PR opens, but stale swap files from a crashed tab would still show up — **in the file drawer too, which is pre-existing**. I could not verify the behavior here (the sandbox has no working Chromium), so it is untouched and worth a look in a real browser before the next release.

Also worth a second opinion: the confirmation dialog itself. It was requested, but every other `modalConfirm` in the IDE guards something destructive, and this one guards a download.

_(Co-created with Claude Code)_
