### PR TITLE
Ignore agent worktrees and browser-test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ src/lib/generated/sources.ts
 # `git add -A` from the root will otherwise stage it as an embedded repository.
 # Only the worktrees: .claude/skills/ is checked in.
 .claude/worktrees/
+
+# Artifacts a failing browser test leaves behind (npm run test:browser)
+__screenshots__/
+.vitest-attachments/

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,8 @@ src/lib/generated/sources.ts
 .zed
 .cursor
 .junie
+
+# Git worktrees created by coding agents. Each is a checkout of this repo, so
+# `git add -A` from the root will otherwise stage it as an embedded repository.
+# Only the worktrees: .claude/skills/ is checked in.
+.claude/worktrees/


### PR DESCRIPTION
Two things that end up in `git status` but should never be committed.

**`.claude/worktrees/`** holds git worktrees created by coding agents. Each is a full checkout of this repo, so `git add -A` from the root stages one as an embedded repository — I did exactly that on #354 and had to amend it out. Only the worktrees are ignored; `.claude/skills/` stays checked in.

**`__screenshots__/` and `.vitest-attachments/`** are what `npm run test:browser` writes when a test fails.

Related, but fixed in #354 since it is a code change rather than an ignore rule: a leftover `__screenshots__/<name>.browser.test.ts/` directory made the browser-test import check from #356 die with EISDIR, because it globs that name expecting a file.

_(Co-created with Claude Code)_