### PR TITLE
Point the image browser test at the canvas module (#355)

### DIFF
--- a/test/libs/image.browser.test.ts
+++ b/test/libs/image.browser.test.ts
@@ -10,6 +10,12 @@
 import { describe, expect, test } from 'vitest'
 import * as L from '../../src/lpm'
 import {
+  canvas_canvasGetPixel,
+  canvas_canvasSetPixels,
+  canvas_canvasToPixels,
+  canvas_pixelsToCanvas,
+} from '../../src/js/canvas/index.js'
+import {
   color_colorToRgb,
   color_hsv,
   color_hsvAlpha,
@@ -37,12 +43,6 @@ import {
   drawing_text,
   drawing_withDash,
 } from '../../src/js/image/drawing.js'
-import {
-  canvas_canvasSetPixels,
-  canvas_canvasGetPixel,
-  canvas_canvasToPixels,
-  canvas_pixelsToCanvas,
-} from '../../src/js/image/image.js'
 
 function makeCanvas(width: number, height: number): HTMLCanvasElement {
   const canvas = document.createElement('canvas')

--- a/test/regressions/browser-test-imports.test.ts
+++ b/test/regressions/browser-test-imports.test.ts
@@ -1,0 +1,129 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { describe, expect, test } from 'vitest'
+
+// Regression test for #355: `test/libs/image.browser.test.ts` kept importing
+// the canvas pixel functions from src/js/image/image.ts after #347 moved them
+// to src/js/canvas/index.ts, and CI was the first thing to notice.
+//
+// Browser tests sit in a blind spot that ordinary test files do not: they are
+// excluded from `npm test` (vite.config.ts skips **/*.browser.test.ts, since
+// jsdom cannot back them) and excluded from `npm run typecheck` (the root
+// tsconfig.json excludes test/). So nothing local ever loads or typechecks
+// them, and a stale import survives all of `npm run validate` only to break
+// `npm run test:browser` in CI.
+//
+// This test runs under the default jsdom suite and checks the one property
+// that failure hinged on: every name a browser test imports from a relative
+// module is actually exported by that module. It deliberately checks bindings
+// rather than typechecking, so it stays fast and is unaffected by unrelated
+// pre-existing type errors in the test tree.
+
+const testRoot = resolve(__dirname, '..')
+
+/** Collects every `*.browser.test.ts` file under `test/`. */
+function browserTestFiles(): string[] {
+  return readdirSync(testRoot, { recursive: true, encoding: 'utf-8' })
+    .filter((f) => f.endsWith('.browser.test.ts'))
+    .map((f) => resolve(testRoot, f))
+    .sort()
+}
+
+interface NamedImport {
+  /** The name as exported by the target module (before any `as` alias). */
+  binding: string
+  /** The import specifier as written, e.g. `../../src/js/canvas/index.js`. */
+  specifier: string
+}
+
+/**
+ * Extracts the named bindings a source file imports from relative modules.
+ * Namespace (`import * as L`), default, and type-only imports are skipped:
+ * only value bindings can break the way #355 broke.
+ */
+function namedRelativeImports(source: string): NamedImport[] {
+  const imports: NamedImport[] = []
+  const pattern = /import\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g
+
+  for (const [, clause, specifier] of source.matchAll(pattern)) {
+    if (!specifier.startsWith('.')) { continue }
+    for (const entry of clause.split(',')) {
+      const name = entry.trim()
+      if (name === '' || name.startsWith('type ')) { continue }
+      imports.push({ binding: name.split(/\s+as\s+/)[0].trim(), specifier })
+    }
+  }
+
+  return imports
+}
+
+/** True if `path` names an existing file rather than a directory. */
+function isFile(path: string): boolean {
+  return existsSync(path) && statSync(path).isFile()
+}
+
+/**
+ * Resolves an import specifier to a file on disk, mirroring how the bundler
+ * reads a `.js` specifier as its `.ts` source and a bare directory as its
+ * `index.ts`. The directory check matters for an extensionless specifier like
+ * `../../src/lpm`, where the first candidate is the directory itself.
+ * @returns the resolved path, or undefined if no candidate exists.
+ */
+function resolveModule(fromFile: string, specifier: string): string | undefined {
+  const base = resolve(dirname(fromFile), specifier)
+  const candidates = [
+    base.replace(/\.js$/, '.ts'),
+    `${base}.ts`,
+    `${base}/index.ts`,
+  ]
+  return candidates.find(isFile)
+}
+
+describe('#355: browser tests import names that still exist', () => {
+  const files = browserTestFiles()
+
+  test('there is at least one browser test to check', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  test('resolves an extensionless directory specifier to its index.ts', () => {
+    const fromFile = resolve(testRoot, 'libs/example.browser.test.ts')
+    expect(resolveModule(fromFile, '../../src/lpm')).toBe(
+      resolve(testRoot, '../src/lpm/index.ts'),
+    )
+  })
+
+  test.each(files.map((f) => [f.slice(testRoot.length + 1), f]))(
+    '%s imports only names its modules export',
+    async (_label, file) => {
+      const imports = namedRelativeImports(readFileSync(file, 'utf-8'))
+
+      // Group by specifier so each module is imported once.
+      const bySpecifier = new Map<string, string[]>()
+      for (const { binding, specifier } of imports) {
+        bySpecifier.set(specifier, [
+          ...(bySpecifier.get(specifier) ?? []),
+          binding,
+        ])
+      }
+
+      for (const [specifier, bindings] of bySpecifier) {
+        const path = resolveModule(file, specifier)
+        if (path === undefined) {
+          expect.fail(`${specifier} does not resolve to a file`)
+        }
+
+        const module = (await import(
+          /* @vite-ignore */ pathToFileURL(path).href
+        )) as Record<string, unknown>
+        const missing = bindings.filter((b) => !(b in module))
+
+        expect(
+          missing,
+          `${specifier} no longer exports: ${missing.join(', ')}`,
+        ).toEqual([])
+      }
+    },
+  )
+})


### PR DESCRIPTION
Fixes #355.

## The bug

`npm run test:browser` fails in CI:

```
SyntaxError: The requested module '/src/js/image/image.ts' does not provide an export named 'canvas_canvasGetPixel'
```

#347 moved the four canvas pixel functions (`canvas_canvasGetPixel`, `canvas_canvasSetPixels`, `canvas_canvasToPixels`, `canvas_pixelsToCanvas`) out of `src/js/image/image.ts` and into `src/js/canvas/index.ts`. It updated the *bodies* of `test/libs/image.browser.test.ts` for the renames, but not the import path. Every other file in the repo already points at `src/js/canvas/index.js`; this was the last stale one.

The import error meant the file collected **0 tests**, so nothing in it has run since #347.

## Why validation missed it

Browser tests sit in a blind spot that ordinary test files do not:

- `vite.config.ts` excludes `**/*.browser.test.ts` from `npm test` — jsdom cannot back them.
- The root `tsconfig.json` excludes `test/` from `npm run typecheck`. (`test/tsconfig.json` exists and covers the tree, but nothing runs it.)

So nothing local ever loads *or* typechecks these files, and a stale import passes all of `npm run validate` only to break in CI.

## The fix

One import specifier, plus a regression test that closes the gap. `test/regressions/browser-test-imports.test.ts` runs under the default jsdom suite and checks, for every `*.browser.test.ts`, that each name imported from a relative module is actually exported by that module. It verifies bindings rather than typechecking, so it stays fast and is unaffected by the pre-existing type errors elsewhere in `test/`.

## Validation

- The regression test fails on the unfixed import, naming all four missing exports, and passes with the fix. Verified in both directions.
- `npm run validate`: typecheck **PASS**, test **PASS**, lint **PASS** (0 errors; the new file adds no warnings).
- `vue-tsc -p test/tsconfig.json` no longer reports any error in `image.browser.test.ts` — including the implicit-`any` at line 360, which was a downstream symptom of the unresolvable import.

**N.B.** I could not run `npm run test:browser` locally — Playwright's Chromium is missing a system library (`libatk-1.0.so.0`) on this machine. The import fix is verified statically, but because the file collected 0 tests since #347, CI will be the first thing to actually execute its bodies. Worth a glance at the CI run on this PR.

_(Co-created with Claude Code)_