### PR TITLE
Guard against the mistakes automation kept making

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Refuses two things that are easy to stage by accident with `git add -A` and
+# awkward to undo once pushed.
+#
+# Agents create git worktrees under .claude/worktrees/. Each is a full checkout
+# of this repo, so staging one records it as an embedded repository (a gitlink)
+# rather than as files -- a clone of scamper would then contain a pointer to a
+# commit nobody else has. .gitignore covers the path, but only while it is
+# untracked, and neither guard helps once it is in the index.
+
+embedded=$(git diff --cached --raw | awk '$2 == "160000" { print $NF }')
+if [ -n "$embedded" ]; then
+  echo "pre-commit: refusing to commit an embedded git repository:" >&2
+  echo "$embedded" | sed 's/^/  /' >&2
+  echo >&2
+  echo "This is usually a worktree swept up by 'git add -A'. Unstage it with:" >&2
+  echo "  git rm --cached -r <path>" >&2
+  echo "and stage explicit paths instead of -A." >&2
+  exit 1
+fi
+
+worktrees=$(git diff --cached --name-only | grep '^\.claude/worktrees/')
+if [ -n "$worktrees" ]; then
+  echo "pre-commit: refusing to commit another session's worktree:" >&2
+  echo "$worktrees" | sed 's/^/  /' >&2
+  echo "  git rm --cached -r .claude/worktrees" >&2
+  exit 1
+fi
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,17 @@ Once that's working, take the codebase tour:
 
 ### Hopefully this was an accelerated course in web development!
 
+## A note on committing
+
+`npm install` points git at the hooks in `.githooks/`, which refuse a commit that
+contains an embedded git repository or anything under `.claude/worktrees/`. Those
+directories are checkouts of Scamper that coding agents work in, and `git add -A`
+from the repo root will otherwise stage one as a pointer to a commit nobody else
+has. If the hook stops you, unstage the path (`git rm --cached -r <path>`) and
+stage the files you meant to commit by name.
+
+If you cloned before this existed, run `npm run hooks` once.
+
 ## No-AI policy (during onboarding only)
 
 For the week this guide covers, please don't use generative AI tools (ChatGPT, Copilot, Cursor's agent, Google's AI Overview, etc.) to write your code or read the docs for you. The goal is to build the mental model of how a TypeScript/Vue/Vite project fits together so that after onboarding, when you *do* use AI tools, you can tell when they're hallucinating. Once you're done onboarding, use whatever makes you productive (and whatever Sam lets you use).

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "The Scamper multimedia programming environment",
   "main": "./_build/js/index.js",
   "scripts": {
-    "postinstall": "npm run generate",
+    "postinstall": "npm run generate && npm run hooks",
     "generate": "npm run generate-parser && npm run generate-lib-sources",
+    "hooks": "git config core.hooksPath .githooks || true",
     "generate-parser": "node scripts/generate-parser.mjs",
     "generate-lib-sources": "node scripts/generate-lib-sources.mjs",
     "dev": "vite",

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -48,6 +48,7 @@ Scamper has a comprehensive test suite whose structure nearly mirrors the struct
 + A few libs/ specs need a real Canvas2D/font-metrics implementation to test meaningfully (real pixel rendering, getImageData round-trips, measureText); these live in test/libs/canvas.browser.test.ts and test/libs/image.browser.test.ts and run under real headless Chromium via Vitest's browser mode + Playwright (test/vitest.browser.config.ts), not jsdom
 + Excluded from `npm test`/`npm run validate` (see vite.config.ts's test.exclude) since a missing Playwright browser binary fails vitest's browser-mode startup outright -- this is a deliberately separate, opt-in suite; CI runs it as its own job
 + One-time setup: `npm run playwright:install` downloads a headless Chromium binary (cached outside the repo); then run with `npm run test:browser` / `npm run coverage:browser`
++ On a bare Linux box the binary needs system libraries that are not installed with it. The symptom is a startup failure naming a missing shared object -- `error while loading shared libraries: libatk-1.0.so.0` -- which reads like a broken test run but is an environment gap: nothing in the suite is at fault and no amount of editing it will help. Install them once with `npx playwright install --with-deps chromium` (needs root; it is what CI's browser-tests job runs). Headlessness is not the problem -- CI runs headless too
 
 ## Style
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,6 @@
 import * as matchers from '@testing-library/jest-dom/matchers'
-import { expect } from 'vitest'
+import { afterEach, expect } from 'vitest'
+import { activeModal, dismissModal } from '../src/app/web/composables/use-modals'
 import 'vitest-canvas-mock'
 import { initializeLibs } from '../src/lib'
 import * as SymbolDB from '../src/scheme/symbol-db'
@@ -18,3 +19,13 @@ await initializeLibs()
 // N.B., after initializeLibs(): the symbol DB snapshots the just-loaded
 // builtin libraries.
 SymbolDB.initialize()
+
+// use-modals keeps a single module-level queue of pending dialogs, so a test
+// that opens one and never answers it leaves the request active -- and the next
+// test's freshly mounted ModalHost renders that stale dialog instead of the one
+// it is waiting for. Draining between tests keeps that from crossing files.
+afterEach(() => {
+  while (activeModal.value !== null) {
+    dismissModal()
+  }
+})


### PR DESCRIPTION
Three small guards, each for something that actually went wrong while landing #353 and #354 — written up rather than left as discipline, since discipline does not survive the next session.

### A pre-commit hook against stray worktrees

Agents create git worktrees under `.claude/worktrees/`. Each is a full checkout of Scamper, so `git add -A` from the repo root stages one as an *embedded repository* — a pointer to a commit nobody else has. I did this twice on #354 and had to amend and force-push both times.

#358 added the ignore rule, which helps only while the path is untracked and not at all once it is in the index. `.githooks/pre-commit` refuses the commit outright and says how to unstage it. `npm install` sets `core.hooksPath`, so a fresh clone is covered without anyone remembering; existing clones need `npm run hooks` once.

Verified by force-adding the live worktree and committing: refused, exit 1.

### What to do when the browser suite will not start

`npm run playwright:install` downloads the binary but not the system libraries it links against. The failure names a missing shared object (`libatk-1.0.so.0`), which reads like a broken test run rather than an environment gap — I spent a while shipping claims I could not verify because of it. test/TESTING.md now names the symptom and the fix (`npx playwright install --with-deps chromium`, what CI already runs), and notes that headlessness is not the problem.

### Draining the modal queue between tests

`use-modals` keeps a single module-level queue. A test that opens a dialog and never answers it leaves the request active, and the *next* test file's freshly mounted `ModalHost` renders that stale dialog instead of the one it is waiting for. This produced three failures in an apparently unrelated test and took a while to see.

A global `afterEach` in test/setup.ts drains it. Verified both ways: removing a test's own dismissal still passes with the drain, and removing the drain as well brings all three failures straight back.

_(Co-created with Claude Code)_