### PR TITLE
Reserve internal `##...##` names so expansion cannot be shadowed (#336)

### DIFF
--- a/src/js/runtime/index.ts
+++ b/src/js/runtime/index.ts
@@ -13,6 +13,32 @@ export function runtime_report (value: L.Value): L.Value {
 }
 
 /**
+ * Raises a runtime error carrying `msg`. Bound to the internal `##error##`,
+ * which expansion and contract insertion inject by reference -- a `cond`
+ * fall-through becomes `(##error## "No matching clause in cond")`. It is
+ * internal (rather than the prelude's `error`) so a user binding named `error`
+ * cannot change what those forms do.
+ *
+ * A separate function object from prelude_error, not an alias: Module
+ * .registerValue renames whatever it binds, so sharing one object would
+ * rename the prelude's `error` too. The reported source is fixed to "error"
+ * either way, so a violation still reads `(error) ...` rather than leaking the
+ * internal spelling.
+ */
+export const runtime_error = L.nameFn('error', (msg: L.Value): L.Value => {
+  if (typeof msg !== 'string') {
+    throw new L.ScamperError(
+      'Runtime',
+      `expected a string, received ${L.typeOf(msg)}`,
+      undefined,
+      undefined,
+      'error',
+    )
+  }
+  throw new L.ScamperError('Runtime', msg, undefined, undefined, 'error')
+}) as L.JsFunction
+
+/**
  * @returns a predicate function for struct types t.
  */
 export function runtime_mkPredFn (t: string): (v: L.Value) => boolean {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -20,8 +20,13 @@ import { librarySources } from './generated/sources.js'
 async function loadLibrary(name: string, src: string): Promise<L.Module> {
   // N.B., insertContracts=true: only the standard library gets its exports
   // wrapped with contract checks derived from their docstrings, not
-  // arbitrary user programs.
-  const { prog, diagnostics } = await compile(src, { insertContracts: true })
+  // arbitrary user programs. allowInternalNames is narrower still: the
+  // `##...##` shape is reserved for the runtime (see ParseOptions), and
+  // runtime.scm is the interop layer that binds those primitives.
+  const { prog, diagnostics } = await compile(src, {
+    insertContracts: true,
+    allowInternalNames: name === 'runtime',
+  })
   if (prog === undefined || diagnostics.length > 0) {
     throw new L.ICE(
       'lib.loadLibrary',
@@ -136,7 +141,9 @@ export async function initializeLibs(): Promise<void> {
     builtinLibs.set(name, mod)
   }
   for (const [name, src] of librarySources) {
-    const { program } = tokenizeAndParse(src)
+    const { program } = tokenizeAndParse(src, undefined, {
+      allowInternalNames: name === 'runtime',
+    })
     docRegistry.set(
       name,
       program ? extractDocs(program) : new Map<string, FunctionDoc>(),

--- a/src/lib/runtime.scm
+++ b/src/lib/runtime.scm
@@ -14,6 +14,12 @@
 
 (define-export ##mkObj## (js-var "runtime_mkObj"))
 
+; Internal: raises a runtime error carrying its argument. Expansion injects it
+; for a `cond` fall-through, and contract insertion for a failed check. It is
+; internal (rather than the prelude's `error`) so that a user binding named
+; `error` cannot change what those forms do.
+(define-export ##error## (js-var "runtime_error"))
+
 ; Internal: aborts the running fiber and reports its argument as the answer to a
 ; live-evaluation query. A query wraps its target sub-expression in
 ; (##report## <expr>).

--- a/src/lpm/lang.ts
+++ b/src/lpm/lang.ts
@@ -224,17 +224,14 @@ export class Env {
   }
 
   extendWithImport(name: string, lib: Module): Env {
-    // A module with private (non-exported) bindings must re-home its exported
-    // closures so they can still reach those private siblings at call time --
-    // the importer's flat scope only holds the exported names (see
-    // rehomeExports). When everything is exported (every builtin library), skip
-    // re-homing: the injected exports already cover every sibling, and closures
-    // resolve dynamically against the fiber env exactly as before.
-    const injected = this.moduleHasPrivates(lib)
-      ? this.rehomeExports(lib, name)
-      : lib
+    // Always re-home: a module's closures must resolve their free names against
+    // the module's own scope, never the importer's. Re-homing used to be
+    // skipped when a module exported everything (every builtin library), on the
+    // reasoning that the injected exports already covered every sibling -- but
+    // lookup consults the importer's top level *before* its imports, so a user
+    // `(define car 5)` captured the prelude's own internal calls to `car`.
     return new Env(
-      this.extendImports(name, injected),
+      this.extendImports(name, this.rehomeExports(lib, name)),
       this.topLevel,
       this.locals,
       this.qualified,
@@ -253,13 +250,6 @@ export class Env {
       this.topLevel,
       this.locals,
       new Map([...this.qualified, [alias, this.rehomeExports(lib, alias)]]),
-    )
-  }
-
-  /** @return whether `lib` binds any name it does not export. */
-  private moduleHasPrivates(lib: Module): boolean {
-    return (
-      lib.allBindings !== undefined && lib.allBindings.size > lib.bindings.size
     )
   }
 
@@ -296,11 +286,12 @@ export class Env {
       )
     }
     // Expose only the exported names (their re-homed versions) to the importer.
+    // N.B., keyed on `has`, not on a non-undefined value: `void` *is*
+    // undefined, so testing the value would silently drop it from the module.
     const exported = new Module()
     for (const name of lib.bindings.keys()) {
-      const value = rehomedAll.bindings.get(name)
-      if (value !== undefined) {
-        exported.registerValue(name, value)
+      if (rehomedAll.bindings.has(name)) {
+        exported.registerValue(name, rehomedAll.bindings.get(name))
       }
     }
     return exported

--- a/src/scheme/contract.ts
+++ b/src/scheme/contract.ts
@@ -158,7 +158,7 @@ function mkCheckChain(
         ),
         targetCall,
         A.mkApp(
-          A.mkId('error', range),
+          A.mkId('##error##', range),
           [mkRestErrorMsg(describePred(restParam.predicate), restParam.name, range)],
           range,
         ),
@@ -175,7 +175,7 @@ function mkCheckChain(
       A.mkApp(predicate, [A.mkId(name, range)], range),
       checkAt(i + 1),
       A.mkApp(
-        A.mkId('error', range),
+        A.mkId('##error##', range),
         [mkErrorMsg(describePred(predicate), name, range)],
         range,
       ),

--- a/src/scheme/expansion.ts
+++ b/src/scheme/expansion.ts
@@ -149,13 +149,16 @@ export function expandExpr(e: A.Exp): A.Exp {
       // -->
       // (if e11 e12
       //   ...
-      //     (if ek1 ek2 (error "No matching clause in cond"))
+      //     (if ek1 ek2 (##error## "No matching clause in cond"))
+      // ##error## is a runtime primitive (src/js/runtime), *not* the prelude's
+      // `error`: a fall-through must raise whether or not the user happens to
+      // have bound the name `error` (#336).
       const branches = e.branches.map((c) => ({
         test: expandExpr(c.test),
         body: expandExpr(c.body),
       }))
       let ret: A.Exp = A.mkApp(
-        A.mkId('error', e.range),
+        A.mkId('##error##', e.range),
         [A.mkLit('No matching clause in cond', e.range)],
         e.range,
         'cond',

--- a/src/scheme/index.ts
+++ b/src/scheme/index.ts
@@ -6,7 +6,7 @@ import { ScamperDiagnostic, mkDiagnostic } from './diagnostic.js'
 import { scopeCheckProgram } from './scope.js'
 import { FiberRaiser } from '../lpm/raiser.js'
 import { raiseFiber } from './raise.js'
-import { parseProgramFromSource } from './lezer-bridge.js'
+import { ParseOptions, parseProgramFromSource } from './lezer-bridge.js'
 import { Exp, mkDisp, Prog } from './ast.js'
 import { getQueriedProgram } from './query'
 import { isExampleTag } from './docstring/tags/example-tag'
@@ -43,16 +43,26 @@ export interface QueryParseResult extends ParseResult {
  * definition's example for on-demand evaluation (see the query/example-tag
  * feature) and reports the queried range.
  * @param queryLoc a cursor position to build a query program around, if any
+ * @param opts parse-level knobs; see ParseOptions
  * @returns the program (absent on a fatal parse or query error) and any diagnostics
  */
-export function tokenizeAndParse(src: string): ParseResult
-export function tokenizeAndParse(src: string, queryLoc: Loc): QueryParseResult
+export function tokenizeAndParse(
+  src: string,
+  queryLoc?: undefined,
+  opts?: ParseOptions,
+): ParseResult
+export function tokenizeAndParse(
+  src: string,
+  queryLoc: Loc,
+  opts?: ParseOptions,
+): QueryParseResult
 export function tokenizeAndParse(
   src: string,
   queryLoc?: Loc,
+  opts: ParseOptions = {},
 ): ParseResult | QueryParseResult {
   const diagnostics: ScamperDiagnostic[] = []
-  const program = parseProgramFromSource(diagnostics, src)
+  const program = parseProgramFromSource(diagnostics, src, opts)
   if (diagnostics.length > 0) {
     // A parse error leaves no usable program.
     return { diagnostics }
@@ -123,7 +133,7 @@ export function tokenizeAndParse(
 }
 
 /** Knobs for {@link compile}. */
-export interface CompileOptions {
+export interface CompileOptions extends ParseOptions {
   /** A cursor position for the on-demand query/example feature. */
   queryLoc?: Loc
   /** Whether to wrap documented definitions in runtime contract checks. */
@@ -161,11 +171,16 @@ export async function compile(
   src: string,
   opts: CompileOptions = {},
 ): Promise<CompileResult | QueryCompileResult> {
-  const { queryLoc, insertContracts = false, scopeCheck = false } = opts
+  const {
+    queryLoc,
+    insertContracts = false,
+    scopeCheck = false,
+    allowInternalNames = false,
+  } = opts
 
   const parsed = queryLoc
-    ? tokenizeAndParse(src, queryLoc)
-    : tokenizeAndParse(src)
+    ? tokenizeAndParse(src, queryLoc, { allowInternalNames })
+    : tokenizeAndParse(src, undefined, { allowInternalNames })
   const diagnostics = [...parsed.diagnostics]
   if (parsed.program === undefined) {
     return queryLoc ? { queriedRange: undefined, diagnostics } : { diagnostics }

--- a/src/scheme/lezer-bridge.ts
+++ b/src/scheme/lezer-bridge.ts
@@ -53,6 +53,8 @@ class Ctx {
     public src: string,
     public lineStarts: number[],
     public diagnostics: ScamperDiagnostic[],
+    // See ParseOptions.allowInternalNames.
+    public allowInternalNames = false,
   ) {}
 
   // N.B., reader.ts's ranges are inclusive on the end position (it points at
@@ -198,6 +200,13 @@ function isPercentId(name: string): boolean {
   return name === '%' || name === '%&' || /^%[1-9][0-9]*$/.test(name)
 }
 
+// An *internal* name: `##...##`, the shape expansion and contract insertion
+// use for the primitives they inject by reference (`##mkVec##`, `##mkCtorFn##`,
+// ...). Only src/lib/runtime.scm may bind one -- see identifierName.
+function isInternalName(name: string): boolean {
+  return name.length > 4 && name.startsWith('##') && name.endsWith('##')
+}
+
 // Validates a qualified reference `mod.member` (only reached when allowQualified
 // is set -- see identifierName). Each half must be a legal simple name: neither
 // a reserved word nor a `%` identifier (those name a `#(...)` parameter, which
@@ -261,6 +270,22 @@ function identifierName(
       return '<error>'
     }
     return qualifiedName(ctx, node, name)
+  }
+  if (isInternalName(name) && !allowPercent && !ctx.allowInternalNames) {
+    // Rejected everywhere but a variable reference (allowPercent is set only
+    // there -- see above). Binding an internal name captures the primitive a
+    // derived form expands to, silently changing what `[...]`, `struct`, ...
+    // mean, so the shape is reserved and only runtime.scm may bind it.
+    // Referring to one stays legal, as with the `%` parameters below.
+    ctx.diagnostics.push(
+      mkDiagnostic(
+        'Parse',
+        'error',
+        `The identifier "${name}" is reserved for Scamper's internal use and cannot be used as a binding name`,
+        ctx.range(node),
+      ),
+    )
+    return '<error>'
   }
   if (name.startsWith('%')) {
     if (!isPercentId(name)) {
@@ -657,12 +682,28 @@ function stmtFromNode(ctx: Ctx, node: SyntaxNode): A.Stmt {
 
 ///// Entry point ///////////////////////////////////////////////////////////////
 
+/** Knobs for {@link parseProgramFromSource}. */
+export interface ParseOptions {
+  /**
+   * Whether internal `##...##` names may be bound. Set only for
+   * src/lib/runtime.scm, the interop layer that defines the primitives
+   * expansion injects; every other program is denied the shape.
+   */
+  allowInternalNames?: boolean
+}
+
 export function parseProgramFromSource(
   diagnostics: ScamperDiagnostic[],
   src: string,
+  opts: ParseOptions = {},
 ): A.Prog {
   const tree = parser.parse(src)
-  const ctx = new Ctx(src, computeLineStarts(src), diagnostics)
+  const ctx = new Ctx(
+    src,
+    computeLineStarts(src),
+    diagnostics,
+    opts.allowInternalNames,
+  )
   const prog: A.Prog = []
   for (const node of children(tree.topNode)) {
     // N.B., a stray error node here (e.g. an extra unmatched closing paren)

--- a/test/regressions/internal-name-hygiene.test.ts
+++ b/test/regressions/internal-name-hygiene.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'vitest'
+import { runProgram } from '../harness.js'
+import builtinLibs from '../../src/lib/index.js'
+import { parseProgramFromSource } from '../../src/scheme/lezer-bridge.js'
+import type { ScamperDiagnostic } from '../../src/scheme/diagnostic.js'
+
+// Derived forms lower into applications of names expansion injects by
+// reference -- `[...]` becomes `(##mkVec## ...)`, `struct` becomes
+// `(##mkCtorFn## ...)`, and so on. Those names resolve against the *user's*
+// top-level environment, so a user binding with the same name silently
+// rewrote what the form meant (#336). The `##...##` shape is now reserved: no
+// program may bind one, so no form's meaning depends on its surroundings.
+describe('internal `##...##` names cannot be bound', () => {
+  const reserved = (name: string) =>
+    expect.stringContaining(
+      `The identifier "${name}" is reserved for Scamper's internal use`,
+    )
+
+  test('the reported repros are rejected at parse time', async () => {
+    // Previously each of these compiled, then failed at runtime with "Not a
+    // function or closure: 5" from a form the user never touched.
+    expect(await runProgram('(define ##mkVec## 5)\n[1 2]')).toEqual([
+      reserved('##mkVec##'),
+    ])
+    expect(await runProgram('(define ##mkObj## 5)\n{"a" 1}')).toEqual([
+      reserved('##mkObj##'),
+    ])
+    expect(
+      await runProgram('(define ##mkCtorFn## 5)\n(struct p (x))\n(p 1)'),
+    ).toEqual([reserved('##mkCtorFn##')])
+  })
+
+  test('every binder position rejects an internal name', async () => {
+    for (const [src, name] of [
+      ['(define ##mkVec## 5)', '##mkVec##'],
+      ['(define-export ##mkVec## 5)', '##mkVec##'],
+      ['(lambda (##mkVec##) 1)', '##mkVec##'],
+      ['(lambda (x & ##mkVec##) 1)', '##mkVec##'],
+      ['(let ([##mkVec## 5]) [1 2])', '##mkVec##'],
+      ['(match 1 [##mkVec## 2])', '##mkVec##'],
+      ['(struct ##foo## (x))', '##foo##'],
+      ['(struct p (##bar##))', '##bar##'],
+    ] as const) {
+      expect(await runProgram(src), src).toContainEqual(reserved(name))
+    }
+  })
+
+  test('the reserved shape is `##...##`, not any `#`-ish name', async () => {
+    // Ordinary names that merely brush the convention stay bindable -- the
+    // rule must not quietly outlaw plausible student identifiers.
+    for (const name of ['x##', '##x', '####', 'a##b##']) {
+      expect(await runProgram(`(define ${name} 5)\n${name}`), name).toEqual([
+        '5',
+      ])
+    }
+  })
+
+  test('referring to an internal name is still allowed', async () => {
+    // Only *binding* is reserved, exactly as with the `%` parameters of
+    // `#(...)`. Sugaring already round-trips a hand-written `(##mkObj## ...)`
+    // (test/scheme/sugar.test.ts), so references must keep parsing.
+    expect(await runProgram('(##mkVec## 1 2)')).toEqual(['(vector 1 2)'])
+  })
+})
+
+// The exemption: runtime.scm is the interop layer that *defines* the
+// primitives expansion injects, so it alone may bind the shape.
+describe('the runtime library keeps its internal bindings', () => {
+  test('runtime exports the internal primitives', () => {
+    for (const name of [
+      '##mkVec##',
+      '##mkObj##',
+      '##mkCtorFn##',
+      '##mkPredFn##',
+      '##mkGetFn##',
+      '##typeOf##',
+      '##report##',
+    ]) {
+      expect([...(builtinLibs.get('runtime')?.bindings.keys() ?? [])]).toContain(
+        name,
+      )
+    }
+  })
+
+  test('the exemption is a parse option, off by default', () => {
+    // src/lib/index.ts parses runtime.scm twice -- once to load it, once for
+    // the doc registry -- so both paths have to pass the option.
+    const parse = (allowInternalNames: boolean) => {
+      const diagnostics: ScamperDiagnostic[] = []
+      parseProgramFromSource(diagnostics, '(define-export ##mkVec## 5)', {
+        allowInternalNames,
+      })
+      return diagnostics
+    }
+    expect(parse(true)).toEqual([])
+    expect(parse(false)).toHaveLength(1)
+  })
+
+  test('the forms those primitives back still work', async () => {
+    expect(await runProgram('[1 2]')).toEqual(['(vector 1 2)'])
+    expect(await runProgram('{"a" 1}')).toEqual(['{ "a" : 1 }'])
+    expect(await runProgram('(struct p (x))\n(p-x (p 1))')).toEqual(['1'])
+  })
+})

--- a/test/regressions/internal-name-hygiene.test.ts
+++ b/test/regressions/internal-name-hygiene.test.ts
@@ -63,6 +63,48 @@ describe('internal `##...##` names cannot be bound', () => {
   })
 })
 
+// Reserving the `##...##` shape only helps names that already live in it.
+// `cond`'s fall-through and the contract checks injected the *ordinary* name
+// `error`, which a student may plausibly bind -- so they now inject the
+// internal `##error##` instead.
+describe('the injected error primitive cannot be shadowed', () => {
+  test('a cond fall-through raises even when `error` is bound', async () => {
+    // Regression: this reported "Not a function or closure: 5" from a form the
+    // user never touched.
+    expect(await runProgram('(define error 5)\n(cond [#f 1])')).toEqual([
+      'Runtime error [2:1-2:13]: (error) No matching clause in cond',
+    ])
+    expect(await runProgram('(let ([error 5]) (cond [#f 1]))')).toEqual([
+      'Runtime error [1:18-1:30]: (error) No matching clause in cond',
+    ])
+  })
+
+  test('a contract violation still raises when `error` is bound', async () => {
+    expect(await runProgram('(define error 5)\n(list-ref 1 2)')).toEqual([
+      'Runtime error [2:1-2:14]: (error) expected a list, received number',
+    ])
+    expect(await runProgram('(define error 5)\n(+ 1 "a")')).toEqual([
+      'Runtime error [2:1-2:9]: (error) expected every value of v1 to be a number, but at least one was not',
+    ])
+  })
+
+  test('the raise still reports itself as `error`, not `##error##`', async () => {
+    // ##error## fixes its ScamperError source to "error", so the internal
+    // spelling never surfaces to a student.
+    expect(await runProgram('(cond [#f 1])')).toEqual([
+      'Runtime error [1:1-1:13]: (error) No matching clause in cond',
+    ])
+  })
+
+  test('`error` is still an ordinary, bindable prelude name', async () => {
+    // Only the *injected* use is reserved; the user-facing name is untouched.
+    expect(await runProgram('(define error 5)\nerror')).toEqual(['5'])
+    expect(await runProgram('(error "boom")')).toEqual([
+      'Runtime error [1:1-1:14]: (error) boom',
+    ])
+  })
+})
+
 // The exemption: runtime.scm is the interop layer that *defines* the
 // primitives expansion injects, so it alone may bind the shape.
 describe('the runtime library keeps its internal bindings', () => {
@@ -75,6 +117,7 @@ describe('the runtime library keeps its internal bindings', () => {
       '##mkGetFn##',
       '##typeOf##',
       '##report##',
+      '##error##',
     ]) {
       expect([...(builtinLibs.get('runtime')?.bindings.keys() ?? [])]).toContain(
         name,

--- a/test/regressions/library-scope-isolation.test.ts
+++ b/test/regressions/library-scope-isolation.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test, vi } from 'vitest'
+import { runProgram } from '../harness.js'
+import * as FS from '../../src/fs'
+import * as S from '../../src/scheme'
+import { Env, LoggingChannel, Module, Value } from '../../src/lpm'
+import { Fiber } from '../../src/lpm/fiber'
+import { Scheduler } from '../../src/lpm/scheduler'
+import { MockFileSystem } from '../stubs/mock-file-system'
+import { patchSchedulerYieldForTests } from '../util'
+
+patchSchedulerYieldForTests()
+
+/** Runs `src` on a real Scheduler with `files` on a mock file system. */
+async function runWithFiles(
+  files: Record<string, string>,
+  src: string,
+): Promise<string[]> {
+  const fs = new MockFileSystem()
+  for (const [name, contents] of Object.entries(files)) {
+    await fs.saveFile(name, contents)
+  }
+  vi.spyOn(FS, 'getFS').mockReturnValue(fs)
+  const { prog, diagnostics } = await S.compile(src)
+  expect(diagnostics.map((d) => d.message)).toEqual([])
+  if (prog === undefined) throw new Error('compile produced no program')
+  const ch = new LoggingChannel(true, false)
+  const sched = new Scheduler()
+  await new Promise<void>((resolve) => {
+    sched.schedule({
+      id: crypto.randomUUID(),
+      fiber: new Fiber(prog, S.mkInitialEnv()),
+      out: ch,
+      err: ch,
+      isTracing: false,
+      onComplete: resolve,
+    })
+  })
+  sched.pauseExecution()
+  return [...(ch.log as string[]), ...ch.errLog]
+}
+
+// A library's closures must resolve their free names against the *library's*
+// own scope. They used not to: Env.lookup consults the importer's top level
+// before its imports, and Env.extendWithImport re-homed a module only when it
+// had private (non-exported) bindings -- which no builtin library does. So
+// every name the prelude used internally was capturable by a user define
+// (#336): `(define car 5)` broke `list-ref`, `(define cdr 5)` broke `length`.
+describe('a user define cannot capture a library\'s internals', () => {
+  test('shadowing a list primitive leaves library functions working', async () => {
+    expect(await runProgram('(define car 5)\n(list-ref (list 1 2) 1)')).toEqual([
+      '2',
+    ])
+    expect(await runProgram('(define cdr 5)\n(length (list 1 2 3))')).toEqual([
+      '3',
+    ])
+    expect(
+      await runProgram('(define null? 5)\n(all-satisfy? number? (list 1 2))'),
+    ).toEqual(['#t'])
+    expect(await runProgram('(define + 5)\n(length (list 1 2 3))')).toEqual(['3'])
+    expect(
+      await runProgram('(define map 5)\n(filter even? (list 1 2 3 4))'),
+    ).toEqual(['(list 2 4)'])
+  })
+
+  test('a contract violation still reports properly when its helpers are bound', async () => {
+    // contract.ts builds a violation's message with `string-append` and checks
+    // a rest parameter with `all-satisfy?`; both were capturable, so a
+    // contract error turned into "Not a function or closure: 5" pointing at a
+    // prelude line number.
+    expect(await runProgram('(define string-append 5)\n(list-ref 1 2)')).toEqual([
+      'Runtime error [2:1-2:14]: (error) expected a list, received number',
+    ])
+    expect(await runProgram('(define all-satisfy? 5)\n(+ 1 "a")')).toEqual([
+      'Runtime error [2:1-2:9]: (error) expected every value of v1 to be a number, but at least one was not',
+    ])
+  })
+
+  test('the user\'s own binding still shadows for the user\'s own code', async () => {
+    // Isolation runs one way only: the library stops seeing the user's scope,
+    // but the user's `car` is still theirs.
+    expect(await runProgram('(define car 5)\ncar')).toEqual(['5'])
+    expect(await runProgram('(define car 5)\n(car (list 1 2))')).toEqual([
+      'Runtime error [2:1-2:16]: Not a function or closure: 5',
+    ])
+  })
+
+  test('a user closure passed into a library function still works', async () => {
+    // Isolation must not cut the other way: values crossing the boundary carry
+    // their own captured scope.
+    expect(
+      await runProgram('(define f (lambda (x) (+ x 1)))\n(map f (list 1 2))'),
+    ).toEqual(['(list 2 3)'])
+    expect(
+      await runProgram('(define acc 10)\n(map (lambda (x) (+ x acc)) (list 1 2))'),
+    ).toEqual(['(list 11 12)'])
+  })
+})
+
+describe('re-homing preserves a module\'s whole export set', () => {
+  test('a binding whose value is undefined survives the import', () => {
+    // Regression: rehomeExports rebuilt the exported Module by testing
+    // `bindings.get(name) !== undefined`, which silently dropped any binding
+    // whose *value* is undefined -- and Scamper's `void` is exactly that. It
+    // only surfaced once every import began re-homing.
+    const mod = new Module()
+    mod.registerValue('void', undefined)
+    mod.registerValue('x', 1)
+    const env = Env.empty.extendWithImport('m', mod)
+    expect(env.has('void')).toBe(true)
+    expect(env.get('void')).toBe(undefined)
+    expect(env.get('x')).toBe(1)
+  })
+
+  test('void is still reachable through the prelude', async () => {
+    // `void` is a value, not a procedure -- and its value is undefined, which
+    // is precisely what the dropped-binding bug keyed on.
+    expect(await runProgram('(void? void)')).toEqual(['#t'])
+  })
+
+  test('an exported closure still reaches its private siblings', () => {
+    // The case re-homing was originally written for; it must keep working now
+    // that it runs unconditionally.
+    const mod = new Module()
+    mod.allBindings = new Map<string, Value>([
+      ['helper', 1],
+      ['exported', 2],
+    ])
+    mod.registerValue('exported', 2)
+    const env = Env.empty.extendWithImport('m', mod)
+    expect(env.has('exported')).toBe(true)
+    expect(env.has('helper')).toBe(false)
+  })
+})
+
+// A student's own multi-file program hits the same mechanism: the helper
+// module and the main program each have their own top level.
+describe('a file module is isolated from its importer\'s scope', () => {
+  test("the importer's define cannot capture the module's internals", async () => {
+    expect(
+      await runWithFiles(
+        { 'm.scm': '(define-export second (lambda (l) (car (cdr l))))' },
+        '(import "m.scm")\n(define car 5)\n(second (list 1 2 3))',
+      ),
+    ).toEqual(['2'])
+  })
+
+  test("the module cannot capture the importer's define either way round", async () => {
+    // The import statement runs before the define here, and after it above;
+    // isolation must not depend on statement order.
+    expect(
+      await runWithFiles(
+        { 'm.scm': '(define-export second (lambda (l) (car (cdr l))))' },
+        '(define car 5)\n(import "m.scm")\n(second (list 1 2 3))',
+      ),
+    ).toEqual(['2'])
+  })
+})

--- a/test/regressions/literal-hygiene.test.ts
+++ b/test/regressions/literal-hygiene.test.ts
@@ -23,14 +23,15 @@ describe('a literal\'s meaning does not depend on user bindings', () => {
     ])
   })
 
-  // N.B., both literals do still expand to a `##...##` primitive, so rebinding
-  // *that* name breaks them -- exactly as rebinding ##mkCtorFn## breaks
-  // `struct`. The `##...##` namespace is reserved for the runtime by
-  // convention, so this is the same boundary every other expansion relies on,
-  // not a property of the literals.
-  test('the internal primitive is what a literal depends on', async () => {
+  // N.B., both literals do still expand to a `##...##` primitive -- but that
+  // namespace is now reserved for the runtime by the parser rather than by
+  // convention (#336), so rebinding one is a parse error instead of a form
+  // that silently changes meaning. See internal-name-hygiene.test.ts.
+  test('the internal primitive a literal depends on cannot be rebound', async () => {
     expect(await runProgram('(define ##mkVec## 5)\n[1 2]')).toEqual([
-      'Runtime error [2:1-2:5]: Not a function or closure: 5',
+      expect.stringContaining(
+        'The identifier "##mkVec##" is reserved for Scamper\'s internal use',
+      ),
     ])
   })
 })

--- a/test/scheme/expansion.test.ts
+++ b/test/scheme/expansion.test.ts
@@ -28,7 +28,7 @@ const orIf = (g: A.Exp, t: A.Exp, e: A.Exp) => A.mkIf(g, t, e, undefined, 'or')
 const orBool = (v: boolean) => A.mkLit(v, undefined, 'or')
 const condIf = (g: A.Exp, t: A.Exp, e: A.Exp) => A.mkIf(g, t, e, undefined, 'cond')
 const condSentinel = () =>
-  A.mkApp(A.mkId('error'), [A.mkLit('No matching clause in cond')], undefined, 'cond')
+  A.mkApp(A.mkId('##error##'), [A.mkLit('No matching clause in cond')], undefined, 'cond')
 
 describe('Expanded expressions', () => {
   test('and', () => {

--- a/test/scheme/sugar.test.ts
+++ b/test/scheme/sugar.test.ts
@@ -91,7 +91,9 @@ describe('cond', () => {
     expect(roundTrip('(cond [a b] [c d] [e f])')).toBe('(cond [a b] [c d] [e f])')
   })
   test('the empty cond expands to the fall-through error and stays that', () => {
-    expect(roundTrip('(cond)')).toBe('(error "No matching clause in cond")')
+    // The sentinel calls the internal ##error##, not the prelude's `error`,
+    // so a user binding named `error` cannot capture it (#336).
+    expect(roundTrip('(cond)')).toBe('(##error## "No matching clause in cond")')
   })
 })
 


### PR DESCRIPTION
Closes #336.

## Problem

Derived forms lower into applications of names that expansion injects **by reference**, and those names resolved against the *user's* top-level environment. A user binding with the same name silently changed — or broke — a form the user never touched:

```scheme
(define ##mkVec## 5)
[1 2]                    ; => Runtime error: Not a function or closure: 5

(define error 5)
(cond [#f 1])            ; => Runtime error: Not a function or closure: 5
```

Three layers, one per commit. The third turned out to be the root cause of the issue's remaining cases.

## 1. Reserve the `##...##` shape

The `##...##` spelling was only a convention: the tokenizer accepted `##foo##` as an ordinary identifier and nothing reserved it. `identifierName` (`src/scheme/lezer-bridge.ts`) now rejects the shape in every position but a variable *reference*, alongside the reserved-word and `%`-identifier rules already there:

```
Parse error [1:9-1:17]: The identifier "##mkVec##" is reserved for
Scamper's internal use and cannot be used as a binding name
```

Referring to one stays legal — same boundary as the `%` parameters of `#(...)`, and `test/scheme/sugar.test.ts` already round-trips a hand-written `(##mkObj## "a" 1)`.

**The exemption.** `src/lib/runtime.scm` is the interop layer that *defines* these primitives, so it alone may bind the shape. That is a new `allowInternalNames` parse option (`ParseOptions`, folded into `CompileOptions`), set by `src/lib/index.ts` for `name === 'runtime'` on both paths that parse library source — loading, and the doc registry.

Everything else that mints a `##...##` binder does so **after** parsing and is unaffected: `contract.ts`'s `##contract-target##` `let`, codegen's `##anonymous##` and `##stmt-N##`.

## 2. Inject `##error##` rather than `error`

Reserving the shape only protects names already in it. `cond`'s fall-through (`expansion.ts`) and the contract checks (`contract.ts`) injected the ordinary name `error` — the repro most likely to bite a student, since `error` is a plausible name to bind.

`runtime.scm` now exports `##error##`, backed by `runtime_error` in `src/js/runtime`, and both sites inject that instead. Notes:

- It is a **separate function object** from `prelude_error`, not an alias — `Module.registerValue` renames whatever it binds, so sharing one object would rename the prelude's `error` too.
- Its `ScamperError` source is fixed to `"error"`, so a violation still reads `(error) No matching clause in cond`; the internal spelling never surfaces to a student.
- `error` itself remains an ordinary, bindable prelude name. Only the *injected* use is protected.

## 3. Isolate a library's scope from its importer's

The issue also listed `string-append` and `all-satisfy?`, which `contract.ts` injects to build a violation's message. Chasing those turned up the real root cause: a library's closures resolved *all* their free names against the user's top level, because `Env.lookup` consults the importer's top-level scope before its imports.

```scheme
(define car 5)
(list-ref (list 1 2) 1)   ; => Not a function or closure: 5

(define cdr 5)
(length (list 1 2 3))     ; => Not a function or closure: 5
```

So every name the prelude used internally was capturable — not just the injected ones.

`Env.rehomeExports` already did exactly the right thing; it was simply gated off for the modules that needed it most. `extendWithImport` re-homed a module only when it had private (non-exported) bindings, on the reasoning that a fully-exported module's injected exports already covered every sibling — true only if the user hasn't shadowed one. No builtin library has privates, so none were ever re-homed. Now every import re-homes.

The fix is a net **−9 lines** in `src/lpm/lang.ts`, and closes `string-append`/`all-satisfy?` along with everything else in the class.

Isolation runs one way only: a user's `car` is still theirs, and a user closure passed into a library function still carries its own captured scope.

**Latent bug this exposed:** `rehomeExports` rebuilt the exported `Module` by testing `bindings.get(name) !== undefined`, silently dropping any binding whose *value* is undefined — and Scamper's `void` is exactly that. Keyed on `has` now.

**Cost:** ~0.07ms per `mkInitialEnv()` (the prelude is 223 bindings), paid once per program run.

## Behavioral notes for review

- Contract violations now report the user's call site (`[2:1-2:14]`) rather than the prelude line the wrapper was built on, since the raise no longer resolves through the user's environment.
- `test/scheme/expansion.test.ts` and `test/scheme/sugar.test.ts` assert the cond sentinel's name, so they move from `error` to `##error##`.
- `test/regressions/literal-hygiene.test.ts` documented the *old* boundary (rebinding `##mkVec##` yielding a runtime error) → now asserts the parse error.

## Tests

`test/regressions/internal-name-hygiene.test.ts` (11 tests) — the three `##...##` repros as parse errors; every binder position (`define`, `define-export`, `lambda` params and rest param, `let`, `match` patterns, `struct` name and fields); near-miss names (`x##`, `##x`, `####`, `a##b##`) staying bindable; references still parsing; the exemption off by default; `cond`/contract violations raising with `error` shadowed and still reporting as `error`.

`test/regressions/library-scope-isolation.test.ts` (9 tests) — shadowing `car`/`cdr`/`null?`/`+`/`map` leaving library functions working; contract violations surviving shadowed `string-append`/`all-satisfy?`; the user's own binding still shadowing for their own code; user closures still crossing the boundary; file modules isolated from their importer in both statement orders; the undefined-valued (`void`) binding surviving re-homing; private siblings still reachable. 5 of the 9 fail without the commit-3 change (verified by reverting it).

`npm run validate` passes: typecheck, 2015 tests, lint (0 errors).

_(Co-created with Claude Code)_
